### PR TITLE
Issue 2 Foundation: bundle runtime and pin Trees

### DIFF
--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@limcpf/everything-is-a-markdown",
       "dependencies": {
+        "@pierre/trees": "1.0.0-beta.4",
         "chokidar": "^4.0.3",
         "gray-matter": "^4.0.3",
         "markdown-it": "^14.1.0",
@@ -21,6 +22,8 @@
     },
   },
   "packages": {
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
+
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
@@ -199,9 +202,17 @@
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -210,6 +221,8 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"
 	},
 	"dependencies": {
+		"@pierre/trees": "1.0.0-beta.4",
 		"chokidar": "^4.0.3",
 		"gray-matter": "^4.0.3",
 		"markdown-it": "^14.1.0",

--- a/src/build.ts
+++ b/src/build.ts
@@ -1163,9 +1163,31 @@ function buildAppShellAssetsForOutput(outputPath: string, runtimeAssets: Runtime
   };
 }
 
+async function bundleRuntimeJs(entrypoint: string): Promise<string> {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    target: "browser",
+    format: "esm",
+    splitting: false,
+    sourcemap: "none",
+  });
+
+  if (!result.success) {
+    const details = result.logs.map((log) => String(log)).filter(Boolean).join("\n");
+    throw new Error(`Failed to bundle runtime app.js${details ? `:\n${details}` : ""}`);
+  }
+
+  const output = result.outputs.find((artifact) => artifact.path.endsWith(".js")) ?? result.outputs[0];
+  if (!output) {
+    throw new Error("Failed to bundle runtime app.js: no JavaScript output was produced");
+  }
+
+  return output.text();
+}
+
 async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeAssets> {
   const runtimeDir = path.join(import.meta.dir, "runtime");
-  const runtimeJs = await Bun.file(path.join(runtimeDir, "app.js")).text();
+  const runtimeJs = await bundleRuntimeJs(path.join(runtimeDir, "app.js"));
   const runtimeCss = await Bun.file(path.join(runtimeDir, "app.css")).text();
 
   const jsRelPath = `assets/app.${makeHash(runtimeJs).slice(0, 12)}.js`;


### PR DESCRIPTION
## Summary

- Pin `@pierre/trees` to exact beta version `1.0.0-beta.4`.
- Bundle `src/runtime/app.js` through `Bun.build()` before hashing and writing runtime assets.
- Keep existing content-hashed `assets/app.<hash>.js/css` naming and stale runtime asset cleanup behavior.

## Scope

Foundation sub PR for #2 only. This does not yet mount `FileTree` or change the sidebar DOM/runtime behavior.

## DnD

- [x] `@pierre/trees` is exact-pinned in `package.json` and `bun.lock`.
- [x] Runtime JS asset generation accepts npm imports through a browser ESM bundle.
- [x] Hashed runtime asset naming and stale app asset restoration remain covered by build-regression tests.

## Verification

```bash
bun run build -- --vault ./test-vault --out ./dist
bun run test:e2e -- tests/e2e/build-regression.spec.ts
```

Related to #2.
