### PR TITLE
Issue 2 Adapter: map EIAM tree to Trees paths

### DIFF
--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,3 +1,5 @@
+import { buildTreesAdapterInput } from "./tree-adapter.js";
+
 const EXPANDED_KEY = "fsblog.expanded";
 const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
 const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
@@ -738,6 +740,7 @@ function buildBranchView(manifest, branch, defaultBranch) {
   const docs = manifest.docs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
   const visibleDocIds = new Set(docs.map((doc) => doc.id));
   const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
+  const trees = buildTreesAdapterInput(tree, docs);
   const routeMap = {};
   const docIndexById = new Map();
   for (const doc of docs) {
@@ -751,6 +754,7 @@ function buildBranchView(manifest, branch, defaultBranch) {
     docs,
     visibleDocIds,
     tree,
+    trees,
     routeMap,
     docIndexById,
   };

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -1,0 +1,161 @@
+const DIRECTORY_SUFFIX = "/";
+const FILE_EXTENSION = ".md";
+const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f]/g;
+const PATH_SEPARATOR_RE = /[\\/]+/g;
+const WHITESPACE_RE = /\s+/g;
+
+function normalizeTreeSegment(value, fallback) {
+  const normalized = String(value ?? "")
+    .replace(CONTROL_CHARS_RE, "")
+    .replace(PATH_SEPARATOR_RE, " - ")
+    .replace(WHITESPACE_RE, " ")
+    .trim();
+
+  return normalized || fallback;
+}
+
+function trimFileExtension(value) {
+  return value.replace(/\.md$/i, "");
+}
+
+function joinTreePath(parentPath, segment, isDirectory) {
+  const cleanParent = parentPath.replace(/\/+$/, "");
+  const cleanSegment = normalizeTreeSegment(segment, "Untitled");
+  const joined = cleanParent ? `${cleanParent}/${cleanSegment}` : cleanSegment;
+  return isDirectory ? `${joined}${DIRECTORY_SUFFIX}` : joined;
+}
+
+function appendCollisionSuffix(pathValue, counter) {
+  const suffix = ` (${counter})`;
+  if (pathValue.endsWith(DIRECTORY_SUFFIX)) {
+    const clean = pathValue.slice(0, -1);
+    return `${clean}${suffix}${DIRECTORY_SUFFIX}`;
+  }
+
+  if (pathValue.toLowerCase().endsWith(FILE_EXTENSION)) {
+    return `${pathValue.slice(0, -FILE_EXTENSION.length)}${suffix}${FILE_EXTENSION}`;
+  }
+
+  return `${pathValue}${suffix}`;
+}
+
+function makeUniquePath(pathValue, usedPaths) {
+  if (!usedPaths.has(pathValue)) {
+    return pathValue;
+  }
+
+  let counter = 2;
+  let candidate = appendCollisionSuffix(pathValue, counter);
+  while (usedPaths.has(candidate)) {
+    counter += 1;
+    candidate = appendCollisionSuffix(pathValue, counter);
+  }
+  return candidate;
+}
+
+export function formatTreesFileBasename(node, doc) {
+  const fallbackTitle = trimFileExtension(node?.name ? String(node.name) : "Untitled");
+  const rawTitle = typeof node?.title === "string" && node.title.trim() ? node.title : doc?.title;
+  const title = normalizeTreeSegment(rawTitle, normalizeTreeSegment(fallbackTitle, "Untitled"));
+  const prefix = normalizeTreeSegment(node?.prefix ?? doc?.prefix ?? "", "");
+  return `${prefix ? `${prefix} ` : ""}${title}${FILE_EXTENSION}`;
+}
+
+export function buildTreesAdapterInput(treeNodes, docs = []) {
+  const docById = new Map();
+  for (const doc of Array.isArray(docs) ? docs : []) {
+    if (typeof doc?.id === "string" && doc.id) {
+      docById.set(doc.id, doc);
+    }
+  }
+
+  const paths = [];
+  const usedPaths = new Set();
+  const metadataByTreePath = new Map();
+  const treePathToDocId = new Map();
+  const treePathToRoute = new Map();
+  const docIdToTreePaths = new Map();
+  const docIdToPrimaryTreePath = new Map();
+
+  const registerPath = (pathValue, metadata) => {
+    const treePath = makeUniquePath(pathValue, usedPaths);
+    usedPaths.add(treePath);
+    paths.push(treePath);
+    metadataByTreePath.set(treePath, metadata);
+    return treePath;
+  };
+
+  const registerDocPath = (treePath, node, doc) => {
+    const docId = typeof node?.id === "string" ? node.id : "";
+    if (!docId) {
+      return;
+    }
+
+    const route = typeof node.route === "string" ? node.route : doc?.route;
+    treePathToDocId.set(treePath, docId);
+    if (typeof route === "string" && route) {
+      treePathToRoute.set(treePath, route);
+    }
+
+    const pathsForDoc = docIdToTreePaths.get(docId) ?? [];
+    pathsForDoc.push(treePath);
+    docIdToTreePaths.set(docId, pathsForDoc);
+
+    // Duplicate docs can appear in virtual folders and the real folder tree.
+    // Selection sync uses the first branch-visible occurrence as the primary
+    // path, while every occurrence still resolves through docId/route maps.
+    if (!docIdToPrimaryTreePath.has(docId)) {
+      docIdToPrimaryTreePath.set(docId, treePath);
+    }
+  };
+
+  const walk = (nodes, parentPath = "") => {
+    if (!Array.isArray(nodes)) {
+      return;
+    }
+
+    for (const node of nodes) {
+      if (!node || typeof node !== "object") {
+        continue;
+      }
+
+      if (node.type === "folder") {
+        const folderPath = registerPath(joinTreePath(parentPath, node.name, true), {
+          kind: "folder",
+          name: normalizeTreeSegment(node.name, "Untitled"),
+          sourcePath: typeof node.path === "string" ? node.path : "",
+          virtual: node.virtual === true,
+        });
+        walk(node.children, folderPath);
+        continue;
+      }
+
+      if (node.type !== "file") {
+        continue;
+      }
+
+      const doc = docById.get(node.id);
+      const treePath = registerPath(joinTreePath(parentPath, formatTreesFileBasename(node, doc), false), {
+        branch: node.branch ?? doc?.branch ?? null,
+        docId: node.id,
+        isNew: node.isNew === true,
+        kind: "file",
+        prefix: node.prefix ?? doc?.prefix ?? "",
+        route: node.route ?? doc?.route ?? "",
+        title: node.title ?? doc?.title ?? "",
+      });
+      registerDocPath(treePath, node, doc);
+    }
+  };
+
+  walk(treeNodes);
+
+  return {
+    docIdToPrimaryTreePath,
+    docIdToTreePaths,
+    metadataByTreePath,
+    paths,
+    treePathToDocId,
+    treePathToRoute,
+  };
+}

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "@playwright/test";
+import { buildTreesAdapterInput, formatTreesFileBasename } from "../../src/runtime/tree-adapter.js";
+
+test.describe("Trees sidebar adapter", () => {
+  test("EIAM tree nodes become canonical Trees paths with doc route lookup maps", () => {
+    const docs = [
+      {
+        id: "doc-a",
+        prefix: "BC-VO-02",
+        route: "/BC-VO-02/",
+        title: "Setup Guide",
+        branch: null,
+      },
+      {
+        id: "doc-b",
+        prefix: "BC-XSS-01",
+        route: "/BC-XSS-01/",
+        title: "Unsafe <img src=x onerror=alert(1)>",
+        branch: null,
+      },
+    ];
+    const tree = [
+      {
+        type: "folder",
+        name: "PINNED",
+        path: "__virtual__/pinned/category/engineering",
+        virtual: true,
+        children: [
+          {
+            type: "file",
+            id: "doc-a",
+            name: "setup-guide.md",
+            prefix: "BC-VO-02",
+            route: "/BC-VO-02/",
+            title: "Setup Guide",
+            isNew: true,
+            branch: null,
+          },
+        ],
+      },
+      {
+        type: "folder",
+        name: "Recent",
+        path: "__virtual__/recent",
+        virtual: true,
+        children: [
+          {
+            type: "file",
+            id: "doc-a",
+            name: "setup-guide.md",
+            prefix: "BC-VO-02",
+            route: "/BC-VO-02/",
+            title: "Setup Guide",
+            isNew: true,
+            branch: null,
+          },
+          {
+            type: "file",
+            id: "doc-b",
+            name: "unsafe.md",
+            prefix: "BC-XSS-01",
+            route: "/BC-XSS-01/",
+            title: "Unsafe <img src=x onerror=alert(1)>",
+            isNew: false,
+            branch: null,
+          },
+        ],
+      },
+      {
+        type: "folder",
+        name: "engineering",
+        path: "engineering",
+        children: [
+          {
+            type: "folder",
+            name: "guides",
+            path: "engineering/guides",
+            children: [
+              {
+                type: "file",
+                id: "doc-a",
+                name: "setup-guide.md",
+                prefix: "BC-VO-02",
+                route: "/BC-VO-02/",
+                title: "Setup Guide",
+                isNew: true,
+                branch: null,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const adapter = buildTreesAdapterInput(tree, docs);
+
+    expect(adapter.paths).toEqual([
+      "PINNED/",
+      "PINNED/BC-VO-02 Setup Guide.md",
+      "Recent/",
+      "Recent/BC-VO-02 Setup Guide.md",
+      "Recent/BC-XSS-01 Unsafe <img src=x onerror=alert(1)>.md",
+      "engineering/",
+      "engineering/guides/",
+      "engineering/guides/BC-VO-02 Setup Guide.md",
+    ]);
+    expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide.md")).toBe("doc-a");
+    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide.md")).toBe("/BC-VO-02/");
+    expect(adapter.docIdToTreePaths.get("doc-a")).toEqual([
+      "PINNED/BC-VO-02 Setup Guide.md",
+      "Recent/BC-VO-02 Setup Guide.md",
+      "engineering/guides/BC-VO-02 Setup Guide.md",
+    ]);
+    expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide.md");
+  });
+
+  test("file basenames use prefix plus title and avoid path separator leaks", () => {
+    expect(
+      formatTreesFileBasename(
+        {
+          name: "fallback.md",
+          prefix: "DOC / 01",
+          title: "Setup\\Install",
+        },
+        null,
+      ),
+    ).toBe("DOC - 01 Setup - Install.md");
+  });
+
+  test("duplicate canonical paths receive stable suffixes without changing route lookup", () => {
+    const tree = [
+      {
+        type: "folder",
+        name: "Docs",
+        path: "docs",
+        children: [
+          {
+            type: "file",
+            id: "doc-a",
+            name: "same.md",
+            route: "/DOC-A/",
+            title: "Same",
+            isNew: false,
+            branch: null,
+          },
+          {
+            type: "file",
+            id: "doc-b",
+            name: "same.md",
+            route: "/DOC-B/",
+            title: "Same",
+            isNew: false,
+            branch: null,
+          },
+        ],
+      },
+    ];
+
+    const adapter = buildTreesAdapterInput(tree, []);
+
+    expect(adapter.paths).toEqual(["Docs/", "Docs/Same.md", "Docs/Same (2).md"]);
+    expect(adapter.treePathToRoute.get("Docs/Same.md")).toBe("/DOC-A/");
+    expect(adapter.treePathToRoute.get("Docs/Same (2).md")).toBe("/DOC-B/");
+  });
+});


### PR DESCRIPTION
## Summary

- Add a runtime adapter that converts EIAM branch-filtered `manifest.tree` nodes into canonical `@pierre/trees` path input.
- Generate path lookup maps for `treePath -> docId`, `treePath -> route`, and `docId -> primary/all tree paths`.
- Define duplicate document behavior at the adapter boundary: the first branch-visible occurrence is the primary selection path, while every occurrence resolves through docId/route maps.
- Attach adapter output to the branch view without changing the legacy DOM renderer yet.

## Scope

Adapter sub PR for #2 only. This does not mount `FileTree`; Runtime Integration will consume this adapter in the next sub PR.

## DnD

- [x] Adapter owns EIAM-specific path shaping from prefix/title and folder labels.
- [x] Adapter maintains route/doc lookup maps instead of using Trees paths as public route identity.
- [x] Duplicate-document behavior for virtual folders is documented in code and covered by tests.
- [x] Existing build-regression coverage remains passing.

## Verification

```bash
bun run build -- --vault ./test-vault --out ./dist
bun run test:e2e -- tests/e2e/tree-adapter.spec.ts tests/e2e/build-regression.spec.ts
```

Related to #2.
