### PR TITLE
Issue 2 UX: add Trees sidebar search

### DIFF
--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -434,147 +434,158 @@ a:hover {
   box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset, 0 2px 6px rgba(136, 57, 239, 0.22);
 }
 
-/* Tree */
-.tree-root {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px 12px 24px;
+/* Tree search */
+.sidebar-search {
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--latte-surface0);
+  background: color-mix(in srgb, var(--latte-mantle) 92%, var(--latte-base));
 }
 
-.tree-root file-tree-container {
-  display: block;
-  width: 100%;
-  height: 100%;
-  min-height: 0;
+.sidebar-search-box {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) 30px;
+  align-items: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 0 6px 0 11px;
+  border: 1px solid var(--latte-surface1);
+  border-radius: 8px;
+  background: var(--elevated-surface);
+  box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
-.tree-folder {
-  margin-bottom: 2px;
-  --tree-depth: 0;
+.sidebar-search-box:focus-within {
+  border-color: color-mix(in srgb, var(--latte-blue) 56%, var(--latte-surface1));
+  background: var(--elevated-surface-hover);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--latte-blue) 18%, transparent);
 }
 
-.tree-children {
-  --tree-indent-step: clamp(6px, calc(12px - (var(--tree-depth, 0) * 1px)), 12px);
-  margin-left: var(--tree-indent-step);
-  padding-left: calc(var(--tree-indent-step) + 1px);
-  border-left: 1px solid var(--latte-surface0);
+.sidebar-search-icon {
+  color: var(--latte-overlay0);
+  font-size: 19px;
 }
 
-.tree-row {
+.tree-search-input {
+  min-width: 0;
   width: 100%;
   border: 0;
+  outline: 0;
   background: transparent;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  justify-content: flex-start;
-  text-align: left;
-  min-height: 38px;
-  padding: 6px 12px;
-  text-decoration: none;
-  color: var(--latte-subtext1);
-  cursor: pointer;
-  font-size: 0.9rem;
-  border-radius: 6px;
-  transition: all 0.15s ease;
+  color: var(--latte-text);
+  font: inherit;
+  font-size: 0.88rem;
 }
 
-.tree-row:hover {
-  background: rgba(204, 208, 218, 0.5);
+.tree-search-input::placeholder {
+  color: var(--latte-overlay0);
+}
+
+.tree-search-input::-webkit-search-decoration,
+.tree-search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.tree-search-clear,
+.tree-search-step {
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--latte-overlay0);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.tree-search-clear[hidden] {
+  display: none;
+}
+
+.tree-search-clear:hover,
+.tree-search-step:hover:not(:disabled) {
+  border-color: var(--latte-surface1);
+  background: var(--elevated-surface-hover);
   color: var(--latte-text);
 }
 
-.tree-row:focus-visible {
+.tree-search-clear:focus-visible,
+.tree-search-step:focus-visible {
   outline: 2px solid var(--latte-blue);
   outline-offset: 1px;
 }
 
-.tree-folder-row {
-  font-weight: 500;
+.tree-search-step:disabled {
+  cursor: default;
+  opacity: 0.42;
 }
 
-.tree-folder-row .material-symbols-outlined {
-  color: var(--latte-blue);
+.tree-search-clear .material-symbols-outlined,
+.tree-search-step .material-symbols-outlined {
+  font-size: 18px;
 }
 
-.tree-folder.virtual > .tree-folder-row .material-symbols-outlined {
-  color: var(--latte-teal);
+.sidebar-search-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 30px;
+  margin-top: 7px;
 }
 
-.tree-file-row .material-symbols-outlined {
+.tree-search-count {
+  min-width: 0;
   color: var(--latte-overlay0);
+  font-size: 0.75rem;
+  font-weight: 650;
 }
 
-.tree-prefix {
-  flex: 0 0 auto;
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--latte-subtext1);
+.tree-search-nav {
+  display: inline-flex;
+  gap: 4px;
 }
 
-.tree-label {
+/* Tree */
+.tree-root {
   flex: 1;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  padding: 12px 12px 24px;
 }
 
-.tree-label-tooltip {
-  position: fixed;
-  z-index: 140;
-  pointer-events: none;
-  max-width: min(440px, calc(100vw - 24px));
-  padding: 6px 10px;
-  border-radius: 8px;
-  background: var(--tooltip-bg);
-  color: var(--tooltip-text);
-  font-size: 0.75rem;
-  line-height: 1.4;
-  box-shadow: 0 10px 24px rgba(76, 79, 105, 0.24);
-}
-
-.tree-label-tooltip[hidden] {
-  display: none;
-}
-
-/* Active file state */
-.tree-file-row.is-active {
-  background: var(--active-surface-bg);
-  color: var(--latte-text);
-  font-weight: 500;
-  border: 1px solid var(--latte-surface0);
-  border-left: 4px solid var(--latte-mauve);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-  padding-left: 8px;
-}
-
-.tree-file-row.is-active .material-symbols-outlined {
-  color: var(--latte-mauve);
-}
-
-/* NEW badge */
-.badge-new {
-  margin-left: auto;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  padding: 2px 6px;
-  border-radius: 999px;
-  color: var(--badge-new-fg);
-  background: var(--badge-new-bg);
-}
-
-/* Active badge */
-.badge-active {
-  margin-left: auto;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  padding: 2px 6px;
-  border-radius: 999px;
-  color: var(--latte-mauve);
-  background: rgba(136, 57, 239, 0.1);
+.tree-root file-tree-container {
+  --trees-bg-override: transparent;
+  --trees-bg-muted-override: color-mix(in srgb, var(--latte-surface0) 44%, transparent);
+  --trees-fg-override: var(--latte-subtext1);
+  --trees-fg-muted-override: var(--latte-overlay0);
+  --trees-accent-override: var(--latte-mauve);
+  --trees-border-color-override: var(--latte-surface0);
+  --trees-focus-ring-color-override: var(--latte-blue);
+  --trees-focus-ring-width-override: 2px;
+  --trees-focus-ring-offset-override: 1px;
+  --trees-selected-bg-override: var(--active-surface-bg);
+  --trees-selected-fg-override: var(--latte-text);
+  --trees-selected-focused-border-color-override: color-mix(in srgb, var(--latte-mauve) 36%, transparent);
+  --trees-font-family-override: inherit;
+  --trees-font-size-override: 0.9rem;
+  --trees-font-weight-regular-override: 450;
+  --trees-font-weight-semibold-override: 700;
+  --trees-border-radius-override: 6px;
+  --trees-gap-override: 2px;
+  --trees-item-margin-x-override: 0px;
+  --trees-item-padding-x-override: 12px;
+  --trees-item-row-gap-override: 8px;
+  --trees-level-gap-override: 10px;
+  --trees-padding-inline-override: 0px;
+  --trees-file-icon-color-default: var(--latte-overlay0);
+  --trees-new-badge-bg: var(--badge-new-bg);
+  --trees-new-badge-fg: var(--badge-new-fg);
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }
 
 /* Sidebar footer */

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -28,6 +28,11 @@ const TREE_UNSAFE_CSS = `
   font-weight: var(--trees-font-weight-semibold);
 }
 
+/* EIAM owns the visible search controls while Trees keeps search projection enabled. */
+[data-file-tree-search-container] {
+  display: none;
+}
+
 [data-item-section='decoration'] > span {
   flex: 0 0 auto;
   width: auto;
@@ -1759,6 +1764,8 @@ async function start() {
         preparedInput,
         renderRowDecoration: renderTreeRowDecoration,
         sort: compareTreesByBranchOrder,
+        search: true,
+        searchBlurBehavior: "retain",
         stickyFolders: true,
         unsafeCSS: TREE_UNSAFE_CSS,
       });

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -17,6 +17,29 @@ const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+const TREE_UNSAFE_CSS = `
+[data-type='item'][data-item-selected] {
+  border-left: 4px solid var(--trees-accent-override, currentColor);
+  box-shadow: inset 0 0 0 1px var(--trees-selected-focused-border-color-override, transparent);
+  padding-left: calc(var(--trees-item-padding-x) - 4px);
+}
+
+[data-type='item'][data-item-selected] [data-item-section='content'] {
+  font-weight: var(--trees-font-weight-semibold);
+}
+
+[data-item-section='decoration'] > span {
+  flex: 0 0 auto;
+  width: auto;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--trees-new-badge-bg, #d20f39);
+  color: var(--trees-new-badge-fg, #ffffff);
+  font-size: 0.625rem;
+  font-weight: 800;
+  line-height: 1;
+}
+`;
 const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
 const MERMAID_DEFAULT_THEME = "default";
 const MERMAID_SELECTOR = "pre.mermaid";
@@ -979,6 +1002,11 @@ async function start() {
   setAppReadyState("booting");
 
   const treeRoot = document.getElementById("tree-root");
+  const treeSearchInput = document.getElementById("tree-search-input");
+  const treeSearchClear = document.getElementById("tree-search-clear");
+  const treeSearchPrev = document.getElementById("tree-search-prev");
+  const treeSearchNext = document.getElementById("tree-search-next");
+  const treeSearchCount = document.getElementById("tree-search-count");
   const appRoot = document.querySelector(".app-root");
   const splitter = document.getElementById("app-splitter");
   const sidebar = document.getElementById("sidebar-panel");
@@ -1010,6 +1038,7 @@ async function start() {
   let fileTree = null;
   let isSyncingTreeSelection = false;
   let treePathOrder = new Map();
+  let treeSearchValue = "";
 
   const announceA11yStatus = (message) => {
     if (!(a11yStatusEl instanceof HTMLElement)) {
@@ -1477,6 +1506,99 @@ async function start() {
     }
   };
 
+  const updateTreeSearchControls = () => {
+    const normalizedSearchValue = fileTree ? fileTree.getSearchValue() : treeSearchValue.trim();
+    const hasSearch = normalizedSearchValue.length > 0;
+    const matchCount = hasSearch && fileTree ? fileTree.getSearchMatchingPaths().length : 0;
+    const canStep = hasSearch && matchCount > 0;
+
+    if (treeSearchClear instanceof HTMLButtonElement) {
+      treeSearchClear.hidden = !hasSearch;
+      treeSearchClear.disabled = !hasSearch;
+    }
+
+    for (const button of [treeSearchPrev, treeSearchNext]) {
+      if (button instanceof HTMLButtonElement) {
+        button.disabled = !canStep;
+      }
+    }
+
+    if (treeSearchCount instanceof HTMLElement) {
+      treeSearchCount.textContent = hasSearch ? `${matchCount}개 일치` : "";
+    }
+  };
+
+  const applyTreeSearch = (value) => {
+    treeSearchValue = value;
+
+    if (treeSearchInput instanceof HTMLInputElement && treeSearchInput.value !== value) {
+      treeSearchInput.value = value;
+    }
+
+    if (fileTree) {
+      const query = value.trim();
+      if (query) {
+        if (fileTree.isSearchOpen()) {
+          fileTree.setSearch(query);
+        } else {
+          fileTree.openSearch(query);
+        }
+      } else {
+        fileTree.closeSearch();
+      }
+    }
+
+    updateTreeSearchControls();
+  };
+
+  const moveTreeSearchFocus = (direction) => {
+    if (!fileTree || !fileTree.isSearchOpen() || fileTree.getSearchMatchingPaths().length === 0) {
+      return;
+    }
+
+    if (direction < 0) {
+      fileTree.focusPreviousSearchMatch();
+    } else {
+      fileTree.focusNextSearchMatch();
+    }
+
+    updateTreeSearchControls();
+  };
+
+  if (treeSearchInput instanceof HTMLInputElement) {
+    treeSearchInput.addEventListener("input", () => {
+      applyTreeSearch(treeSearchInput.value);
+    });
+    treeSearchInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        moveTreeSearchFocus(event.shiftKey ? -1 : 1);
+        return;
+      }
+
+      if (event.key === "Escape" && treeSearchInput.value.trim()) {
+        event.preventDefault();
+        event.stopPropagation();
+        applyTreeSearch("");
+      }
+    });
+  }
+
+  treeSearchClear?.addEventListener("click", () => {
+    applyTreeSearch("");
+    if (treeSearchInput instanceof HTMLInputElement) {
+      treeSearchInput.focus();
+    }
+  });
+
+  treeSearchPrev?.addEventListener("click", () => {
+    moveTreeSearchFocus(-1);
+  });
+
+  treeSearchNext?.addEventListener("click", () => {
+    moveTreeSearchFocus(1);
+  });
+
   const syncActiveTreeSelection = (docId, { scroll = true } = {}) => {
     if (!fileTree || !docId) {
       return;
@@ -1637,9 +1759,8 @@ async function start() {
         preparedInput,
         renderRowDecoration: renderTreeRowDecoration,
         sort: compareTreesByBranchOrder,
-        search: true,
-        searchBlurBehavior: "retain",
         stickyFolders: true,
+        unsafeCSS: TREE_UNSAFE_CSS,
       });
       fileTree.render({ containerWrapper: treeRoot });
     } else {
@@ -1652,6 +1773,7 @@ async function start() {
     }
 
     syncActiveTreeSelection(state.currentDocId || "");
+    applyTreeSearch(treeSearchValue);
   };
 
   const updateBacklinks = (doc) => {

--- a/src/template.ts
+++ b/src/template.ts
@@ -231,6 +231,34 @@ ${headMeta}
             <span id="sidebar-branch-info" class="branch-info">publish: true</span>
           </div>
         </div>
+        <div class="sidebar-search">
+          <div class="sidebar-search-box">
+            <span class="material-symbols-outlined sidebar-search-icon" aria-hidden="true">search</span>
+            <input
+              id="tree-search-input"
+              class="tree-search-input"
+              type="search"
+              autocomplete="off"
+              spellcheck="false"
+              aria-label="문서 검색"
+              placeholder="Search"
+            />
+            <button id="tree-search-clear" class="tree-search-clear" type="button" aria-label="검색 지우기" title="검색 지우기" hidden>
+              <span class="material-symbols-outlined">close</span>
+            </button>
+          </div>
+          <div class="sidebar-search-actions" aria-live="polite">
+            <span id="tree-search-count" class="tree-search-count"></span>
+            <div class="tree-search-nav">
+              <button id="tree-search-prev" class="tree-search-step" type="button" aria-label="이전 검색 결과" title="이전 검색 결과" disabled>
+                <span class="material-symbols-outlined">keyboard_arrow_up</span>
+              </button>
+              <button id="tree-search-next" class="tree-search-step" type="button" aria-label="다음 검색 결과" title="다음 검색 결과" disabled>
+                <span class="material-symbols-outlined">keyboard_arrow_down</span>
+              </button>
+            </div>
+          </div>
+        </div>
         <nav id="tree-root" class="tree-root" aria-label="문서 탐색기" tabindex="0"></nav>
         <div class="sidebar-footer">
           <div class="status-online">

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+test.describe("Trees sidebar search", () => {
+  test("검색 결과를 필터링하고 clear 후 일반 트리로 복귀한다", async ({ page }) => {
+    await page.goto("/");
+    await waitForAppReady(page);
+
+    const searchInput = page.locator("#tree-search-input");
+    const searchCount = page.locator("#tree-search-count");
+    const searchClear = page.locator("#tree-search-clear");
+    const searchNext = page.locator("#tree-search-next");
+    const setupRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+      .first();
+
+    await expect(searchInput).toBeVisible();
+    await expect(setupRow).toBeVisible();
+
+    await searchInput.fill("Unsafe");
+
+    await expect(searchCount).toHaveText(/[1-9]\d*개 일치/);
+    await expect(searchClear).toBeVisible();
+    await expect(searchNext).toBeEnabled();
+    await expect(setupRow).toBeHidden();
+
+    const unsafeRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"]')
+      .filter({ hasText: "Unsafe" })
+      .first();
+    await expect(unsafeRow).toBeVisible();
+
+    await searchNext.click();
+    await expect(
+      page.locator('#tree-root [data-type="item"][data-item-type="file"][data-item-focused="true"]').first(),
+    ).toContainText("Unsafe");
+
+    await unsafeRow.click();
+    await expect(page).toHaveURL(/\/BC-XSS-01\/$/);
+    await expect(page.locator("#viewer-title")).toContainText("Unsafe");
+
+    await searchClear.click();
+    await expect(searchInput).toHaveValue("");
+    await expect(searchCount).toHaveText("");
+    await expect(setupRow).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- add a first-class sidebar search control backed by the Trees search model
- wire clear and previous/next result controls without scraping Trees internal DOM
- align the Trees host styling with the existing Catppuccin sidebar and style NEW/active rows
- add e2e coverage for search, clear, result focus, and document navigation

## DnD
- Search input uses public Trees APIs: openSearch, setSearch, closeSearch, focusNextSearchMatch/focusPreviousSearchMatch.
- Search state is reapplied after branch/model resets.
- NEW row decoration and active row styling are visible in the mounted tree.
- Existing pathBase, XSS, mobile focus trap, and full e2e suites pass.

## Verification
- bun run build -- --vault ./test-vault --out ./dist
- PLAYWRIGHT_PORT=4181 bun run test:e2e -- tests/e2e/tree-search.spec.ts tests/e2e/runtime-xss-guard.spec.ts tests/e2e/path-base-routing.spec.ts tests/e2e/mobile-sidebar-focus-trap.spec.ts
- desktop/mobile Playwright layout probe against http://localhost:4182
- PLAYWRIGHT_PORT=4183 bun run test:e2e