### PR TITLE
Issue 2 Docs: document Trees sidebar verification

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -277,6 +277,23 @@ markdown: {
 - `markdown.mermaid.theme`이 유효한 식별자 형식이 아니면 빌드 시 `default`로 자동 폴백합니다.
 - 런타임 로더는 실패 후 남은 Mermaid 스크립트를 정리하고, 중복 삽입을 피하며, 다음 렌더에서 재시도합니다.
 
+## UI와 런타임 동작
+
+빌드된 사이트는 별도 앱 프레임워크 없이 클라이언트 런타임으로 문서 탐색을 처리합니다.
+
+주요 동작:
+
+- 사이드바 파일 트리는 vanilla `@pierre/trees` 런타임으로 렌더링됩니다.
+- `Recent` 가상 폴더와 선택적 pinned 가상 폴더를 유지합니다.
+- 파일 행은 `prefix`와 제목 기준으로 표시되고, `ui.newWithinDays` 기준에 맞으면 NEW 배지를 보여줍니다.
+- 브랜치 pill로 문서 목록을 전환합니다.
+- 활성 문서 선택 상태는 트리, 브라우저 히스토리, 문서 뷰어 사이에서 동기화됩니다.
+- 트리 검색 입력은 Trees 검색 모델에 연결되며, clear와 이전/다음 결과 이동을 지원합니다.
+- 직접 URL 진입, 이전/다음 문서 링크, 백링크, 모바일 사이드바 포커스 트랩을 지원합니다.
+- 테마 모드(`light`, `dark`, `system`)와 데스크톱 사이드바 폭을 저장합니다.
+
+사이드바는 표시용 EIAM canonical tree path를 사용하지만, 공개 라우트와 문서 식별자는 계속 `prefix` 기반 route/docId를 기준으로 합니다. rename, drag/drop, git status 표시, multi-select bulk action은 의도적으로 활성화하지 않습니다.
+
 ## bunx 실행 (선택)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -438,17 +438,21 @@ The generated site includes a client-side runtime that powers navigation without
 
 Main behaviors:
 
-- folder tree with expand/collapse state in `localStorage`
+- searchable sidebar tree rendered by the vanilla `@pierre/trees` runtime
 - `Recent` virtual folder
 - optional pinned virtual folder
+- prefix/title file labels with NEW badges when `ui.newWithinDays` matches
 - branch pills in the sidebar
-- active document syncing with browser history
+- active document selection synced between the tree, browser history, and document viewer
+- model-level tree search with clear and previous/next match controls
 - direct-link loading from route HTML
 - previous/next document navigation
 - backlink list for notes referenced by other notes
 - mobile sidebar with accessibility handling and focus trap behavior
 - theme mode persistence: `light`, `dark`, `system`
 - sidebar width persistence on desktop
+
+The sidebar uses EIAM canonical tree paths for display and keeps public routes sourced from document `prefix` routes. Rename, drag/drop, git status, and multi-select workflows are intentionally not enabled.
 
 Branch behavior:
 
@@ -551,6 +555,7 @@ E2E coverage in `tests/e2e/` includes:
 - build regression around incremental outputs
 - subpath routing with `seo.pathBase`
 - prefix routing, backlinks, and branch switching
+- searchable Trees sidebar behavior
 - Mermaid runtime behavior
 - mobile sidebar accessibility and focus trap behavior
 - runtime XSS/path-base guardrails
@@ -563,6 +568,7 @@ E2E coverage in `tests/e2e/` includes:
 - Local images may be omitted depending on config.
 - Wikilinks resolve only to published docs.
 - Mermaid rendering depends on runtime script loading in the browser.
+- Sidebar rename, drag/drop, git status indicators, and bulk actions are intentionally out of scope.
 - SEO files are not generated unless `seo.siteUrl` is configured.
 
 ## License

--- a/scripts/lint-published-markdown.ts
+++ b/scripts/lint-published-markdown.ts
@@ -3,19 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { createRequire } from "node:module";
 import matter from "gray-matter";
+import { lint as lintMarkdown } from "markdownlint/promise";
 import { loadUserConfig, resolveBuildOptions, type CliArgs } from "../src/config";
 import { buildExcluder, relativePosix } from "../src/utils";
 
 const require = createRequire(import.meta.url);
-const markdownlint = require("markdownlint") as {
-  promises: {
-    markdownlint(options: {
-      strings: Record<string, string>;
-      config: Record<string, unknown>;
-      frontMatter?: RegExp;
-    }): Promise<Record<string, Array<Record<string, unknown>>>>;
-  };
-};
 const lintConfigModule = require("../.markdownlint.cjs") as { config: Record<string, unknown> };
 
 const REPORT_FILE_NAME = "mdlint-report.json";
@@ -310,11 +302,11 @@ async function main(): Promise<void> {
 
   const lintResults =
     scanResult.docs.length > 0
-      ? await markdownlint.promises.markdownlint({
+      ? ((await lintMarkdown({
           strings: lintStrings,
           config: lintConfigModule.config,
           frontMatter: FRONTMATTER_RE,
-        })
+        })) as Record<string, Array<Record<string, unknown>>>)
       : {};
 
   const markdownlintIssues = mapMarkdownlintIssues(lintResults);


### PR DESCRIPTION
## Summary
- update README and README.ko for the searchable @pierre/trees sidebar
- document prefix/title/NEW behavior and intentionally disabled rename/drag/drop/git-status workflows
- fix lint:md:publish for markdownlint 0.40 promise exports so the issue verification command runs

## DnD
- README.md runtime behavior section describes the Trees-backed searchable sidebar.
- README.ko.md includes the matching Korean runtime behavior section.
- The publish markdown lint verification command exits successfully.

## Verification
- bun install
- bun run build -- --vault ./test-vault --out ./dist
- PLAYWRIGHT_PORT=4189 bun run test:e2e → 28 passed, Mermaid mock case timed out
- PLAYWRIGHT_PORT=4190 bun run test:e2e -- tests/e2e/mermaid-runtime.spec.ts -g "로컬 mock 스크립트로 Mermaid 다이어그램을 렌더링한다"
- bun run lint:md:publish -- --vault ./test-vault --out-dir ./reports