### PR TITLE
Issue 2: Replace sidebar tree with @pierre/trees

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -277,6 +277,23 @@ markdown: {
 - `markdown.mermaid.theme`이 유효한 식별자 형식이 아니면 빌드 시 `default`로 자동 폴백합니다.
 - 런타임 로더는 실패 후 남은 Mermaid 스크립트를 정리하고, 중복 삽입을 피하며, 다음 렌더에서 재시도합니다.
 
+## UI와 런타임 동작
+
+빌드된 사이트는 별도 앱 프레임워크 없이 클라이언트 런타임으로 문서 탐색을 처리합니다.
+
+주요 동작:
+
+- 사이드바 파일 트리는 vanilla `@pierre/trees` 런타임으로 렌더링됩니다.
+- `Recent` 가상 폴더와 선택적 pinned 가상 폴더를 유지합니다.
+- 파일 행은 `prefix`와 제목 기준으로 표시되고, `ui.newWithinDays` 기준에 맞으면 NEW 배지를 보여줍니다.
+- 브랜치 pill로 문서 목록을 전환합니다.
+- 활성 문서 선택 상태는 트리, 브라우저 히스토리, 문서 뷰어 사이에서 동기화됩니다.
+- 트리 검색 입력은 Trees 검색 모델에 연결되며, clear와 이전/다음 결과 이동을 지원합니다.
+- 직접 URL 진입, 이전/다음 문서 링크, 백링크, 모바일 사이드바 포커스 트랩을 지원합니다.
+- 테마 모드(`light`, `dark`, `system`)와 데스크톱 사이드바 폭을 저장합니다.
+
+사이드바는 표시용 EIAM canonical tree path를 사용하지만, 공개 라우트와 문서 식별자는 계속 `prefix` 기반 route/docId를 기준으로 합니다. rename, drag/drop, git status 표시, multi-select bulk action은 의도적으로 활성화하지 않습니다.
+
 ## bunx 실행 (선택)
 
 ```bash

--- a/README.md
+++ b/README.md
@@ -438,17 +438,21 @@ The generated site includes a client-side runtime that powers navigation without
 
 Main behaviors:
 
-- folder tree with expand/collapse state in `localStorage`
+- searchable sidebar tree rendered by the vanilla `@pierre/trees` runtime
 - `Recent` virtual folder
 - optional pinned virtual folder
+- prefix/title file labels with NEW badges when `ui.newWithinDays` matches
 - branch pills in the sidebar
-- active document syncing with browser history
+- active document selection synced between the tree, browser history, and document viewer
+- model-level tree search with clear and previous/next match controls
 - direct-link loading from route HTML
 - previous/next document navigation
 - backlink list for notes referenced by other notes
 - mobile sidebar with accessibility handling and focus trap behavior
 - theme mode persistence: `light`, `dark`, `system`
 - sidebar width persistence on desktop
+
+The sidebar uses EIAM canonical tree paths for display and keeps public routes sourced from document `prefix` routes. Rename, drag/drop, git status, and multi-select workflows are intentionally not enabled.
 
 Branch behavior:
 
@@ -551,6 +555,7 @@ E2E coverage in `tests/e2e/` includes:
 - build regression around incremental outputs
 - subpath routing with `seo.pathBase`
 - prefix routing, backlinks, and branch switching
+- searchable Trees sidebar behavior
 - Mermaid runtime behavior
 - mobile sidebar accessibility and focus trap behavior
 - runtime XSS/path-base guardrails
@@ -563,6 +568,7 @@ E2E coverage in `tests/e2e/` includes:
 - Local images may be omitted depending on config.
 - Wikilinks resolve only to published docs.
 - Mermaid rendering depends on runtime script loading in the browser.
+- Sidebar rename, drag/drop, git status indicators, and bulk actions are intentionally out of scope.
 - SEO files are not generated unless `seo.siteUrl` is configured.
 
 ## License

--- a/bun.lock
+++ b/bun.lock
@@ -5,6 +5,7 @@
     "": {
       "name": "@limcpf/everything-is-a-markdown",
       "dependencies": {
+        "@pierre/trees": "1.0.0-beta.4",
         "chokidar": "^4.0.3",
         "gray-matter": "^4.0.3",
         "markdown-it": "^14.1.0",
@@ -21,6 +22,8 @@
     },
   },
   "packages": {
+    "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
+
     "@playwright/test": ["@playwright/test@1.58.2", "", { "dependencies": { "playwright": "1.58.2" }, "bin": { "playwright": "cli.js" } }, "sha512-akea+6bHYBBfA9uQqSYmlJXn61cTa+jbO87xVLCWbTqbWadRVmhxlXATaOjOgcBaWU4ePo0wB41KMFv3o35IXA=="],
 
     "@shikijs/core": ["@shikijs/core@3.22.0", "", { "dependencies": { "@shikijs/types": "3.22.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-iAlTtSDDbJiRpvgL5ugKEATDtHdUVkqgHDm/gbD2ZS9c88mx7G1zSYjjOxp5Qa0eaW0MAQosFRmJSk354PRoQA=="],
@@ -199,9 +202,17 @@
 
     "playwright-core": ["playwright-core@1.58.2", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-yZkEtftgwS8CsfYo7nm0KE8jsvm6i/PTgVtB8DL726wNf6H2IMsDuxCpJj59KDaxCtSnrWan2AeDqM7JBaultg=="],
 
+    "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
+
+    "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
+
+    "react": ["react@19.2.7", "", {}, "sha512-HNe9WslTbXmFK8o8cmwgAeJFSBvt1bPdHCVKtaaV+WlAN36mpT4hcRpwbf3fY56ar2oIXzsBpOAiIRHAdY0OlQ=="],
+
+    "react-dom": ["react-dom@19.2.7", "", { "dependencies": { "scheduler": "^0.27.0" }, "peerDependencies": { "react": "^19.2.7" } }, "sha512-t0BRVXvbiE/o20Hfw669rLbMCDWtYZLvmJigy2f0MxsXF+71pxhR3xOkspmsO8h3ZlNzyibAmtCa3l4lYKk6gQ=="],
 
     "readdirp": ["readdirp@4.1.2", "", {}, "sha512-GDhwkLfywWL2s6vEjyhri+eXmfH6j1L7JE27WhqLeYzoh/A3DBaYGEj2H/HFZCn/kMfim73FXxEJTw06WtxQwg=="],
 
@@ -210,6 +221,8 @@
     "regex-recursion": ["regex-recursion@6.0.2", "", { "dependencies": { "regex-utilities": "^2.3.0" } }, "sha512-0YCaSCq2VRIebiaUviZNs0cBz1kg5kVS2UKUfNIx8YVs1cN3AV7NTctO5FOKBA+UT2BPJIWZauYHPqJODG50cg=="],
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
+
+    "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 

--- a/package.json
+++ b/package.json
@@ -26,6 +26,7 @@
 		"test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"
 	},
 	"dependencies": {
+		"@pierre/trees": "1.0.0-beta.4",
 		"chokidar": "^4.0.3",
 		"gray-matter": "^4.0.3",
 		"markdown-it": "^14.1.0",

--- a/scripts/lint-published-markdown.ts
+++ b/scripts/lint-published-markdown.ts
@@ -3,19 +3,11 @@ import fs from "node:fs/promises";
 import path from "node:path";
 import { createRequire } from "node:module";
 import matter from "gray-matter";
+import { lint as lintMarkdown } from "markdownlint/promise";
 import { loadUserConfig, resolveBuildOptions, type CliArgs } from "../src/config";
 import { buildExcluder, relativePosix } from "../src/utils";
 
 const require = createRequire(import.meta.url);
-const markdownlint = require("markdownlint") as {
-  promises: {
-    markdownlint(options: {
-      strings: Record<string, string>;
-      config: Record<string, unknown>;
-      frontMatter?: RegExp;
-    }): Promise<Record<string, Array<Record<string, unknown>>>>;
-  };
-};
 const lintConfigModule = require("../.markdownlint.cjs") as { config: Record<string, unknown> };
 
 const REPORT_FILE_NAME = "mdlint-report.json";
@@ -310,11 +302,11 @@ async function main(): Promise<void> {
 
   const lintResults =
     scanResult.docs.length > 0
-      ? await markdownlint.promises.markdownlint({
+      ? ((await lintMarkdown({
           strings: lintStrings,
           config: lintConfigModule.config,
           frontMatter: FRONTMATTER_RE,
-        })
+        })) as Record<string, Array<Record<string, unknown>>>)
       : {};
 
   const markdownlintIssues = mapMarkdownlintIssues(lintResults);

--- a/src/build.ts
+++ b/src/build.ts
@@ -1163,9 +1163,31 @@ function buildAppShellAssetsForOutput(outputPath: string, runtimeAssets: Runtime
   };
 }
 
+async function bundleRuntimeJs(entrypoint: string): Promise<string> {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    target: "browser",
+    format: "esm",
+    splitting: false,
+    sourcemap: "none",
+  });
+
+  if (!result.success) {
+    const details = result.logs.map((log) => String(log)).filter(Boolean).join("\n");
+    throw new Error(`Failed to bundle runtime app.js${details ? `:\n${details}` : ""}`);
+  }
+
+  const output = result.outputs.find((artifact) => artifact.path.endsWith(".js")) ?? result.outputs[0];
+  if (!output) {
+    throw new Error("Failed to bundle runtime app.js: no JavaScript output was produced");
+  }
+
+  return output.text();
+}
+
 async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeAssets> {
   const runtimeDir = path.join(import.meta.dir, "runtime");
-  const runtimeJs = await Bun.file(path.join(runtimeDir, "app.js")).text();
+  const runtimeJs = await bundleRuntimeJs(path.join(runtimeDir, "app.js"));
   const runtimeCss = await Bun.file(path.join(runtimeDir, "app.css")).text();
 
   const jsRelPath = `assets/app.${makeHash(runtimeJs).slice(0, 12)}.js`;

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -441,6 +441,13 @@ a:hover {
   padding: 16px 12px 24px;
 }
 
+.tree-root file-tree-container {
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
+}
+
 .tree-folder {
   margin-bottom: 2px;
   --tree-depth: 0;

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -434,147 +434,158 @@ a:hover {
   box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset, 0 2px 6px rgba(136, 57, 239, 0.22);
 }
 
-/* Tree */
-.tree-root {
-  flex: 1;
-  overflow-y: auto;
-  padding: 16px 12px 24px;
+/* Tree search */
+.sidebar-search {
+  padding: 14px 16px 10px;
+  border-bottom: 1px solid var(--latte-surface0);
+  background: color-mix(in srgb, var(--latte-mantle) 92%, var(--latte-base));
 }
 
-.tree-root file-tree-container {
-  display: block;
-  width: 100%;
-  height: 100%;
-  min-height: 0;
+.sidebar-search-box {
+  display: grid;
+  grid-template-columns: 22px minmax(0, 1fr) 30px;
+  align-items: center;
+  gap: 6px;
+  min-height: 40px;
+  padding: 0 6px 0 11px;
+  border: 1px solid var(--latte-surface1);
+  border-radius: 8px;
+  background: var(--elevated-surface);
+  box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
+  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
 }
 
-.tree-folder {
-  margin-bottom: 2px;
-  --tree-depth: 0;
+.sidebar-search-box:focus-within {
+  border-color: color-mix(in srgb, var(--latte-blue) 56%, var(--latte-surface1));
+  background: var(--elevated-surface-hover);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--latte-blue) 18%, transparent);
 }
 
-.tree-children {
-  --tree-indent-step: clamp(6px, calc(12px - (var(--tree-depth, 0) * 1px)), 12px);
-  margin-left: var(--tree-indent-step);
-  padding-left: calc(var(--tree-indent-step) + 1px);
-  border-left: 1px solid var(--latte-surface0);
+.sidebar-search-icon {
+  color: var(--latte-overlay0);
+  font-size: 19px;
 }
 
-.tree-row {
+.tree-search-input {
+  min-width: 0;
   width: 100%;
   border: 0;
+  outline: 0;
   background: transparent;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-  justify-content: flex-start;
-  text-align: left;
-  min-height: 38px;
-  padding: 6px 12px;
-  text-decoration: none;
-  color: var(--latte-subtext1);
-  cursor: pointer;
-  font-size: 0.9rem;
-  border-radius: 6px;
-  transition: all 0.15s ease;
+  color: var(--latte-text);
+  font: inherit;
+  font-size: 0.88rem;
 }
 
-.tree-row:hover {
-  background: rgba(204, 208, 218, 0.5);
+.tree-search-input::placeholder {
+  color: var(--latte-overlay0);
+}
+
+.tree-search-input::-webkit-search-decoration,
+.tree-search-input::-webkit-search-cancel-button {
+  display: none;
+}
+
+.tree-search-clear,
+.tree-search-step {
+  width: 30px;
+  height: 30px;
+  border: 1px solid transparent;
+  border-radius: 8px;
+  background: transparent;
+  color: var(--latte-overlay0);
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  cursor: pointer;
+}
+
+.tree-search-clear[hidden] {
+  display: none;
+}
+
+.tree-search-clear:hover,
+.tree-search-step:hover:not(:disabled) {
+  border-color: var(--latte-surface1);
+  background: var(--elevated-surface-hover);
   color: var(--latte-text);
 }
 
-.tree-row:focus-visible {
+.tree-search-clear:focus-visible,
+.tree-search-step:focus-visible {
   outline: 2px solid var(--latte-blue);
   outline-offset: 1px;
 }
 
-.tree-folder-row {
-  font-weight: 500;
+.tree-search-step:disabled {
+  cursor: default;
+  opacity: 0.42;
 }
 
-.tree-folder-row .material-symbols-outlined {
-  color: var(--latte-blue);
+.tree-search-clear .material-symbols-outlined,
+.tree-search-step .material-symbols-outlined {
+  font-size: 18px;
 }
 
-.tree-folder.virtual > .tree-folder-row .material-symbols-outlined {
-  color: var(--latte-teal);
+.sidebar-search-actions {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 8px;
+  min-height: 30px;
+  margin-top: 7px;
 }
 
-.tree-file-row .material-symbols-outlined {
+.tree-search-count {
+  min-width: 0;
   color: var(--latte-overlay0);
+  font-size: 0.75rem;
+  font-weight: 650;
 }
 
-.tree-prefix {
-  flex: 0 0 auto;
-  font-size: 0.68rem;
-  font-weight: 600;
-  letter-spacing: 0.02em;
-  color: var(--latte-subtext1);
+.tree-search-nav {
+  display: inline-flex;
+  gap: 4px;
 }
 
-.tree-label {
+/* Tree */
+.tree-root {
   flex: 1;
   overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
+  padding: 12px 12px 24px;
 }
 
-.tree-label-tooltip {
-  position: fixed;
-  z-index: 140;
-  pointer-events: none;
-  max-width: min(440px, calc(100vw - 24px));
-  padding: 6px 10px;
-  border-radius: 8px;
-  background: var(--tooltip-bg);
-  color: var(--tooltip-text);
-  font-size: 0.75rem;
-  line-height: 1.4;
-  box-shadow: 0 10px 24px rgba(76, 79, 105, 0.24);
-}
-
-.tree-label-tooltip[hidden] {
-  display: none;
-}
-
-/* Active file state */
-.tree-file-row.is-active {
-  background: var(--active-surface-bg);
-  color: var(--latte-text);
-  font-weight: 500;
-  border: 1px solid var(--latte-surface0);
-  border-left: 4px solid var(--latte-mauve);
-  box-shadow: 0 1px 3px rgba(0, 0, 0, 0.08);
-  padding-left: 8px;
-}
-
-.tree-file-row.is-active .material-symbols-outlined {
-  color: var(--latte-mauve);
-}
-
-/* NEW badge */
-.badge-new {
-  margin-left: auto;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  padding: 2px 6px;
-  border-radius: 999px;
-  color: var(--badge-new-fg);
-  background: var(--badge-new-bg);
-}
-
-/* Active badge */
-.badge-active {
-  margin-left: auto;
-  font-size: 0.6rem;
-  font-weight: 700;
-  letter-spacing: 0.03em;
-  padding: 2px 6px;
-  border-radius: 999px;
-  color: var(--latte-mauve);
-  background: rgba(136, 57, 239, 0.1);
+.tree-root file-tree-container {
+  --trees-bg-override: transparent;
+  --trees-bg-muted-override: color-mix(in srgb, var(--latte-surface0) 44%, transparent);
+  --trees-fg-override: var(--latte-subtext1);
+  --trees-fg-muted-override: var(--latte-overlay0);
+  --trees-accent-override: var(--latte-mauve);
+  --trees-border-color-override: var(--latte-surface0);
+  --trees-focus-ring-color-override: var(--latte-blue);
+  --trees-focus-ring-width-override: 2px;
+  --trees-focus-ring-offset-override: 1px;
+  --trees-selected-bg-override: var(--active-surface-bg);
+  --trees-selected-fg-override: var(--latte-text);
+  --trees-selected-focused-border-color-override: color-mix(in srgb, var(--latte-mauve) 36%, transparent);
+  --trees-font-family-override: inherit;
+  --trees-font-size-override: 0.9rem;
+  --trees-font-weight-regular-override: 450;
+  --trees-font-weight-semibold-override: 700;
+  --trees-border-radius-override: 6px;
+  --trees-gap-override: 2px;
+  --trees-item-margin-x-override: 0px;
+  --trees-item-padding-x-override: 12px;
+  --trees-item-row-gap-override: 8px;
+  --trees-level-gap-override: 10px;
+  --trees-padding-inline-override: 0px;
+  --trees-file-icon-color-default: var(--latte-overlay0);
+  --trees-new-badge-bg: var(--badge-new-bg);
+  --trees-new-badge-fg: var(--badge-new-fg);
+  display: block;
+  width: 100%;
+  height: 100%;
+  min-height: 0;
 }
 
 /* Sidebar footer */

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -28,6 +28,11 @@ const TREE_UNSAFE_CSS = `
   font-weight: var(--trees-font-weight-semibold);
 }
 
+/* EIAM owns the visible search controls while Trees keeps search projection enabled. */
+[data-file-tree-search-container] {
+  display: none;
+}
+
 [data-item-section='decoration'] > span {
   flex: 0 0 auto;
   width: auto;
@@ -1759,6 +1764,8 @@ async function start() {
         preparedInput,
         renderRowDecoration: renderTreeRowDecoration,
         sort: compareTreesByBranchOrder,
+        search: true,
+        searchBlurBehavior: "retain",
         stickyFolders: true,
         unsafeCSS: TREE_UNSAFE_CSS,
       });

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -17,6 +17,29 @@ const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+const TREE_UNSAFE_CSS = `
+[data-type='item'][data-item-selected] {
+  border-left: 4px solid var(--trees-accent-override, currentColor);
+  box-shadow: inset 0 0 0 1px var(--trees-selected-focused-border-color-override, transparent);
+  padding-left: calc(var(--trees-item-padding-x) - 4px);
+}
+
+[data-type='item'][data-item-selected] [data-item-section='content'] {
+  font-weight: var(--trees-font-weight-semibold);
+}
+
+[data-item-section='decoration'] > span {
+  flex: 0 0 auto;
+  width: auto;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--trees-new-badge-bg, #d20f39);
+  color: var(--trees-new-badge-fg, #ffffff);
+  font-size: 0.625rem;
+  font-weight: 800;
+  line-height: 1;
+}
+`;
 const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
 const MERMAID_DEFAULT_THEME = "default";
 const MERMAID_SELECTOR = "pre.mermaid";
@@ -979,6 +1002,11 @@ async function start() {
   setAppReadyState("booting");
 
   const treeRoot = document.getElementById("tree-root");
+  const treeSearchInput = document.getElementById("tree-search-input");
+  const treeSearchClear = document.getElementById("tree-search-clear");
+  const treeSearchPrev = document.getElementById("tree-search-prev");
+  const treeSearchNext = document.getElementById("tree-search-next");
+  const treeSearchCount = document.getElementById("tree-search-count");
   const appRoot = document.querySelector(".app-root");
   const splitter = document.getElementById("app-splitter");
   const sidebar = document.getElementById("sidebar-panel");
@@ -1010,6 +1038,7 @@ async function start() {
   let fileTree = null;
   let isSyncingTreeSelection = false;
   let treePathOrder = new Map();
+  let treeSearchValue = "";
 
   const announceA11yStatus = (message) => {
     if (!(a11yStatusEl instanceof HTMLElement)) {
@@ -1477,6 +1506,99 @@ async function start() {
     }
   };
 
+  const updateTreeSearchControls = () => {
+    const normalizedSearchValue = fileTree ? fileTree.getSearchValue() : treeSearchValue.trim();
+    const hasSearch = normalizedSearchValue.length > 0;
+    const matchCount = hasSearch && fileTree ? fileTree.getSearchMatchingPaths().length : 0;
+    const canStep = hasSearch && matchCount > 0;
+
+    if (treeSearchClear instanceof HTMLButtonElement) {
+      treeSearchClear.hidden = !hasSearch;
+      treeSearchClear.disabled = !hasSearch;
+    }
+
+    for (const button of [treeSearchPrev, treeSearchNext]) {
+      if (button instanceof HTMLButtonElement) {
+        button.disabled = !canStep;
+      }
+    }
+
+    if (treeSearchCount instanceof HTMLElement) {
+      treeSearchCount.textContent = hasSearch ? `${matchCount}개 일치` : "";
+    }
+  };
+
+  const applyTreeSearch = (value) => {
+    treeSearchValue = value;
+
+    if (treeSearchInput instanceof HTMLInputElement && treeSearchInput.value !== value) {
+      treeSearchInput.value = value;
+    }
+
+    if (fileTree) {
+      const query = value.trim();
+      if (query) {
+        if (fileTree.isSearchOpen()) {
+          fileTree.setSearch(query);
+        } else {
+          fileTree.openSearch(query);
+        }
+      } else {
+        fileTree.closeSearch();
+      }
+    }
+
+    updateTreeSearchControls();
+  };
+
+  const moveTreeSearchFocus = (direction) => {
+    if (!fileTree || !fileTree.isSearchOpen() || fileTree.getSearchMatchingPaths().length === 0) {
+      return;
+    }
+
+    if (direction < 0) {
+      fileTree.focusPreviousSearchMatch();
+    } else {
+      fileTree.focusNextSearchMatch();
+    }
+
+    updateTreeSearchControls();
+  };
+
+  if (treeSearchInput instanceof HTMLInputElement) {
+    treeSearchInput.addEventListener("input", () => {
+      applyTreeSearch(treeSearchInput.value);
+    });
+    treeSearchInput.addEventListener("keydown", (event) => {
+      if (event.key === "Enter") {
+        event.preventDefault();
+        moveTreeSearchFocus(event.shiftKey ? -1 : 1);
+        return;
+      }
+
+      if (event.key === "Escape" && treeSearchInput.value.trim()) {
+        event.preventDefault();
+        event.stopPropagation();
+        applyTreeSearch("");
+      }
+    });
+  }
+
+  treeSearchClear?.addEventListener("click", () => {
+    applyTreeSearch("");
+    if (treeSearchInput instanceof HTMLInputElement) {
+      treeSearchInput.focus();
+    }
+  });
+
+  treeSearchPrev?.addEventListener("click", () => {
+    moveTreeSearchFocus(-1);
+  });
+
+  treeSearchNext?.addEventListener("click", () => {
+    moveTreeSearchFocus(1);
+  });
+
   const syncActiveTreeSelection = (docId, { scroll = true } = {}) => {
     if (!fileTree || !docId) {
       return;
@@ -1637,9 +1759,8 @@ async function start() {
         preparedInput,
         renderRowDecoration: renderTreeRowDecoration,
         sort: compareTreesByBranchOrder,
-        search: true,
-        searchBlurBehavior: "retain",
         stickyFolders: true,
+        unsafeCSS: TREE_UNSAFE_CSS,
       });
       fileTree.render({ containerWrapper: treeRoot });
     } else {
@@ -1652,6 +1773,7 @@ async function start() {
     }
 
     syncActiveTreeSelection(state.currentDocId || "");
+    applyTreeSearch(treeSearchValue);
   };
 
   const updateBacklinks = (doc) => {

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,12 +1,11 @@
+import { FileTree, prepareFileTreeInput } from "@pierre/trees";
 import { buildTreesAdapterInput } from "./tree-adapter.js";
 
-const EXPANDED_KEY = "fsblog.expanded";
 const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
 const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
 const THEME_MODE_KEY = "fsblog.themeMode";
 const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
 const SIDEBAR_WIDTH_KEY = "fsblog.desktopSidebarWidth";
-const TYPEAHEAD_RESET_MS = 700;
 const DESKTOP_SIDEBAR_DEFAULT = 420;
 const DESKTOP_SIDEBAR_MIN = 320;
 const DESKTOP_VIEWER_MIN = 680;
@@ -767,26 +766,6 @@ function pickHomeRoute(view) {
   return [...view.docs].sort(compareDocsByRecentDateThenRoute)[0]?.route || "/";
 }
 
-function loadExpandedSet() {
-  try {
-    const raw = localStorage.getItem(EXPANDED_KEY);
-    if (!raw) {
-      return new Set();
-    }
-    const parsed = JSON.parse(raw);
-    if (!Array.isArray(parsed)) {
-      return new Set();
-    }
-    return new Set(parsed.filter((x) => typeof x === "string"));
-  } catch {
-    return new Set();
-  }
-}
-
-function persistExpandedSet(expanded) {
-  localStorage.setItem(EXPANDED_KEY, JSON.stringify(Array.from(expanded)));
-}
-
 function loadMenuTogglePosition() {
   const raw = localStorage.getItem(MENU_TOGGLE_POSITION_KEY);
   return raw === "left" ? "left" : "right";
@@ -863,7 +842,24 @@ function getFocusableElements(container) {
     return [];
   }
 
-  return Array.from(container.querySelectorAll(FOCUSABLE_SELECTOR)).filter((el) => {
+  const candidates = [];
+  const collect = (root) => {
+    for (const el of root.querySelectorAll("*")) {
+      if (!(el instanceof HTMLElement)) {
+        continue;
+      }
+      if (el.matches(FOCUSABLE_SELECTOR)) {
+        candidates.push(el);
+      }
+      if (el.shadowRoot) {
+        collect(el.shadowRoot);
+      }
+    }
+  };
+
+  collect(container);
+
+  return candidates.filter((el) => {
     if (!(el instanceof HTMLElement)) {
       return false;
     }
@@ -887,354 +883,6 @@ function getFocusableElements(container) {
 
     return el.getClientRects().length > 0;
   });
-}
-
-function getTreeLabelText(row) {
-  const label = row.querySelector(".tree-label");
-  if (!(label instanceof HTMLElement)) {
-    return "";
-  }
-  return label.textContent?.trim() || "";
-}
-
-function getVisibleTreeRows(treeRoot) {
-  const rows = [];
-  for (const row of treeRoot.querySelectorAll(".tree-row")) {
-    if (!(row instanceof HTMLElement)) {
-      continue;
-    }
-    if (row.closest("[hidden]")) {
-      continue;
-    }
-    rows.push(row);
-  }
-  return rows;
-}
-
-function initializeTreeTypeahead(treeRoot) {
-  if (!(treeRoot instanceof HTMLElement)) {
-    return;
-  }
-
-  let query = "";
-  let resetTimer = 0;
-
-  const scheduleReset = () => {
-    if (resetTimer) {
-      clearTimeout(resetTimer);
-    }
-    resetTimer = window.setTimeout(() => {
-      query = "";
-    }, TYPEAHEAD_RESET_MS);
-  };
-
-  const findMatch = (rows, needle, startIndex) => {
-    if (!needle) {
-      return null;
-    }
-
-    for (let offset = 1; offset <= rows.length; offset += 1) {
-      const idx = (startIndex + offset + rows.length) % rows.length;
-      const row = rows[idx];
-      const text = getTreeLabelText(row).toLocaleLowerCase("ko-KR");
-      if (text.startsWith(needle)) {
-        return row;
-      }
-    }
-
-    return null;
-  };
-
-  treeRoot.addEventListener("keydown", (event) => {
-    if (event.defaultPrevented || event.altKey || event.ctrlKey || event.metaKey) {
-      return;
-    }
-
-    const target = event.target;
-    if (target instanceof HTMLInputElement || target instanceof HTMLTextAreaElement) {
-      return;
-    }
-
-    if (event.key === "Backspace" && query.length > 0) {
-      query = query.slice(0, -1);
-      scheduleReset();
-      event.preventDefault();
-    } else if (event.key.length === 1 && /\S/.test(event.key)) {
-      query += event.key.toLocaleLowerCase("ko-KR");
-      scheduleReset();
-    } else {
-      return;
-    }
-
-    const rows = getVisibleTreeRows(treeRoot);
-    if (rows.length === 0 || query.length === 0) {
-      return;
-    }
-
-    const activeElement = document.activeElement;
-    const startIndex = rows.findIndex((row) => row === activeElement);
-    const matchedRow = findMatch(rows, query, startIndex);
-    if (!(matchedRow instanceof HTMLElement)) {
-      return;
-    }
-
-    matchedRow.focus();
-    matchedRow.scrollIntoView({ block: "nearest" });
-    event.preventDefault();
-  });
-}
-
-function initializeTreeLabelTooltip(treeRoot, tooltipEl) {
-  if (!(treeRoot instanceof HTMLElement) || !(tooltipEl instanceof HTMLElement)) {
-    return { hide: () => {}, dispose: () => {} };
-  }
-
-  let activeRow = null;
-  const cleanups = [];
-
-  const hide = () => {
-    tooltipEl.hidden = true;
-    tooltipEl.textContent = "";
-    if (activeRow instanceof HTMLElement) {
-      activeRow.removeAttribute("aria-describedby");
-    }
-    activeRow = null;
-  };
-
-  const show = (row) => {
-    if (!(row instanceof HTMLElement)) {
-      hide();
-      return;
-    }
-
-    if (activeRow === row && !tooltipEl.hidden) {
-      return;
-    }
-
-    const labelEl = row.querySelector(".tree-label");
-    if (!(labelEl instanceof HTMLElement)) {
-      hide();
-      return;
-    }
-
-    if (labelEl.scrollWidth <= labelEl.clientWidth + 1) {
-      hide();
-      return;
-    }
-
-    const labelText = labelEl.textContent?.trim();
-    if (!labelText) {
-      hide();
-      return;
-    }
-
-    tooltipEl.textContent = labelText;
-    tooltipEl.hidden = false;
-
-    const labelRect = labelEl.getBoundingClientRect();
-    const tooltipRect = tooltipEl.getBoundingClientRect();
-    const safePadding = 8;
-    const gap = 8;
-
-    let top = labelRect.top - tooltipRect.height - gap;
-    if (top < safePadding) {
-      top = labelRect.bottom + gap;
-    }
-
-    let left = labelRect.left;
-    const rightOverflow = left + tooltipRect.width - (window.innerWidth - safePadding);
-    if (rightOverflow > 0) {
-      left -= rightOverflow;
-    }
-    if (left < safePadding) {
-      left = safePadding;
-    }
-
-    tooltipEl.style.top = `${Math.round(top)}px`;
-    tooltipEl.style.left = `${Math.round(left)}px`;
-
-    if (activeRow instanceof HTMLElement && activeRow !== row) {
-      activeRow.removeAttribute("aria-describedby");
-    }
-    activeRow = row;
-    row.setAttribute("aria-describedby", tooltipEl.id);
-  };
-
-  const getTreeRow = (target) => {
-    if (!(target instanceof Element)) {
-      return null;
-    }
-    const row = target.closest(".tree-row");
-    if (!(row instanceof HTMLElement) || !treeRoot.contains(row)) {
-      return null;
-    }
-    return row;
-  };
-
-  const onMouseOver = (event) => {
-    const row = getTreeRow(event.target);
-    if (!row) {
-      return;
-    }
-    show(row);
-  };
-
-  const onMouseOut = (event) => {
-    const fromRow = getTreeRow(event.target);
-    if (!fromRow) {
-      return;
-    }
-    const toRow = getTreeRow(event.relatedTarget);
-    if (toRow === fromRow) {
-      return;
-    }
-    hide();
-  };
-
-  const onFocusIn = (event) => {
-    const row = getTreeRow(event.target);
-    if (!row) {
-      return;
-    }
-    show(row);
-  };
-
-  const onFocusOut = (event) => {
-    const toRow = getTreeRow(event.relatedTarget);
-    if (toRow) {
-      return;
-    }
-    hide();
-  };
-
-  treeRoot.addEventListener("mouseover", onMouseOver);
-  treeRoot.addEventListener("mouseout", onMouseOut);
-  treeRoot.addEventListener("focusin", onFocusIn);
-  treeRoot.addEventListener("focusout", onFocusOut);
-
-  cleanups.push(() => treeRoot.removeEventListener("mouseover", onMouseOver));
-  cleanups.push(() => treeRoot.removeEventListener("mouseout", onMouseOut));
-  cleanups.push(() => treeRoot.removeEventListener("focusin", onFocusIn));
-  cleanups.push(() => treeRoot.removeEventListener("focusout", onFocusOut));
-
-  treeRoot.addEventListener("scroll", hide);
-  window.addEventListener("resize", hide);
-  document.addEventListener("scroll", hide, true);
-
-  cleanups.push(() => treeRoot.removeEventListener("scroll", hide));
-  cleanups.push(() => window.removeEventListener("resize", hide));
-  cleanups.push(() => document.removeEventListener("scroll", hide, true));
-
-  return {
-    hide,
-    dispose() {
-      hide();
-      for (const cleanup of cleanups) {
-        cleanup();
-      }
-    },
-  };
-}
-
-function createFolderNode(node, expandedSet, fileRowsById, pathBase, depth = 0) {
-  const wrapper = document.createElement("div");
-  wrapper.className = node.virtual ? "tree-folder virtual" : "tree-folder";
-  wrapper.style.setProperty("--tree-depth", String(depth));
-
-  const row = document.createElement("button");
-  row.type = "button";
-  row.className = "tree-folder-row tree-row";
-  row.dataset.rowType = "folder";
-  row.dataset.folderPath = node.path;
-  row.dataset.virtual = String(Boolean(node.virtual));
-
-  const isExpanded = node.virtual ? true : expandedSet.has(node.path);
-  const iconName = isExpanded ? "folder_open" : "folder";
-
-  row.innerHTML = `<span class="material-symbols-outlined">${iconName}</span><span class="tree-label">${escapeHtmlAttr(node.name)}</span>`;
-  row.setAttribute("aria-expanded", String(isExpanded));
-
-  const children = document.createElement("div");
-  children.className = "tree-children";
-  if (!isExpanded) {
-    children.hidden = true;
-  }
-
-  for (const child of node.children) {
-    if (child.type === "folder") {
-      children.appendChild(createFolderNode(child, expandedSet, fileRowsById, pathBase, depth + 1));
-    } else {
-      children.appendChild(createFileNode(child, fileRowsById, pathBase, depth + 1));
-    }
-  }
-
-  wrapper.appendChild(row);
-  wrapper.appendChild(children);
-  return wrapper;
-}
-
-function createFileNode(node, fileRowsById, pathBase, depth = 0) {
-  const row = document.createElement("a");
-  row.href = toPathWithBase(node.route, pathBase);
-  row.className = "tree-row tree-file-row";
-  row.dataset.rowType = "file";
-  row.dataset.route = node.route;
-  row.dataset.fileId = node.id;
-  row.style.setProperty("--tree-depth", String(depth));
-
-  const prefix = typeof node.prefix === "string" ? node.prefix.trim() : "";
-  const prefixHtml = prefix ? `<span class="tree-prefix">${escapeHtmlAttr(prefix)}</span>` : "";
-  const label = escapeHtmlAttr(node.title || node.name);
-  const newBadge = node.isNew ? `<span class="badge-new">NEW</span>` : "";
-  row.innerHTML = `<span class="material-symbols-outlined">article</span>${prefixHtml}<span class="tree-label">${label}</span>${newBadge}`;
-  fileRowsById.set(node.id, row);
-
-  return row;
-}
-
-function setFileRowActive(row, active) {
-  if (!(row instanceof HTMLElement)) {
-    return;
-  }
-
-  const badge = row.querySelector(".badge-active");
-  if (badge) {
-    badge.remove();
-  }
-
-  if (active) {
-    row.classList.add("is-active");
-    row.setAttribute("aria-current", "page");
-    const activeBadge = document.createElement("span");
-    activeBadge.className = "badge-active";
-    activeBadge.textContent = "active";
-    row.appendChild(activeBadge);
-    return;
-  }
-
-  row.classList.remove("is-active");
-  row.removeAttribute("aria-current");
-}
-
-function markActive(fileRowsById, activeState, id) {
-  if (activeState.currentId === id) {
-    return;
-  }
-
-  if (activeState.current instanceof HTMLElement) {
-    setFileRowActive(activeState.current, false);
-  }
-
-  const next = id ? fileRowsById.get(id) : null;
-  if (next instanceof HTMLElement) {
-    setFileRowActive(next, true);
-    activeState.current = next;
-    activeState.currentId = id;
-    return;
-  }
-
-  activeState.current = null;
-  activeState.currentId = "";
 }
 
 function renderBreadcrumb(route) {
@@ -1337,7 +985,6 @@ async function start() {
   const sidebarToggle = document.getElementById("sidebar-toggle");
   const sidebarClose = document.getElementById("sidebar-close");
   const sidebarOverlay = document.getElementById("sidebar-overlay");
-  const treeLabelTooltip = document.getElementById("tree-label-tooltip");
   const sidebarBranchPills = document.getElementById("sidebar-branch-pills");
   const sidebarBranchInfo = document.getElementById("sidebar-branch-info");
   const settingsToggle = document.getElementById("settings-toggle");
@@ -1356,17 +1003,13 @@ async function start() {
   const initialViewData = loadInitialViewData();
   let hasHydratedInitialView = false;
 
-  let hideTreeTooltip = () => {};
-  let disposeTreeTooltip = () => {};
   let desktopSidebarWidth = clampDesktopSidebarWidth(loadDesktopSidebarWidth());
   let activeResizePointerId = null;
   let resizeStartX = 0;
   let resizeStartWidth = desktopSidebarWidth;
-  let treeFileRowsById = new Map();
-  const activeFileState = {
-    current: null,
-    currentId: "",
-  };
+  let fileTree = null;
+  let isSyncingTreeSelection = false;
+  let treePathOrder = new Map();
 
   const announceA11yStatus = (message) => {
     if (!(a11yStatusEl instanceof HTMLElement)) {
@@ -1546,7 +1189,6 @@ async function start() {
     if (sidebarOverlay) {
       sidebarOverlay.hidden = true;
     }
-    hideTreeTooltip();
     closeSettings();
     document.body.classList.remove("menu-open");
     syncSidebarA11y(false);
@@ -1815,7 +1457,6 @@ async function start() {
   let view = getBranchView(activeBranch);
 
   const docsById = new Map(manifest.docs.map((doc) => [doc.id, doc]));
-  const expanded = loadExpandedSet();
 
   const updateBranchInfo = () => {
     if (sidebarBranchInfo instanceof HTMLElement) {
@@ -1836,28 +1477,100 @@ async function start() {
     }
   };
 
+  const syncActiveTreeSelection = (docId, { scroll = true } = {}) => {
+    if (!fileTree || !docId) {
+      return;
+    }
+
+    const treePath = view.trees.docIdToPrimaryTreePath.get(docId);
+    if (!treePath) {
+      return;
+    }
+
+    const selectedPaths = fileTree.getSelectedPaths();
+    if (selectedPaths.length === 1 && selectedPaths[0] === treePath) {
+      return;
+    }
+
+    const item = fileTree.getItem(treePath);
+    if (!item) {
+      return;
+    }
+
+    isSyncingTreeSelection = true;
+    try {
+      item.select();
+    } finally {
+      isSyncingTreeSelection = false;
+    }
+
+    if (scroll) {
+      fileTree.scrollToPath(treePath, { focus: false, offset: "nearest" });
+    }
+  };
+
+  const compareTreesByBranchOrder = (left, right) => {
+    const leftIndex = treePathOrder.get(left.path) ?? Number.MAX_SAFE_INTEGER;
+    const rightIndex = treePathOrder.get(right.path) ?? Number.MAX_SAFE_INTEGER;
+    if (leftIndex !== rightIndex) {
+      return leftIndex - rightIndex;
+    }
+    return left.path.localeCompare(right.path, "ko-KR");
+  };
+
+  const prepareTreesInput = () => {
+    treePathOrder = new Map(view.trees.paths.map((treePath, index) => [treePath, index]));
+    return prepareFileTreeInput(view.trees.paths, { sort: compareTreesByBranchOrder });
+  };
+
   const renderTree = (state) => {
     if (!(treeRoot instanceof HTMLElement)) {
       return;
     }
 
-    hideTreeTooltip();
-    disposeTreeTooltip();
-    treeRoot.innerHTML = "";
-    treeFileRowsById = new Map();
+    const preparedInput = prepareTreesInput();
+    const selectedTreePath = state.currentDocId
+      ? view.trees.docIdToPrimaryTreePath.get(state.currentDocId)
+      : null;
 
-    for (const node of view.tree) {
-      if (node.type === "folder") {
-        treeRoot.appendChild(createFolderNode(node, state.expanded, treeFileRowsById, pathBase));
-      } else {
-        treeRoot.appendChild(createFileNode(node, treeFileRowsById, pathBase));
+    if (!fileTree) {
+      fileTree = new FileTree({
+        fileTreeSearchMode: "hide-non-matches",
+        flattenEmptyDirectories: false,
+        initialExpansion: 1,
+        initialSelectedPaths: selectedTreePath ? [selectedTreePath] : [],
+        itemHeight: 38,
+        onSelectionChange(selectedPaths) {
+          if (isSyncingTreeSelection) {
+            return;
+          }
+
+          const selectedPath = selectedPaths.at(-1);
+          const route = selectedPath ? view.trees.treePathToRoute.get(selectedPath) : null;
+          if (!route) {
+            window.queueMicrotask(() => syncActiveTreeSelection(state.currentDocId, { scroll: false }));
+            return;
+          }
+
+          void state.navigate(route, true);
+        },
+        preparedInput,
+        sort: compareTreesByBranchOrder,
+        search: true,
+        searchBlurBehavior: "retain",
+        stickyFolders: true,
+      });
+      fileTree.render({ containerWrapper: treeRoot });
+    } else {
+      isSyncingTreeSelection = true;
+      try {
+        fileTree.resetPaths(preparedInput.paths, { preparedInput });
+      } finally {
+        isSyncingTreeSelection = false;
       }
     }
 
-    const tooltipController = initializeTreeLabelTooltip(treeRoot, treeLabelTooltip);
-    hideTreeTooltip = tooltipController.hide;
-    disposeTreeTooltip = tooltipController.dispose;
-    markActive(treeFileRowsById, activeFileState, state.currentDocId || "");
+    syncActiveTreeSelection(state.currentDocId || "");
   };
 
   const updateBacklinks = (doc) => {
@@ -1875,11 +1588,8 @@ async function start() {
   };
 
   const state = {
-    expanded,
     currentDocId: initialViewData?.docId ?? "",
     async navigate(rawRoute, push) {
-      hideTreeTooltip();
-
       if (isCompactLayout()) {
         closeSidebar();
       }
@@ -1910,7 +1620,6 @@ async function start() {
         contentEl.innerHTML = '<p class="placeholder">요청한 경로에 해당하는 문서가 없습니다.</p>';
         updateBacklinks(null);
         navEl.innerHTML = "";
-        markActive(treeFileRowsById, activeFileState, "");
         announceA11yStatus("탐색 실패: 요청한 문서를 찾을 수 없습니다.");
         if (push) {
           history.pushState(null, "", toPathWithBase(route, pathBase));
@@ -1928,7 +1637,7 @@ async function start() {
       }
 
       state.currentDocId = id;
-      markActive(treeFileRowsById, activeFileState, id);
+      syncActiveTreeSelection(id);
 
       const shouldUseInitialView =
         !hasHydratedInitialView &&
@@ -1980,60 +1689,6 @@ async function start() {
       announceA11yStatus(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
     },
   };
-
-  if (treeRoot instanceof HTMLElement) {
-    treeRoot.addEventListener("click", (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) {
-        return;
-      }
-
-      const row = target.closest(".tree-row");
-      if (!(row instanceof HTMLElement) || !treeRoot.contains(row)) {
-        return;
-      }
-
-      if (row.dataset.rowType === "folder") {
-        if (row.dataset.virtual === "true") {
-          return;
-        }
-
-        const children = row.nextElementSibling;
-        if (!(children instanceof HTMLElement) || !children.classList.contains("tree-children")) {
-          return;
-        }
-
-        const currentlyExpanded = !children.hidden;
-        children.hidden = currentlyExpanded;
-        row.setAttribute("aria-expanded", String(!currentlyExpanded));
-        const icon = row.querySelector(".material-symbols-outlined");
-        if (icon instanceof HTMLElement) {
-          icon.textContent = currentlyExpanded ? "folder" : "folder_open";
-        }
-
-        const folderPath = row.dataset.folderPath;
-        if (!folderPath) {
-          return;
-        }
-        if (currentlyExpanded) {
-          state.expanded.delete(folderPath);
-        } else {
-          state.expanded.add(folderPath);
-        }
-        persistExpandedSet(state.expanded);
-        return;
-      }
-
-      if (row.dataset.rowType === "file") {
-        event.preventDefault();
-        const route = row.dataset.route;
-        if (!route) {
-          return;
-        }
-        state.navigate(route, true);
-      }
-    });
-  }
 
   if (contentEl instanceof HTMLElement) {
     contentEl.addEventListener("click", async (event) => {
@@ -2119,8 +1774,6 @@ async function start() {
       }
     });
   }
-
-  initializeTreeTypeahead(treeRoot);
 
   const setActiveBranch = async (nextBranch) => {
     const normalized = normalizeBranch(nextBranch);

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,3 +1,5 @@
+import { buildTreesAdapterInput } from "./tree-adapter.js";
+
 const EXPANDED_KEY = "fsblog.expanded";
 const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
 const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
@@ -738,6 +740,7 @@ function buildBranchView(manifest, branch, defaultBranch) {
   const docs = manifest.docs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
   const visibleDocIds = new Set(docs.map((doc) => doc.id));
   const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
+  const trees = buildTreesAdapterInput(tree, docs);
   const routeMap = {};
   const docIndexById = new Map();
   for (const doc of docs) {
@@ -751,6 +754,7 @@ function buildBranchView(manifest, branch, defaultBranch) {
     docs,
     visibleDocIds,
     tree,
+    trees,
     routeMap,
     docIndexById,
   };

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1509,6 +1509,26 @@ async function start() {
     }
   };
 
+  const clearTreeSelection = () => {
+    if (!fileTree) {
+      return;
+    }
+
+    const selectedPaths = fileTree.getSelectedPaths();
+    if (selectedPaths.length === 0) {
+      return;
+    }
+
+    isSyncingTreeSelection = true;
+    try {
+      for (const selectedPath of selectedPaths) {
+        fileTree.getItem(selectedPath)?.deselect();
+      }
+    } finally {
+      isSyncingTreeSelection = false;
+    }
+  };
+
   const compareTreesByBranchOrder = (left, right) => {
     const leftIndex = treePathOrder.get(left.path) ?? Number.MAX_SAFE_INTEGER;
     const rightIndex = treePathOrder.get(right.path) ?? Number.MAX_SAFE_INTEGER;
@@ -1523,6 +1543,59 @@ async function start() {
     return prepareFileTreeInput(view.trees.paths, { sort: compareTreesByBranchOrder });
   };
 
+  const renderTreeRowDecoration = ({ item }) => {
+    const metadata = view.trees.metadataByTreePath.get(item.path);
+    if (metadata?.kind !== "file" || metadata.isNew !== true) {
+      return null;
+    }
+
+    return {
+      text: "NEW",
+      title: "New document",
+    };
+  };
+
+  const renderTreeContextMenu = (item, context) => {
+    const route = view.trees.treePathToRoute.get(item.path);
+    if (!route) {
+      return null;
+    }
+
+    const menu = document.createElement("div");
+    menu.className = "tree-context-menu";
+    Object.assign(menu.style, {
+      background: "var(--trees-bg-override, canvas)",
+      border: "1px solid var(--trees-border-color-override, color-mix(in srgb, currentColor 18%, transparent))",
+      borderRadius: "6px",
+      boxShadow: "0 10px 24px rgba(0, 0, 0, 0.18)",
+      minWidth: "120px",
+      padding: "4px",
+    });
+
+    const link = document.createElement("a");
+    link.className = "tree-context-link";
+    link.href = toPathWithBase(route, pathBase);
+    link.textContent = "Open";
+    Object.assign(link.style, {
+      borderRadius: "4px",
+      color: "inherit",
+      display: "block",
+      padding: "6px 8px",
+      textDecoration: "none",
+    });
+    link.addEventListener("click", (event) => {
+      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
+        return;
+      }
+      event.preventDefault();
+      context.close();
+      void state.navigate(route, true);
+    });
+
+    menu.appendChild(link);
+    return menu;
+  };
+
   const renderTree = (state) => {
     if (!(treeRoot instanceof HTMLElement)) {
       return;
@@ -1535,6 +1608,13 @@ async function start() {
 
     if (!fileTree) {
       fileTree = new FileTree({
+        composition: {
+          contextMenu: {
+            enabled: true,
+            render: renderTreeContextMenu,
+            triggerMode: "right-click",
+          },
+        },
         fileTreeSearchMode: "hide-non-matches",
         flattenEmptyDirectories: false,
         initialExpansion: 1,
@@ -1555,6 +1635,7 @@ async function start() {
           void state.navigate(route, true);
         },
         preparedInput,
+        renderRowDecoration: renderTreeRowDecoration,
         sort: compareTreesByBranchOrder,
         search: true,
         searchBlurBehavior: "retain",
@@ -1614,6 +1695,7 @@ async function start() {
       
       if (!id) {
         state.currentDocId = "";
+        clearTreeSelection();
         breadcrumbEl.innerHTML = renderBreadcrumb(route);
         titleEl.textContent = "문서를 찾을 수 없습니다";
         metaEl.innerHTML = "";

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -1,0 +1,161 @@
+const DIRECTORY_SUFFIX = "/";
+const FILE_EXTENSION = ".md";
+const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f]/g;
+const PATH_SEPARATOR_RE = /[\\/]+/g;
+const WHITESPACE_RE = /\s+/g;
+
+function normalizeTreeSegment(value, fallback) {
+  const normalized = String(value ?? "")
+    .replace(CONTROL_CHARS_RE, "")
+    .replace(PATH_SEPARATOR_RE, " - ")
+    .replace(WHITESPACE_RE, " ")
+    .trim();
+
+  return normalized || fallback;
+}
+
+function trimFileExtension(value) {
+  return value.replace(/\.md$/i, "");
+}
+
+function joinTreePath(parentPath, segment, isDirectory) {
+  const cleanParent = parentPath.replace(/\/+$/, "");
+  const cleanSegment = normalizeTreeSegment(segment, "Untitled");
+  const joined = cleanParent ? `${cleanParent}/${cleanSegment}` : cleanSegment;
+  return isDirectory ? `${joined}${DIRECTORY_SUFFIX}` : joined;
+}
+
+function appendCollisionSuffix(pathValue, counter) {
+  const suffix = ` (${counter})`;
+  if (pathValue.endsWith(DIRECTORY_SUFFIX)) {
+    const clean = pathValue.slice(0, -1);
+    return `${clean}${suffix}${DIRECTORY_SUFFIX}`;
+  }
+
+  if (pathValue.toLowerCase().endsWith(FILE_EXTENSION)) {
+    return `${pathValue.slice(0, -FILE_EXTENSION.length)}${suffix}${FILE_EXTENSION}`;
+  }
+
+  return `${pathValue}${suffix}`;
+}
+
+function makeUniquePath(pathValue, usedPaths) {
+  if (!usedPaths.has(pathValue)) {
+    return pathValue;
+  }
+
+  let counter = 2;
+  let candidate = appendCollisionSuffix(pathValue, counter);
+  while (usedPaths.has(candidate)) {
+    counter += 1;
+    candidate = appendCollisionSuffix(pathValue, counter);
+  }
+  return candidate;
+}
+
+export function formatTreesFileBasename(node, doc) {
+  const fallbackTitle = trimFileExtension(node?.name ? String(node.name) : "Untitled");
+  const rawTitle = typeof node?.title === "string" && node.title.trim() ? node.title : doc?.title;
+  const title = normalizeTreeSegment(rawTitle, normalizeTreeSegment(fallbackTitle, "Untitled"));
+  const prefix = normalizeTreeSegment(node?.prefix ?? doc?.prefix ?? "", "");
+  return `${prefix ? `${prefix} ` : ""}${title}${FILE_EXTENSION}`;
+}
+
+export function buildTreesAdapterInput(treeNodes, docs = []) {
+  const docById = new Map();
+  for (const doc of Array.isArray(docs) ? docs : []) {
+    if (typeof doc?.id === "string" && doc.id) {
+      docById.set(doc.id, doc);
+    }
+  }
+
+  const paths = [];
+  const usedPaths = new Set();
+  const metadataByTreePath = new Map();
+  const treePathToDocId = new Map();
+  const treePathToRoute = new Map();
+  const docIdToTreePaths = new Map();
+  const docIdToPrimaryTreePath = new Map();
+
+  const registerPath = (pathValue, metadata) => {
+    const treePath = makeUniquePath(pathValue, usedPaths);
+    usedPaths.add(treePath);
+    paths.push(treePath);
+    metadataByTreePath.set(treePath, metadata);
+    return treePath;
+  };
+
+  const registerDocPath = (treePath, node, doc) => {
+    const docId = typeof node?.id === "string" ? node.id : "";
+    if (!docId) {
+      return;
+    }
+
+    const route = typeof node.route === "string" ? node.route : doc?.route;
+    treePathToDocId.set(treePath, docId);
+    if (typeof route === "string" && route) {
+      treePathToRoute.set(treePath, route);
+    }
+
+    const pathsForDoc = docIdToTreePaths.get(docId) ?? [];
+    pathsForDoc.push(treePath);
+    docIdToTreePaths.set(docId, pathsForDoc);
+
+    // Duplicate docs can appear in virtual folders and the real folder tree.
+    // Selection sync uses the first branch-visible occurrence as the primary
+    // path, while every occurrence still resolves through docId/route maps.
+    if (!docIdToPrimaryTreePath.has(docId)) {
+      docIdToPrimaryTreePath.set(docId, treePath);
+    }
+  };
+
+  const walk = (nodes, parentPath = "") => {
+    if (!Array.isArray(nodes)) {
+      return;
+    }
+
+    for (const node of nodes) {
+      if (!node || typeof node !== "object") {
+        continue;
+      }
+
+      if (node.type === "folder") {
+        const folderPath = registerPath(joinTreePath(parentPath, node.name, true), {
+          kind: "folder",
+          name: normalizeTreeSegment(node.name, "Untitled"),
+          sourcePath: typeof node.path === "string" ? node.path : "",
+          virtual: node.virtual === true,
+        });
+        walk(node.children, folderPath);
+        continue;
+      }
+
+      if (node.type !== "file") {
+        continue;
+      }
+
+      const doc = docById.get(node.id);
+      const treePath = registerPath(joinTreePath(parentPath, formatTreesFileBasename(node, doc), false), {
+        branch: node.branch ?? doc?.branch ?? null,
+        docId: node.id,
+        isNew: node.isNew === true,
+        kind: "file",
+        prefix: node.prefix ?? doc?.prefix ?? "",
+        route: node.route ?? doc?.route ?? "",
+        title: node.title ?? doc?.title ?? "",
+      });
+      registerDocPath(treePath, node, doc);
+    }
+  };
+
+  walk(treeNodes);
+
+  return {
+    docIdToPrimaryTreePath,
+    docIdToTreePaths,
+    metadataByTreePath,
+    paths,
+    treePathToDocId,
+    treePathToRoute,
+  };
+}

--- a/src/template.ts
+++ b/src/template.ts
@@ -231,6 +231,34 @@ ${headMeta}
             <span id="sidebar-branch-info" class="branch-info">publish: true</span>
           </div>
         </div>
+        <div class="sidebar-search">
+          <div class="sidebar-search-box">
+            <span class="material-symbols-outlined sidebar-search-icon" aria-hidden="true">search</span>
+            <input
+              id="tree-search-input"
+              class="tree-search-input"
+              type="search"
+              autocomplete="off"
+              spellcheck="false"
+              aria-label="문서 검색"
+              placeholder="Search"
+            />
+            <button id="tree-search-clear" class="tree-search-clear" type="button" aria-label="검색 지우기" title="검색 지우기" hidden>
+              <span class="material-symbols-outlined">close</span>
+            </button>
+          </div>
+          <div class="sidebar-search-actions" aria-live="polite">
+            <span id="tree-search-count" class="tree-search-count"></span>
+            <div class="tree-search-nav">
+              <button id="tree-search-prev" class="tree-search-step" type="button" aria-label="이전 검색 결과" title="이전 검색 결과" disabled>
+                <span class="material-symbols-outlined">keyboard_arrow_up</span>
+              </button>
+              <button id="tree-search-next" class="tree-search-step" type="button" aria-label="다음 검색 결과" title="다음 검색 결과" disabled>
+                <span class="material-symbols-outlined">keyboard_arrow_down</span>
+              </button>
+            </div>
+          </div>
+        </div>
         <nav id="tree-root" class="tree-root" aria-label="문서 탐색기" tabindex="0"></nav>
         <div class="sidebar-footer">
           <div class="status-online">

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -123,8 +123,10 @@ test.describe("pathBase 정식 지원", () => {
       await page.goto(`${server.baseUrl}/blog/BC-VO-00/`);
       await expect(page.locator("#viewer-title")).toHaveText("About");
 
-      const setupRow = page.locator('.tree-file-row[data-route="/BC-VO-02/"]').first();
-      await expect(setupRow).toHaveAttribute("href", "/blog/BC-VO-02/");
+      const setupRow = page
+        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+        .first();
+      await expect(setupRow).toBeVisible();
       await setupRow.click();
 
       await expect(page).toHaveURL(/\/blog\/BC-VO-02\/$/);

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -115,7 +115,16 @@ test.describe("pathBase 정식 지원", () => {
       "utf8",
     );
 
-    const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+    const build = runCli(workDir, [
+      cliPath,
+      "build",
+      "--vault",
+      vaultPath,
+      "--out",
+      outDir,
+      "--new-within-days",
+      "9999",
+    ]);
     expect(build.status, build.output).toBe(0);
 
     const server = await startStaticServer(outDir, pathBase);
@@ -127,6 +136,10 @@ test.describe("pathBase 정식 지원", () => {
         .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
         .first();
       await expect(setupRow).toBeVisible();
+      await expect(setupRow).toContainText("NEW");
+      await setupRow.click({ button: "right" });
+      await expect(page.locator("#tree-root .tree-context-link").first()).toHaveAttribute("href", "/blog/BC-VO-02/");
+      await page.keyboard.press("Escape");
       await setupRow.click();
 
       await expect(page).toHaveURL(/\/blog\/BC-VO-02\/$/);

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -10,12 +10,22 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     await page.goto("/BC-VO-02/");
     await waitForAppReady(page);
     await expect(page.locator("#tree-root")).toBeVisible();
+    await expect(
+      page
+        .locator(
+          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="Recent/BC-VO-02 Setup Guide.md"]',
+        )
+        .first(),
+    ).toBeVisible();
 
     const navNextTitle = page.locator("#viewer-nav .nav-link-next .nav-link-title");
     await expect(navNextTitle).toContainText("Unsafe");
     await expect(navNextTitle.locator("img")).toHaveCount(0);
 
-    const treeXssRow = page.locator('.tree-file-row[data-route="/BC-XSS-01/"]').first();
+    const treeXssRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"]')
+      .filter({ hasText: "Unsafe" })
+      .first();
     await expect(treeXssRow).toBeVisible();
     await expect(treeXssRow.locator("img")).toHaveCount(0);
 

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -1,0 +1,165 @@
+import { expect, test } from "@playwright/test";
+import { buildTreesAdapterInput, formatTreesFileBasename } from "../../src/runtime/tree-adapter.js";
+
+test.describe("Trees sidebar adapter", () => {
+  test("EIAM tree nodes become canonical Trees paths with doc route lookup maps", () => {
+    const docs = [
+      {
+        id: "doc-a",
+        prefix: "BC-VO-02",
+        route: "/BC-VO-02/",
+        title: "Setup Guide",
+        branch: null,
+      },
+      {
+        id: "doc-b",
+        prefix: "BC-XSS-01",
+        route: "/BC-XSS-01/",
+        title: "Unsafe <img src=x onerror=alert(1)>",
+        branch: null,
+      },
+    ];
+    const tree = [
+      {
+        type: "folder",
+        name: "PINNED",
+        path: "__virtual__/pinned/category/engineering",
+        virtual: true,
+        children: [
+          {
+            type: "file",
+            id: "doc-a",
+            name: "setup-guide.md",
+            prefix: "BC-VO-02",
+            route: "/BC-VO-02/",
+            title: "Setup Guide",
+            isNew: true,
+            branch: null,
+          },
+        ],
+      },
+      {
+        type: "folder",
+        name: "Recent",
+        path: "__virtual__/recent",
+        virtual: true,
+        children: [
+          {
+            type: "file",
+            id: "doc-a",
+            name: "setup-guide.md",
+            prefix: "BC-VO-02",
+            route: "/BC-VO-02/",
+            title: "Setup Guide",
+            isNew: true,
+            branch: null,
+          },
+          {
+            type: "file",
+            id: "doc-b",
+            name: "unsafe.md",
+            prefix: "BC-XSS-01",
+            route: "/BC-XSS-01/",
+            title: "Unsafe <img src=x onerror=alert(1)>",
+            isNew: false,
+            branch: null,
+          },
+        ],
+      },
+      {
+        type: "folder",
+        name: "engineering",
+        path: "engineering",
+        children: [
+          {
+            type: "folder",
+            name: "guides",
+            path: "engineering/guides",
+            children: [
+              {
+                type: "file",
+                id: "doc-a",
+                name: "setup-guide.md",
+                prefix: "BC-VO-02",
+                route: "/BC-VO-02/",
+                title: "Setup Guide",
+                isNew: true,
+                branch: null,
+              },
+            ],
+          },
+        ],
+      },
+    ];
+
+    const adapter = buildTreesAdapterInput(tree, docs);
+
+    expect(adapter.paths).toEqual([
+      "PINNED/",
+      "PINNED/BC-VO-02 Setup Guide.md",
+      "Recent/",
+      "Recent/BC-VO-02 Setup Guide.md",
+      "Recent/BC-XSS-01 Unsafe <img src=x onerror=alert(1)>.md",
+      "engineering/",
+      "engineering/guides/",
+      "engineering/guides/BC-VO-02 Setup Guide.md",
+    ]);
+    expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide.md")).toBe("doc-a");
+    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide.md")).toBe("/BC-VO-02/");
+    expect(adapter.docIdToTreePaths.get("doc-a")).toEqual([
+      "PINNED/BC-VO-02 Setup Guide.md",
+      "Recent/BC-VO-02 Setup Guide.md",
+      "engineering/guides/BC-VO-02 Setup Guide.md",
+    ]);
+    expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide.md");
+  });
+
+  test("file basenames use prefix plus title and avoid path separator leaks", () => {
+    expect(
+      formatTreesFileBasename(
+        {
+          name: "fallback.md",
+          prefix: "DOC / 01",
+          title: "Setup\\Install",
+        },
+        null,
+      ),
+    ).toBe("DOC - 01 Setup - Install.md");
+  });
+
+  test("duplicate canonical paths receive stable suffixes without changing route lookup", () => {
+    const tree = [
+      {
+        type: "folder",
+        name: "Docs",
+        path: "docs",
+        children: [
+          {
+            type: "file",
+            id: "doc-a",
+            name: "same.md",
+            route: "/DOC-A/",
+            title: "Same",
+            isNew: false,
+            branch: null,
+          },
+          {
+            type: "file",
+            id: "doc-b",
+            name: "same.md",
+            route: "/DOC-B/",
+            title: "Same",
+            isNew: false,
+            branch: null,
+          },
+        ],
+      },
+    ];
+
+    const adapter = buildTreesAdapterInput(tree, []);
+
+    expect(adapter.paths).toEqual(["Docs/", "Docs/Same.md", "Docs/Same (2).md"]);
+    expect(adapter.treePathToRoute.get("Docs/Same.md")).toBe("/DOC-A/");
+    expect(adapter.treePathToRoute.get("Docs/Same (2).md")).toBe("/DOC-B/");
+  });
+});

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -1,0 +1,47 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+test.describe("Trees sidebar search", () => {
+  test("검색 결과를 필터링하고 clear 후 일반 트리로 복귀한다", async ({ page }) => {
+    await page.goto("/");
+    await waitForAppReady(page);
+
+    const searchInput = page.locator("#tree-search-input");
+    const searchCount = page.locator("#tree-search-count");
+    const searchClear = page.locator("#tree-search-clear");
+    const searchNext = page.locator("#tree-search-next");
+    const setupRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+      .first();
+
+    await expect(searchInput).toBeVisible();
+    await expect(setupRow).toBeVisible();
+
+    await searchInput.fill("Unsafe");
+
+    await expect(searchCount).toHaveText(/[1-9]\d*개 일치/);
+    await expect(searchClear).toBeVisible();
+    await expect(searchNext).toBeEnabled();
+    await expect(setupRow).toBeHidden();
+
+    const unsafeRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"]')
+      .filter({ hasText: "Unsafe" })
+      .first();
+    await expect(unsafeRow).toBeVisible();
+
+    await searchNext.click();
+    await expect(
+      page.locator('#tree-root [data-type="item"][data-item-type="file"][data-item-focused="true"]').first(),
+    ).toContainText("Unsafe");
+
+    await unsafeRow.click();
+    await expect(page).toHaveURL(/\/BC-XSS-01\/$/);
+    await expect(page.locator("#viewer-title")).toContainText("Unsafe");
+
+    await searchClear.click();
+    await expect(searchInput).toHaveValue("");
+    await expect(searchCount).toHaveText("");
+    await expect(setupRow).toBeVisible();
+  });
+});


### PR DESCRIPTION
## Summary
- replace the custom sidebar tree runtime with the vanilla @pierre/trees FileTree
- bundle the browser runtime so npm dependencies are included in hashed app assets
- add EIAM adapter mappings from manifest tree/doc routes to canonical Trees paths
- wire route selection, active sync, branch resets, NEW decorations, pathBase links, and sidebar search
- update e2e coverage and README/README.ko documentation

## Sub PRs
- #3 Foundation: bundle runtime and pin Trees
- #4 Adapter: map EIAM tree to Trees paths
- #5 Runtime Integration: mount Trees sidebar
- #6 UX: add Trees sidebar search
- #7 Docs: document Trees sidebar verification

## Verification
- bun install
- bun run build -- --vault ./test-vault --out ./dist
- PLAYWRIGHT_PORT=4189 bun run test:e2e → 28 passed, Mermaid mock case timed out
- PLAYWRIGHT_PORT=4190 bun run test:e2e -- tests/e2e/mermaid-runtime.spec.ts -g "로컬 mock 스크립트로 Mermaid 다이어그램을 렌더링한다" → 1 passed
- bun run lint:md:publish -- --vault ./test-vault --out-dir ./reports
- Sub PR GitHub quality checks passed on #3, #4, #5, #6, #7

Closes #2