### PR TITLE
Sub PR 1: Remove md extension from tree labels

### DIFF
--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -58,7 +58,7 @@ export function formatTreesFileBasename(node, doc) {
   const rawTitle = typeof node?.title === "string" && node.title.trim() ? node.title : doc?.title;
   const title = normalizeTreeSegment(rawTitle, normalizeTreeSegment(fallbackTitle, "Untitled"));
   const prefix = normalizeTreeSegment(node?.prefix ?? doc?.prefix ?? "", "");
-  return `${prefix ? `${prefix} ` : ""}${title}${FILE_EXTENSION}`;
+  return `${prefix ? `${prefix} ` : ""}${title}`;
 }
 
 export function buildTreesAdapterInput(treeNodes, docs = []) {

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -133,7 +133,7 @@ test.describe("pathBase 정식 지원", () => {
       await expect(page.locator("#viewer-title")).toHaveText("About");
 
       const setupRow = page
-        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')
         .first();
       await expect(setupRow).toBeVisible();
       await expect(setupRow).toContainText("NEW");

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -13,7 +13,7 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     await expect(
       page
         .locator(
-          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="Recent/BC-VO-02 Setup Guide.md"]',
+          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="Recent/BC-VO-02 Setup Guide"]',
         )
         .first(),
     ).toBeVisible();

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -96,22 +96,22 @@ test.describe("Trees sidebar adapter", () => {
 
     expect(adapter.paths).toEqual([
       "PINNED/",
-      "PINNED/BC-VO-02 Setup Guide.md",
+      "PINNED/BC-VO-02 Setup Guide",
       "Recent/",
-      "Recent/BC-VO-02 Setup Guide.md",
-      "Recent/BC-XSS-01 Unsafe <img src=x onerror=alert(1)>.md",
+      "Recent/BC-VO-02 Setup Guide",
+      "Recent/BC-XSS-01 Unsafe <img src=x onerror=alert(1)>",
       "engineering/",
       "engineering/guides/",
-      "engineering/guides/BC-VO-02 Setup Guide.md",
+      "engineering/guides/BC-VO-02 Setup Guide",
     ]);
-    expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide.md")).toBe("doc-a");
-    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide.md")).toBe("/BC-VO-02/");
+    expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide")).toBe("doc-a");
+    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide")).toBe("/BC-VO-02/");
     expect(adapter.docIdToTreePaths.get("doc-a")).toEqual([
-      "PINNED/BC-VO-02 Setup Guide.md",
-      "Recent/BC-VO-02 Setup Guide.md",
-      "engineering/guides/BC-VO-02 Setup Guide.md",
+      "PINNED/BC-VO-02 Setup Guide",
+      "Recent/BC-VO-02 Setup Guide",
+      "engineering/guides/BC-VO-02 Setup Guide",
     ]);
-    expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide.md");
+    expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide");
   });
 
   test("file basenames use prefix plus title and avoid path separator leaks", () => {
@@ -124,7 +124,7 @@ test.describe("Trees sidebar adapter", () => {
         },
         null,
       ),
-    ).toBe("DOC - 01 Setup - Install.md");
+    ).toBe("DOC - 01 Setup - Install");
   });
 
   test("duplicate canonical paths receive stable suffixes without changing route lookup", () => {
@@ -158,8 +158,8 @@ test.describe("Trees sidebar adapter", () => {
 
     const adapter = buildTreesAdapterInput(tree, []);
 
-    expect(adapter.paths).toEqual(["Docs/", "Docs/Same.md", "Docs/Same (2).md"]);
-    expect(adapter.treePathToRoute.get("Docs/Same.md")).toBe("/DOC-A/");
-    expect(adapter.treePathToRoute.get("Docs/Same (2).md")).toBe("/DOC-B/");
+    expect(adapter.paths).toEqual(["Docs/", "Docs/Same", "Docs/Same (2)"]);
+    expect(adapter.treePathToRoute.get("Docs/Same")).toBe("/DOC-A/");
+    expect(adapter.treePathToRoute.get("Docs/Same (2)")).toBe("/DOC-B/");
   });
 });

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -11,7 +11,7 @@ test.describe("Trees sidebar search", () => {
     const searchClear = page.locator("#tree-search-clear");
     const searchNext = page.locator("#tree-search-next");
     const setupRow = page
-      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')
       .first();
 
     await expect(searchInput).toBeVisible();


### PR DESCRIPTION
## Summary
- Remove visible .md suffixes from Trees file basenames while keeping docId and route lookup maps unchanged.
- Update adapter expectations and existing e2e selectors to use extensionless tree paths.

## Issue #9 Scope
Sub PR 1: Adapter label cleanup

## DnD
- Displayed Trees file rows use prefix/title labels without a visible .md extension.
- Duplicate display paths still receive stable suffixes.
- Tree click/navigation, active selection, pathBase selectors, search, and XSS guard coverage still exercise the renamed tree paths.

## Verification
- bun install
- bun run test:e2e tests/e2e/tree-adapter.spec.ts tests/e2e/tree-search.spec.ts tests/e2e/path-base-routing.spec.ts tests/e2e/runtime-xss-guard.spec.ts