### PR TITLE
Sub PR 3: Add responsive sidebar coverage and docs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -285,14 +285,14 @@ markdown: {
 
 - 사이드바 파일 트리는 vanilla `@pierre/trees` 런타임으로 렌더링됩니다.
 - `Recent` 가상 폴더와 선택적 pinned 가상 폴더를 유지합니다.
-- 파일 행은 `prefix`와 제목 기준으로 표시되고, `ui.newWithinDays` 기준에 맞으면 NEW 배지를 보여줍니다.
+- 파일 행은 보이는 `.md` 확장자 없이 `prefix`와 제목 기준으로 표시되고, `ui.newWithinDays` 기준에 맞으면 NEW 배지를 보여줍니다.
 - 브랜치 pill로 문서 목록을 전환합니다.
 - 활성 문서 선택 상태는 트리, 브라우저 히스토리, 문서 뷰어 사이에서 동기화됩니다.
 - 트리 검색 입력은 Trees 검색 모델에 연결되며, clear와 이전/다음 결과 이동을 지원합니다.
 - 직접 URL 진입, 이전/다음 문서 링크, 백링크, 모바일 사이드바 포커스 트랩을 지원합니다.
 - 테마 모드(`light`, `dark`, `system`)와 데스크톱 사이드바 폭을 저장합니다.
 
-사이드바는 표시용 EIAM canonical tree path를 사용하지만, 공개 라우트와 문서 식별자는 계속 `prefix` 기반 route/docId를 기준으로 합니다. rename, drag/drop, git status 표시, multi-select bulk action은 의도적으로 활성화하지 않습니다.
+사이드바는 표시용 EIAM canonical tree path를 사용하지만, 공개 라우트와 문서 식별자는 계속 `prefix` 기반 route/docId를 기준으로 합니다. 보이는 파일 label에서는 `.md`를 생략하지만 route/docId lookup 동작은 바뀌지 않습니다. rename, drag/drop, git status 표시, multi-select bulk action은 의도적으로 활성화하지 않습니다.
 
 ## bunx 실행 (선택)
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Main behaviors:
 - searchable sidebar tree rendered by the vanilla `@pierre/trees` runtime
 - `Recent` virtual folder
 - optional pinned virtual folder
-- prefix/title file labels with NEW badges when `ui.newWithinDays` matches
+- prefix/title file labels without visible `.md` extensions, plus NEW badges when `ui.newWithinDays` matches
 - branch pills in the sidebar
 - active document selection synced between the tree, browser history, and document viewer
 - model-level tree search with clear and previous/next match controls
@@ -452,7 +452,7 @@ Main behaviors:
 - theme mode persistence: `light`, `dark`, `system`
 - sidebar width persistence on desktop
 
-The sidebar uses EIAM canonical tree paths for display and keeps public routes sourced from document `prefix` routes. Rename, drag/drop, git status, and multi-select workflows are intentionally not enabled.
+The sidebar uses EIAM canonical tree paths for display and keeps public routes sourced from document `prefix` routes. Visible file labels omit `.md`, but route and docId lookup behavior remains unchanged. Rename, drag/drop, git status, and multi-select workflows are intentionally not enabled.
 
 Branch behavior:
 
@@ -556,6 +556,7 @@ E2E coverage in `tests/e2e/` includes:
 - subpath routing with `seo.pathBase`
 - prefix routing, backlinks, and branch switching
 - searchable Trees sidebar behavior
+- responsive sidebar layout bounds with long Korean/English labels
 - Mermaid runtime behavior
 - mobile sidebar accessibility and focus trap behavior
 - runtime XSS/path-base guardrails

--- a/tests/e2e/responsive-sidebar-layout.spec.ts
+++ b/tests/e2e/responsive-sidebar-layout.spec.ts
@@ -1,0 +1,256 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+interface Rect {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}
+
+interface CliResult {
+  status: number | null;
+  output: string;
+}
+
+const VIEWPORTS = [
+  { width: 320, height: 568 },
+  { width: 390, height: 844 },
+  { width: 820, height: 1180 },
+  { width: 1024, height: 600 },
+] as const;
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function runCli(cwd: string, args: string[]): CliResult {
+  const result = spawnSync("bun", args, { cwd, encoding: "utf8" });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+function contentType(filePath: string): string {
+  if (filePath.endsWith(".html")) return "text/html; charset=utf-8";
+  if (filePath.endsWith(".json")) return "application/json; charset=utf-8";
+  if (filePath.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (filePath.endsWith(".css")) return "text/css; charset=utf-8";
+  return "application/octet-stream";
+}
+
+function toFilePath(outDir: string, pathname: string): string {
+  const clean = pathname.replace(/^\/+/, "");
+  if (!clean) {
+    return path.join(outDir, "index.html");
+  }
+
+  const direct = path.join(outDir, clean);
+  if (fs.existsSync(direct) && fs.statSync(direct).isFile()) {
+    return direct;
+  }
+
+  const withIndex = path.join(outDir, clean, "index.html");
+  if (fs.existsSync(withIndex)) {
+    return withIndex;
+  }
+
+  return path.join(outDir, "404.html");
+}
+
+async function startStaticServer(outDir: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    const filePath = toFilePath(outDir, requestUrl.pathname);
+    if (!fs.existsSync(filePath)) {
+      res.statusCode = 404;
+      res.end("Not Found");
+      return;
+    }
+
+    res.statusCode = filePath.endsWith("404.html") ? 404 : 200;
+    res.setHeader("Content-Type", contentType(filePath));
+    res.end(fs.readFileSync(filePath));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function writeResponsiveVault(vaultDir: string): void {
+  const titles = [
+    "초장문 모바일 사이드바 레이아웃 검증 문서와 영어 Title For Narrow Rows",
+    "한국어와 English Mixed Title That Stays Readable On Small Screens",
+    "Very Long English Knowledge Base Article Title With Several Useful Words",
+    "중복 제목 확인을 위한 초장문 모바일 사이드바 레이아웃 검증 문서",
+  ];
+
+  for (let index = 0; index < 24; index += 1) {
+    const title = titles[index % titles.length];
+    const prefix = `RS-${String(index + 1).padStart(2, "0")}`;
+    writeText(
+      path.join(vaultDir, "notes", `responsive-long-title-${index + 1}.md`),
+      `---
+publish: true
+prefix: ${prefix}
+category_path: responsive-section-${String(index + 1).padStart(2, "0")}
+title: "${title} ${index + 1}"
+date: "2026-01-${String((index % 9) + 1).padStart(2, "0")}"
+---
+
+# ${title}
+
+Responsive sidebar fixture content.
+`,
+    );
+  }
+}
+
+async function openSidebar(page: Page, baseUrl: string): Promise<void> {
+  await page.goto(`${baseUrl}/RS-01/`);
+  await waitForAppReady(page);
+  const toggle = page.getByRole("button", { name: "탐색기 열기" });
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+  await expect(page.locator("#sidebar-panel")).toHaveAttribute("role", "dialog");
+}
+
+async function getRect(page: Page, selector: string): Promise<Rect> {
+  return page.locator(selector).evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      bottom: rect.bottom,
+      height: rect.height,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      width: rect.width,
+    };
+  });
+}
+
+test.describe("responsive Trees sidebar layout", () => {
+  const repoRoot = process.cwd();
+  const cliPath = path.join(repoRoot, "src/cli.ts");
+  let workDir = "";
+  let server: { baseUrl: string; close: () => Promise<void> } | null = null;
+
+  test.beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-responsive-sidebar-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    writeResponsiveVault(vaultDir);
+
+    const build = runCli(workDir, [
+      cliPath,
+      "build",
+      "--vault",
+      vaultDir,
+      "--out",
+      outDir,
+      "--new-within-days",
+      "9999",
+    ]);
+    expect(build.status, build.output).toBe(0);
+    server = await startStaticServer(outDir);
+  });
+
+  test.afterAll(async () => {
+    await server?.close();
+    if (workDir) {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  for (const viewport of VIEWPORTS) {
+    test(`${viewport.width}x${viewport.height} keeps sidebar sections ordered and contained`, async ({ page }) => {
+      expect(server).not.toBeNull();
+      await page.setViewportSize(viewport);
+      await openSidebar(page, server!.baseUrl);
+
+      const header = await getRect(page, ".sidebar-header");
+      const search = await getRect(page, ".sidebar-search");
+      const tree = await getRect(page, "#tree-root");
+      const footer = await getRect(page, ".sidebar-footer");
+      const sidebar = await getRect(page, "#sidebar-panel");
+
+      expect(header.top).toBeGreaterThanOrEqual(sidebar.top);
+      expect(search.top).toBeGreaterThanOrEqual(header.bottom - 1);
+      expect(tree.top).toBeGreaterThanOrEqual(search.bottom - 1);
+      expect(footer.top).toBeGreaterThanOrEqual(tree.bottom - 1);
+      expect(footer.bottom).toBeLessThanOrEqual(Math.min(sidebar.bottom, viewport.height) + 1);
+      expect(tree.height).toBeGreaterThan(80);
+      expect(footer.top).toBeGreaterThanOrEqual(tree.top + 80);
+
+      const rowState = await page.locator("#tree-root").evaluate(() => {
+        const host = document.querySelector("#tree-root file-tree-container");
+        const root = host?.shadowRoot;
+        const rows = Array.from(root?.querySelectorAll('[data-type="item"][data-item-type="file"]') ?? []);
+        const firstRow = rows[0] as HTMLElement | undefined;
+        const content = firstRow?.querySelector('[data-item-section="content"]') as HTMLElement | null;
+        const decoration = firstRow?.querySelector('[data-item-section="decoration"]') as HTMLElement | null;
+        const rowRect = firstRow?.getBoundingClientRect();
+        const contentRect = content?.getBoundingClientRect();
+        const decorationRect = decoration?.getBoundingClientRect();
+        return {
+          path: firstRow?.dataset.itemPath ?? "",
+          text: firstRow?.textContent ?? "",
+          rowWithinTree:
+            Boolean(rowRect) &&
+            rowRect!.left >= host!.getBoundingClientRect().left - 1 &&
+            rowRect!.right <= host!.getBoundingClientRect().right + 1,
+          lanesDoNotOverlap:
+            Boolean(contentRect && decorationRect) && contentRect!.right <= decorationRect!.left + 1,
+        };
+      });
+
+      expect(rowState.path).not.toContain(".md");
+      expect(rowState.text).not.toContain(".md");
+      expect(rowState.rowWithinTree).toBe(true);
+      expect(rowState.lanesDoNotOverlap).toBe(true);
+
+      const scrollState = await page.locator("#tree-root").evaluate((treeRoot) => {
+        const host = treeRoot.querySelector("file-tree-container");
+        const scroller = host?.shadowRoot?.querySelector('[data-file-tree-virtualized-scroll="true"]') as HTMLElement | null;
+        const beforeWindowY = window.scrollY;
+        if (scroller) {
+          scroller.scrollTop = 240;
+        }
+        return {
+          beforeWindowY,
+          scrollTop: scroller?.scrollTop ?? 0,
+          windowY: window.scrollY,
+        };
+      });
+      expect(scrollState.scrollTop).toBeGreaterThan(0);
+      expect(scrollState.windowY).toBe(scrollState.beforeWindowY);
+
+      const searchInput = page.locator("#tree-search-input");
+      await searchInput.fill("초장문");
+      await expect(page.locator("#tree-search-count")).toHaveText(/[1-9]\d*개 일치/);
+      await page.locator("#tree-search-clear").click();
+      await expect(searchInput).toHaveValue("");
+    });
+  }
+});


### PR DESCRIPTION
## Summary
- Add responsive sidebar layout e2e coverage for 320x568, 390x844, 820x1180, and 1024x600.
- Exercise long Korean/English labels, extensionless tree paths, footer/tree bounds, tree-local scrolling, and search clear behavior.
- Document extensionless visible sidebar labels in README and README.ko.

## Issue #9 Scope
Sub PR 3: Responsive e2e and docs

## DnD
- Responsive e2e covers required mobile/tablet viewports.
- Tests verify footer visibility, no tree/footer overlap, stable section ordering, tree row containment, tree-local scrolling, extensionless labels, and search clear behavior.
- User-facing README/README.ko label behavior is updated.
- Full verification was run.

## Verification
- bun run build -- --vault ./test-vault --out ./dist: pass
- bun run test:e2e tests/e2e/responsive-sidebar-layout.spec.ts: 4 passed
- bun run test:e2e: first run had one existing Mermaid mobile timeout; immediate single-test rerun passed in 2.2s; second full run passed, 33 passed
- bun run lint:md:publish -- --vault ./test-vault --out-dir ./reports: exit 0, targets=5 issues=18 report generated