### PR TITLE
Polish responsive Trees sidebar layout

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -285,14 +285,14 @@ markdown: {
 
 - 사이드바 파일 트리는 vanilla `@pierre/trees` 런타임으로 렌더링됩니다.
 - `Recent` 가상 폴더와 선택적 pinned 가상 폴더를 유지합니다.
-- 파일 행은 `prefix`와 제목 기준으로 표시되고, `ui.newWithinDays` 기준에 맞으면 NEW 배지를 보여줍니다.
+- 파일 행은 보이는 `.md` 확장자 없이 `prefix`와 제목 기준으로 표시되고, `ui.newWithinDays` 기준에 맞으면 NEW 배지를 보여줍니다.
 - 브랜치 pill로 문서 목록을 전환합니다.
 - 활성 문서 선택 상태는 트리, 브라우저 히스토리, 문서 뷰어 사이에서 동기화됩니다.
 - 트리 검색 입력은 Trees 검색 모델에 연결되며, clear와 이전/다음 결과 이동을 지원합니다.
 - 직접 URL 진입, 이전/다음 문서 링크, 백링크, 모바일 사이드바 포커스 트랩을 지원합니다.
 - 테마 모드(`light`, `dark`, `system`)와 데스크톱 사이드바 폭을 저장합니다.
 
-사이드바는 표시용 EIAM canonical tree path를 사용하지만, 공개 라우트와 문서 식별자는 계속 `prefix` 기반 route/docId를 기준으로 합니다. rename, drag/drop, git status 표시, multi-select bulk action은 의도적으로 활성화하지 않습니다.
+사이드바는 표시용 EIAM canonical tree path를 사용하지만, 공개 라우트와 문서 식별자는 계속 `prefix` 기반 route/docId를 기준으로 합니다. 보이는 파일 label에서는 `.md`를 생략하지만 route/docId lookup 동작은 바뀌지 않습니다. rename, drag/drop, git status 표시, multi-select bulk action은 의도적으로 활성화하지 않습니다.
 
 ## bunx 실행 (선택)
 

--- a/README.md
+++ b/README.md
@@ -441,7 +441,7 @@ Main behaviors:
 - searchable sidebar tree rendered by the vanilla `@pierre/trees` runtime
 - `Recent` virtual folder
 - optional pinned virtual folder
-- prefix/title file labels with NEW badges when `ui.newWithinDays` matches
+- prefix/title file labels without visible `.md` extensions, plus NEW badges when `ui.newWithinDays` matches
 - branch pills in the sidebar
 - active document selection synced between the tree, browser history, and document viewer
 - model-level tree search with clear and previous/next match controls
@@ -452,7 +452,7 @@ Main behaviors:
 - theme mode persistence: `light`, `dark`, `system`
 - sidebar width persistence on desktop
 
-The sidebar uses EIAM canonical tree paths for display and keeps public routes sourced from document `prefix` routes. Rename, drag/drop, git status, and multi-select workflows are intentionally not enabled.
+The sidebar uses EIAM canonical tree paths for display and keeps public routes sourced from document `prefix` routes. Visible file labels omit `.md`, but route and docId lookup behavior remains unchanged. Rename, drag/drop, git status, and multi-select workflows are intentionally not enabled.
 
 Branch behavior:
 
@@ -556,6 +556,7 @@ E2E coverage in `tests/e2e/` includes:
 - subpath routing with `seo.pathBase`
 - prefix routing, backlinks, and branch switching
 - searchable Trees sidebar behavior
+- responsive sidebar layout bounds with long Korean/English labels
 - Mermaid runtime behavior
 - mobile sidebar accessibility and focus trap behavior
 - runtime XSS/path-base guardrails

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -242,6 +242,8 @@ a:hover {
     var(--splitter-width)
     minmax(var(--desktop-viewer-min), 1fr);
   height: 100vh;
+  height: 100dvh;
+  min-height: 0;
   width: 100vw;
 }
 
@@ -299,6 +301,7 @@ a:hover {
   border-right: 0;
   display: flex;
   flex-direction: column;
+  min-height: 0;
   overflow: hidden;
 }
 
@@ -316,6 +319,7 @@ a:hover {
 
 .sidebar-header {
   position: relative;
+  flex: 0 0 auto;
   padding: 24px 20px;
   border-bottom: 1px solid var(--latte-surface0);
 }
@@ -436,6 +440,7 @@ a:hover {
 
 /* Tree search */
 .sidebar-search {
+  flex: 0 0 auto;
   padding: 14px 16px 10px;
   border-bottom: 1px solid var(--latte-surface0);
   background: color-mix(in srgb, var(--latte-mantle) 92%, var(--latte-base));
@@ -538,6 +543,9 @@ a:hover {
 
 .tree-search-count {
   min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--latte-overlay0);
   font-size: 0.75rem;
   font-weight: 650;
@@ -550,7 +558,8 @@ a:hover {
 
 /* Tree */
 .tree-root {
-  flex: 1;
+  flex: 1 1 auto;
+  min-height: 0;
   overflow: hidden;
   padding: 12px 12px 24px;
 }
@@ -591,12 +600,15 @@ a:hover {
 /* Sidebar footer */
 .sidebar-footer {
   position: relative;
+  flex: 0 0 auto;
   padding: 12px 16px;
   background: var(--latte-crust);
   border-top: 1px solid var(--latte-surface0);
   display: flex;
   justify-content: space-between;
   align-items: center;
+  gap: 12px;
+  min-height: 57px;
   font-size: 0.75rem;
   color: var(--latte-subtext1);
 }
@@ -605,6 +617,7 @@ a:hover {
   display: flex;
   align-items: center;
   gap: 6px;
+  min-width: 0;
 }
 
 .status-dot {
@@ -628,12 +641,18 @@ a:hover {
 
 .status-encoding {
   font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  flex: 0 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
   color: var(--latte-subtext1);
 }
 
 .sidebar-footer-actions {
   display: flex;
   align-items: center;
+  flex: 0 0 auto;
   gap: 8px;
 }
 
@@ -1514,6 +1533,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
     top: 0;
     left: 0;
     bottom: 0;
+    height: 100vh;
+    height: 100dvh;
+    max-height: 100dvh;
     width: 70vw;
     min-width: 300px;
     max-width: 560px;
@@ -1540,6 +1562,22 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
   .sidebar-close {
     display: inline-flex;
+  }
+
+  .sidebar-header {
+    padding: 18px 18px 16px;
+  }
+
+  .sidebar-title {
+    padding-right: 42px;
+  }
+
+  .sidebar-search {
+    padding: 12px 14px 9px;
+  }
+
+  .tree-root {
+    padding: 10px 10px 18px;
   }
 
   .viewer-container {
@@ -1577,6 +1615,41 @@ body.mobile-toggle-left .mobile-menu-toggle {
     max-width: none;
   }
 
+  .sidebar-header {
+    padding: 16px 16px 14px;
+  }
+
+  .sidebar-branch {
+    row-gap: 8px;
+    margin-top: 10px;
+  }
+
+  .branch-pills {
+    gap: 6px;
+  }
+
+  .branch-pill {
+    padding: 6px 10px;
+  }
+
+  .sidebar-search {
+    padding: 10px 12px 8px;
+  }
+
+  .sidebar-search-actions {
+    min-height: 28px;
+    margin-top: 5px;
+  }
+
+  .tree-root {
+    padding: 8px 8px 14px;
+  }
+
+  .sidebar-footer {
+    min-height: 52px;
+    padding: 10px 12px;
+  }
+
   .viewer-container {
     padding: 20px 18px 104px;
   }
@@ -1603,5 +1676,58 @@ body.mobile-toggle-left .mobile-menu-toggle {
     display: block;
     overflow-x: auto;
     white-space: nowrap;
+  }
+}
+
+@media (max-width: 1024px) and (max-height: 640px) {
+  .sidebar-header {
+    padding-top: 12px;
+    padding-bottom: 10px;
+  }
+
+  .sidebar-title {
+    font-size: 1rem;
+  }
+
+  .sidebar-branch {
+    row-gap: 6px;
+    margin-top: 8px;
+  }
+
+  .branch-badge {
+    padding: 5px 9px;
+  }
+
+  .branch-pill {
+    padding: 5px 9px;
+  }
+
+  .branch-info {
+    font-size: 0.7rem;
+  }
+
+  .sidebar-search {
+    padding-top: 8px;
+    padding-bottom: 6px;
+  }
+
+  .sidebar-search-box {
+    min-height: 36px;
+  }
+
+  .tree-search-clear,
+  .tree-search-step {
+    width: 28px;
+    height: 28px;
+  }
+
+  .tree-root {
+    padding-bottom: 10px;
+  }
+
+  .sidebar-footer {
+    min-height: 48px;
+    padding-top: 8px;
+    padding-bottom: 8px;
   }
 }

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -44,6 +44,17 @@ const TREE_UNSAFE_CSS = `
   font-weight: 800;
   line-height: 1;
 }
+
+[data-type='item'][data-item-type='file'] [data-item-section='content'] {
+  flex: 1 1 auto;
+  min-width: 0;
+}
+
+[data-type='item'][data-item-type='file'] [data-item-section='decoration'] {
+  flex: 0 0 auto;
+  margin-left: 6px;
+  min-width: max-content;
+}
 `;
 const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
 const MERMAID_DEFAULT_THEME = "default";

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -58,7 +58,7 @@ export function formatTreesFileBasename(node, doc) {
   const rawTitle = typeof node?.title === "string" && node.title.trim() ? node.title : doc?.title;
   const title = normalizeTreeSegment(rawTitle, normalizeTreeSegment(fallbackTitle, "Untitled"));
   const prefix = normalizeTreeSegment(node?.prefix ?? doc?.prefix ?? "", "");
-  return `${prefix ? `${prefix} ` : ""}${title}${FILE_EXTENSION}`;
+  return `${prefix ? `${prefix} ` : ""}${title}`;
 }
 
 export function buildTreesAdapterInput(treeNodes, docs = []) {

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -133,7 +133,7 @@ test.describe("pathBase 정식 지원", () => {
       await expect(page.locator("#viewer-title")).toHaveText("About");
 
       const setupRow = page
-        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')
         .first();
       await expect(setupRow).toBeVisible();
       await expect(setupRow).toContainText("NEW");

--- a/tests/e2e/responsive-sidebar-layout.spec.ts
+++ b/tests/e2e/responsive-sidebar-layout.spec.ts
@@ -1,0 +1,256 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { expect, type Page, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+interface Rect {
+  bottom: number;
+  height: number;
+  left: number;
+  right: number;
+  top: number;
+  width: number;
+}
+
+interface CliResult {
+  status: number | null;
+  output: string;
+}
+
+const VIEWPORTS = [
+  { width: 320, height: 568 },
+  { width: 390, height: 844 },
+  { width: 820, height: 1180 },
+  { width: 1024, height: 600 },
+] as const;
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function runCli(cwd: string, args: string[]): CliResult {
+  const result = spawnSync("bun", args, { cwd, encoding: "utf8" });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+function contentType(filePath: string): string {
+  if (filePath.endsWith(".html")) return "text/html; charset=utf-8";
+  if (filePath.endsWith(".json")) return "application/json; charset=utf-8";
+  if (filePath.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (filePath.endsWith(".css")) return "text/css; charset=utf-8";
+  return "application/octet-stream";
+}
+
+function toFilePath(outDir: string, pathname: string): string {
+  const clean = pathname.replace(/^\/+/, "");
+  if (!clean) {
+    return path.join(outDir, "index.html");
+  }
+
+  const direct = path.join(outDir, clean);
+  if (fs.existsSync(direct) && fs.statSync(direct).isFile()) {
+    return direct;
+  }
+
+  const withIndex = path.join(outDir, clean, "index.html");
+  if (fs.existsSync(withIndex)) {
+    return withIndex;
+  }
+
+  return path.join(outDir, "404.html");
+}
+
+async function startStaticServer(outDir: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    const filePath = toFilePath(outDir, requestUrl.pathname);
+    if (!fs.existsSync(filePath)) {
+      res.statusCode = 404;
+      res.end("Not Found");
+      return;
+    }
+
+    res.statusCode = filePath.endsWith("404.html") ? 404 : 200;
+    res.setHeader("Content-Type", contentType(filePath));
+    res.end(fs.readFileSync(filePath));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", () => resolve());
+  });
+
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+      }),
+  };
+}
+
+function writeResponsiveVault(vaultDir: string): void {
+  const titles = [
+    "초장문 모바일 사이드바 레이아웃 검증 문서와 영어 Title For Narrow Rows",
+    "한국어와 English Mixed Title That Stays Readable On Small Screens",
+    "Very Long English Knowledge Base Article Title With Several Useful Words",
+    "중복 제목 확인을 위한 초장문 모바일 사이드바 레이아웃 검증 문서",
+  ];
+
+  for (let index = 0; index < 24; index += 1) {
+    const title = titles[index % titles.length];
+    const prefix = `RS-${String(index + 1).padStart(2, "0")}`;
+    writeText(
+      path.join(vaultDir, "notes", `responsive-long-title-${index + 1}.md`),
+      `---
+publish: true
+prefix: ${prefix}
+category_path: responsive-section-${String(index + 1).padStart(2, "0")}
+title: "${title} ${index + 1}"
+date: "2026-01-${String((index % 9) + 1).padStart(2, "0")}"
+---
+
+# ${title}
+
+Responsive sidebar fixture content.
+`,
+    );
+  }
+}
+
+async function openSidebar(page: Page, baseUrl: string): Promise<void> {
+  await page.goto(`${baseUrl}/RS-01/`);
+  await waitForAppReady(page);
+  const toggle = page.getByRole("button", { name: "탐색기 열기" });
+  await expect(toggle).toBeVisible();
+  await toggle.click();
+  await expect(page.locator("#sidebar-panel")).toHaveAttribute("role", "dialog");
+}
+
+async function getRect(page: Page, selector: string): Promise<Rect> {
+  return page.locator(selector).evaluate((element) => {
+    const rect = element.getBoundingClientRect();
+    return {
+      bottom: rect.bottom,
+      height: rect.height,
+      left: rect.left,
+      right: rect.right,
+      top: rect.top,
+      width: rect.width,
+    };
+  });
+}
+
+test.describe("responsive Trees sidebar layout", () => {
+  const repoRoot = process.cwd();
+  const cliPath = path.join(repoRoot, "src/cli.ts");
+  let workDir = "";
+  let server: { baseUrl: string; close: () => Promise<void> } | null = null;
+
+  test.beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-responsive-sidebar-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    writeResponsiveVault(vaultDir);
+
+    const build = runCli(workDir, [
+      cliPath,
+      "build",
+      "--vault",
+      vaultDir,
+      "--out",
+      outDir,
+      "--new-within-days",
+      "9999",
+    ]);
+    expect(build.status, build.output).toBe(0);
+    server = await startStaticServer(outDir);
+  });
+
+  test.afterAll(async () => {
+    await server?.close();
+    if (workDir) {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  for (const viewport of VIEWPORTS) {
+    test(`${viewport.width}x${viewport.height} keeps sidebar sections ordered and contained`, async ({ page }) => {
+      expect(server).not.toBeNull();
+      await page.setViewportSize(viewport);
+      await openSidebar(page, server!.baseUrl);
+
+      const header = await getRect(page, ".sidebar-header");
+      const search = await getRect(page, ".sidebar-search");
+      const tree = await getRect(page, "#tree-root");
+      const footer = await getRect(page, ".sidebar-footer");
+      const sidebar = await getRect(page, "#sidebar-panel");
+
+      expect(header.top).toBeGreaterThanOrEqual(sidebar.top);
+      expect(search.top).toBeGreaterThanOrEqual(header.bottom - 1);
+      expect(tree.top).toBeGreaterThanOrEqual(search.bottom - 1);
+      expect(footer.top).toBeGreaterThanOrEqual(tree.bottom - 1);
+      expect(footer.bottom).toBeLessThanOrEqual(Math.min(sidebar.bottom, viewport.height) + 1);
+      expect(tree.height).toBeGreaterThan(80);
+      expect(footer.top).toBeGreaterThanOrEqual(tree.top + 80);
+
+      const rowState = await page.locator("#tree-root").evaluate(() => {
+        const host = document.querySelector("#tree-root file-tree-container");
+        const root = host?.shadowRoot;
+        const rows = Array.from(root?.querySelectorAll('[data-type="item"][data-item-type="file"]') ?? []);
+        const firstRow = rows[0] as HTMLElement | undefined;
+        const content = firstRow?.querySelector('[data-item-section="content"]') as HTMLElement | null;
+        const decoration = firstRow?.querySelector('[data-item-section="decoration"]') as HTMLElement | null;
+        const rowRect = firstRow?.getBoundingClientRect();
+        const contentRect = content?.getBoundingClientRect();
+        const decorationRect = decoration?.getBoundingClientRect();
+        return {
+          path: firstRow?.dataset.itemPath ?? "",
+          text: firstRow?.textContent ?? "",
+          rowWithinTree:
+            Boolean(rowRect) &&
+            rowRect!.left >= host!.getBoundingClientRect().left - 1 &&
+            rowRect!.right <= host!.getBoundingClientRect().right + 1,
+          lanesDoNotOverlap:
+            Boolean(contentRect && decorationRect) && contentRect!.right <= decorationRect!.left + 1,
+        };
+      });
+
+      expect(rowState.path).not.toContain(".md");
+      expect(rowState.text).not.toContain(".md");
+      expect(rowState.rowWithinTree).toBe(true);
+      expect(rowState.lanesDoNotOverlap).toBe(true);
+
+      const scrollState = await page.locator("#tree-root").evaluate((treeRoot) => {
+        const host = treeRoot.querySelector("file-tree-container");
+        const scroller = host?.shadowRoot?.querySelector('[data-file-tree-virtualized-scroll="true"]') as HTMLElement | null;
+        const beforeWindowY = window.scrollY;
+        if (scroller) {
+          scroller.scrollTop = 240;
+        }
+        return {
+          beforeWindowY,
+          scrollTop: scroller?.scrollTop ?? 0,
+          windowY: window.scrollY,
+        };
+      });
+      expect(scrollState.scrollTop).toBeGreaterThan(0);
+      expect(scrollState.windowY).toBe(scrollState.beforeWindowY);
+
+      const searchInput = page.locator("#tree-search-input");
+      await searchInput.fill("초장문");
+      await expect(page.locator("#tree-search-count")).toHaveText(/[1-9]\d*개 일치/);
+      await page.locator("#tree-search-clear").click();
+      await expect(searchInput).toHaveValue("");
+    });
+  }
+});

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -13,7 +13,7 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     await expect(
       page
         .locator(
-          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="Recent/BC-VO-02 Setup Guide.md"]',
+          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="Recent/BC-VO-02 Setup Guide"]',
         )
         .first(),
     ).toBeVisible();

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -96,22 +96,22 @@ test.describe("Trees sidebar adapter", () => {
 
     expect(adapter.paths).toEqual([
       "PINNED/",
-      "PINNED/BC-VO-02 Setup Guide.md",
+      "PINNED/BC-VO-02 Setup Guide",
       "Recent/",
-      "Recent/BC-VO-02 Setup Guide.md",
-      "Recent/BC-XSS-01 Unsafe <img src=x onerror=alert(1)>.md",
+      "Recent/BC-VO-02 Setup Guide",
+      "Recent/BC-XSS-01 Unsafe <img src=x onerror=alert(1)>",
       "engineering/",
       "engineering/guides/",
-      "engineering/guides/BC-VO-02 Setup Guide.md",
+      "engineering/guides/BC-VO-02 Setup Guide",
     ]);
-    expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide.md")).toBe("doc-a");
-    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide.md")).toBe("/BC-VO-02/");
+    expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide")).toBe("doc-a");
+    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide")).toBe("/BC-VO-02/");
     expect(adapter.docIdToTreePaths.get("doc-a")).toEqual([
-      "PINNED/BC-VO-02 Setup Guide.md",
-      "Recent/BC-VO-02 Setup Guide.md",
-      "engineering/guides/BC-VO-02 Setup Guide.md",
+      "PINNED/BC-VO-02 Setup Guide",
+      "Recent/BC-VO-02 Setup Guide",
+      "engineering/guides/BC-VO-02 Setup Guide",
     ]);
-    expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide.md");
+    expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide");
   });
 
   test("file basenames use prefix plus title and avoid path separator leaks", () => {
@@ -124,7 +124,7 @@ test.describe("Trees sidebar adapter", () => {
         },
         null,
       ),
-    ).toBe("DOC - 01 Setup - Install.md");
+    ).toBe("DOC - 01 Setup - Install");
   });
 
   test("duplicate canonical paths receive stable suffixes without changing route lookup", () => {
@@ -158,8 +158,8 @@ test.describe("Trees sidebar adapter", () => {
 
     const adapter = buildTreesAdapterInput(tree, []);
 
-    expect(adapter.paths).toEqual(["Docs/", "Docs/Same.md", "Docs/Same (2).md"]);
-    expect(adapter.treePathToRoute.get("Docs/Same.md")).toBe("/DOC-A/");
-    expect(adapter.treePathToRoute.get("Docs/Same (2).md")).toBe("/DOC-B/");
+    expect(adapter.paths).toEqual(["Docs/", "Docs/Same", "Docs/Same (2)"]);
+    expect(adapter.treePathToRoute.get("Docs/Same")).toBe("/DOC-A/");
+    expect(adapter.treePathToRoute.get("Docs/Same (2)")).toBe("/DOC-B/");
   });
 });

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -11,7 +11,7 @@ test.describe("Trees sidebar search", () => {
     const searchClear = page.locator("#tree-search-clear");
     const searchNext = page.locator("#tree-search-next");
     const setupRow = page
-      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide.md"]')
+      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')
       .first();
 
     await expect(searchInput).toBeVisible();


### PR DESCRIPTION
## Summary
- Remove visible .md suffixes from Trees sidebar file labels while preserving route/docId lookup behavior.
- Harden sidebar header/search/tree/footer flex behavior for mobile and tablet layouts.
- Add responsive e2e coverage for 320x568, 390x844, 820x1180, and 1024x600 with long Korean/English labels.
- Document extensionless visible labels in README and README.ko.

## Issue
Closes #9

## Sub PRs
- #10 Sub PR 1: Remove md extension from tree labels
- #11 Sub PR 2: Harden responsive sidebar layout
- #12 Sub PR 3: Add responsive sidebar coverage and docs

## Verification
- bun install
- bun run build -- --vault ./test-vault --out ./dist: pass
- bun run test:e2e tests/e2e/tree-adapter.spec.ts tests/e2e/tree-search.spec.ts tests/e2e/path-base-routing.spec.ts tests/e2e/runtime-xss-guard.spec.ts: 6 passed
- bun run build -- --vault ./test-vault --out ./dist && bun run test:e2e tests/e2e/mobile-sidebar-focus-trap.spec.ts tests/e2e/tree-search.spec.ts: pass, 2 passed
- bun run test:e2e tests/e2e/responsive-sidebar-layout.spec.ts: 4 passed
- bun run test:e2e: one full 2-worker run passed on Sub PR 3; later mother 2-worker reruns showed existing Mermaid timeout flakes that passed immediately in single-test reruns
- bun run test:e2e -- --workers=1: 33 passed on mother
- bun run lint:md:publish -- --vault ./test-vault --out-dir ./reports: exit 0, targets=5 issues=18

## Notes
- Generated reports/test-results were not committed.
- Final PR is intentionally left unmerged.