### PR TITLE
Sub PR 1: Guard clean operations with owned outputs

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -33,7 +33,9 @@ bun run blog [build|dev|clean] [options]
 
 - `bun run build`: 정적 파일 빌드
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
-- `bun run clean`: `dist`와 `.cache` 삭제
+- `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 EIAM cache index만 삭제
+
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Notes:
 
 - Unknown CLI options fail fast.
 - Invalid numeric options fail fast.
-- `clean` removes both the output directory and `.cache`.
+- Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
+- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and EIAM's `.cache/build-index.json`, preserving unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -24,6 +24,9 @@ import {
 const CACHE_VERSION = 4;
 const CACHE_DIR_NAME = ".cache";
 const CACHE_FILE_NAME = "build-index.json";
+const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
+const OUTPUT_MARKER_FORMAT = "everything-is-a-markdown-output";
+const OUTPUT_MARKER_VERSION = 1;
 const DEFAULT_BRANCH = "dev";
 const DEFAULT_SITE_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 const DEFAULT_SITE_TITLE = "File-System Blog";
@@ -65,6 +68,126 @@ function toContentFileName(id: string): string {
 
 function toCachePath(): string {
   return path.join(process.cwd(), CACHE_DIR_NAME, CACHE_FILE_NAME);
+}
+
+function isSamePathOrAncestor(candidate: string, target: string): boolean {
+  const relative = path.relative(candidate, target);
+  return (
+    relative === "" ||
+    (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))
+  );
+}
+
+async function toCanonicalPath(input: string): Promise<string> {
+  let existingAncestor = path.resolve(input);
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      const canonicalAncestor = await fs.realpath(existingAncestor);
+      return path.join(canonicalAncestor, ...missingSegments);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) {
+        return path.resolve(input);
+      }
+      missingSegments.unshift(path.basename(existingAncestor));
+      existingAncestor = parent;
+    }
+  }
+}
+
+async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<string> {
+  const outputRoot = await toCanonicalPath(outDir);
+  const filesystemRoot = path.parse(outputRoot).root;
+  const cwd = await toCanonicalPath(process.cwd());
+  const vaultRoot = await toCanonicalPath(vaultDir);
+
+  if (
+    outputRoot === filesystemRoot ||
+    isSamePathOrAncestor(outputRoot, cwd) ||
+    isSamePathOrAncestor(outputRoot, vaultRoot)
+  ) {
+    throw new Error(
+      `[safety] Refusing dangerous output directory: ${outputRoot}. Choose a dedicated child directory.`,
+    );
+  }
+
+  return outputRoot;
+}
+
+async function hasValidOutputMarker(outputRoot: string): Promise<boolean> {
+  const markerPath = path.join(outputRoot, OUTPUT_MARKER_FILE_NAME);
+
+  try {
+    const markerStat = await fs.lstat(markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+      return false;
+    }
+
+    const parsed = (await Bun.file(markerPath).json()) as unknown;
+    return (
+      isRecord(parsed) &&
+      parsed.format === OUTPUT_MARKER_FORMAT &&
+      parsed.version === OUTPUT_MARKER_VERSION
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function writeOutputMarker(outputRoot: string): Promise<void> {
+  const marker = {
+    format: OUTPUT_MARKER_FORMAT,
+    version: OUTPUT_MARKER_VERSION,
+  };
+  await Bun.write(path.join(outputRoot, OUTPUT_MARKER_FILE_NAME), `${JSON.stringify(marker, null, 2)}\n`);
+}
+
+async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void> {
+  const requestedOutputRoot = path.resolve(options.outDir);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
+
+  try {
+    const outputStat = await fs.lstat(requestedOutputRoot);
+    if (!outputStat.isDirectory() || outputStat.isSymbolicLink()) {
+      throw new Error(`[safety] Output path must be a real directory: ${outputRoot}`);
+    }
+
+    const entries = await fs.readdir(outputRoot);
+    if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot))) {
+      throw new Error(
+        `[safety] Refusing non-empty output directory without a valid ${OUTPUT_MARKER_FILE_NAME}: ${outputRoot}`,
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    await fs.mkdir(requestedOutputRoot, { recursive: true });
+  }
+
+  if (!(await hasValidOutputMarker(outputRoot))) {
+    await writeOutputMarker(outputRoot);
+  }
+}
+
+async function removeLegacyCacheIndex(): Promise<void> {
+  const cachePath = toCachePath();
+  await fs.rm(cachePath, { force: true });
+
+  try {
+    await fs.rmdir(path.dirname(cachePath));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && code !== "ENOTEMPTY") {
+      throw error;
+    }
+  }
 }
 
 function createEmptyCache(): BuildCache {
@@ -1496,10 +1619,28 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
   }
 }
 
-export async function cleanBuildArtifacts(outDir: string): Promise<void> {
-  const cachePath = toCachePath();
-  await fs.rm(outDir, { recursive: true, force: true });
-  await fs.rm(path.dirname(cachePath), { recursive: true, force: true });
+export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
+  const requestedOutputRoot = path.resolve(options.outDir);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
+
+  try {
+    const outputStat = await fs.lstat(requestedOutputRoot);
+    if (!outputStat.isDirectory() || outputStat.isSymbolicLink()) {
+      throw new Error(`[safety] Refusing to clean non-directory output path: ${outputRoot}`);
+    }
+    if (!(await hasValidOutputMarker(outputRoot))) {
+      throw new Error(
+        `[safety] Refusing to clean output directory without a valid ${OUTPUT_MARKER_FILE_NAME}: ${outputRoot}`,
+      );
+    }
+    await fs.rm(requestedOutputRoot, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  await removeLegacyCacheIndex();
 }
 
 function buildWikiResolutionSignature(doc: DocRecord, lookup: WikiLookup): string {
@@ -1551,7 +1692,7 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
-  await ensureDir(options.outDir);
+  await prepareOwnedOutputDirectory(options);
   await ensureDir(path.join(options.outDir, "content"));
 
   const cachePath = toCachePath();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,8 +16,8 @@ async function main(): Promise<void> {
   const buildOptions = resolveBuildOptions(cli, userConfig, pinnedMenu);
 
   if (cli.command === "clean") {
-    await cleanBuildArtifacts(buildOptions.outDir);
-    console.log(`[clean] removed ${buildOptions.outDir} and .cache`);
+    await cleanBuildArtifacts(buildOptions);
+    console.log(`[clean] removed ${buildOptions.outDir} and EIAM cache index`);
     return;
   }
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -137,6 +137,71 @@ test.describe("빌드 회귀 가드", () => {
     }
   });
 
+  test("clean은 EIAM 소유 출력과 cache index만 제거한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-clean-"));
+    const outDir = path.join(workDir, "dist");
+    const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
+
+    try {
+      const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(build.status, build.output).toBe(0);
+      expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
+      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(true);
+
+      writeText(unrelatedCacheFile, "unrelated cache data");
+      const clean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
+      expect(clean.status, clean.output).toBe(0);
+      expect(fs.existsSync(outDir)).toBe(false);
+      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(false);
+      expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build와 clean은 broad 또는 미소유 출력 디렉터리를 거부한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-output-"));
+    const unownedOutDir = path.join(workDir, "unowned");
+    const unownedSentinel = path.join(unownedOutDir, "keep.txt");
+    const cwdSentinel = path.join(workDir, "cwd-keep.txt");
+
+    try {
+      writeText(unownedSentinel, "do not remove");
+      writeText(cwdSentinel, "keep cwd");
+
+      const buildIntoUnowned = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        unownedOutDir,
+      ]);
+      expect(buildIntoUnowned.status).not.toBe(0);
+      expect(buildIntoUnowned.output).toContain("Refusing non-empty output directory");
+      expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+
+      const cleanUnowned = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        unownedOutDir,
+      ]);
+      expect(cleanUnowned.status).not.toBe(0);
+      expect(cleanUnowned.output).toContain("Refusing to clean output directory");
+      expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+
+      const cleanCwd = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", workDir]);
+      expect(cleanCwd.status).not.toBe(0);
+      expect(cleanCwd.output).toContain("Refusing dangerous output directory");
+      expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("CLI 숫자 옵션은 잘못된 값을 거부한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-validation-"));
 


### PR DESCRIPTION
## Summary
- Mark EIAM-owned output directories with `.eiam-output.json`.
- Refuse filesystem roots, working/vault ancestors, symlink outputs, and non-empty unowned output directories.
- Make `clean` remove only a verified EIAM output and the EIAM cache index while preserving unrelated `.cache` data.
- Document the safety behavior in English and Korean.

## Issue #14 Scope
Sub PR 1: Guard destructive clean paths and limit cleanup to verified EIAM output.

## DnD
- Recursive clean cannot target a filesystem root, cwd/vault ancestor, symlink, or unrelated directory.
- Builds cannot claim a non-empty unmarked directory.
- Marked EIAM output can still be built incrementally and cleaned.
- Unrelated files under `.cache` survive clean.
- Regression coverage proves sentinels remain intact after rejected clean/build attempts.
- User-facing clean behavior is documented.

## Verification
- `git diff --check`: pass
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:1 bun run test:e2e tests/e2e/build-regression.spec.ts --workers=1`: 12 passed
- isolated sample build with `bun src/cli.ts build --vault test-vault --out <temp>/dist`: pass (`total=5 rendered=5 skipped=0`)
