### PR TITLE
Sub PR 2: Sanitize rendered HTML by default

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -87,6 +87,7 @@ const config = {
     defaultOgImage: "/assets/og.png",
   },
   markdown: {
+    allowUnsafeHtml: false,
     mermaid: {
       enabled: true,
       cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
@@ -116,6 +117,13 @@ export default config;
 - 서브패스 배포(예: `/blog`)를 정식 지원합니다.
 - 내부 라우팅/본문 fetch 링크에 동일한 base path가 적용됩니다.
 - 루트 배포는 빈 문자열(`""`)을 사용합니다.
+
+`markdown.allowUnsafeHtml`:
+
+- 기본값은 `false`이며, 렌더된 HTML을 직접 route와 client navigation용 본문 모두에서 sanitize합니다.
+- 일반 Markdown 서식, 표, 이미지, figure/details, EIAM/Shiki 코드 마크업, 안전한 URL과 Shiki 색상 스타일은 유지합니다.
+- script, 이벤트 핸들러, `javascript:` URL, iframe, SVG, 임의 style은 제거합니다.
+- 신뢰할 수 있는 볼트에서만 `true`로 명시할 수 있으며, 이 경우 임의의 client-side 코드가 실행될 수 있습니다.
 
 예시:
 
@@ -265,6 +273,7 @@ Mermaid fence는 일반 코드 블록 UI와 분리된 전용 컨테이너(`.merm
 
 ```ts
 markdown: {
+  allowUnsafeHtml: false, // true면 렌더 HTML sanitize를 비활성화하므로 신뢰된 볼트에서만 사용
   mermaid: {
     enabled: true, // false면 코드 블록만 표시
     cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js", // http/https 또는 /, ./, ../ 경로

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ export default {
     wikilinks: true,
     images: "omit-local",
     gfm: true,
+    allowUnsafeHtml: false,
     highlight: {
       engine: "shiki",
       theme: "github-dark",
@@ -282,6 +283,7 @@ export default {
 - `markdown.wikilinks`: enable or disable wikilink resolution.
 - `markdown.images`: `"keep"` or `"omit-local"`.
 - `markdown.gfm`: enable or disable GFM table/strikethrough support.
+- `markdown.allowUnsafeHtml`: disables rendered HTML sanitization only when explicitly set to `true`; default `false`.
 - `markdown.highlight.theme`: Shiki theme.
 - `markdown.mermaid.*`: Mermaid runtime settings.
 - `seo.*`: canonical URL, social metadata, sitemap, robots, and path-base behavior.
@@ -370,6 +372,22 @@ Remote URLs are kept even when `"omit-local"` is used.
 
 This rule also applies to Obsidian-style image embeds such as `![[image.png]]`.
 
+### Raw HTML safety
+
+Rendered HTML is sanitized by default before it is written to fetched content files or embedded in direct route pages. The allowlist keeps standard Markdown formatting, tables, images, figures, details, and EIAM/Shiki code markup. It permits classes, safe link/image URLs (`http`, `https`, `mailto`, and relative paths), and Shiki's hex `color`/`background-color` styles. Scripts, event-handler attributes, `javascript:` URLs, iframes, SVG, and arbitrary inline styles are removed.
+
+Trusted vaults can opt out explicitly:
+
+```ts
+export default {
+  markdown: {
+    allowUnsafeHtml: true,
+  },
+};
+```
+
+This setting allows arbitrary authored HTML and can execute client-side code. Do not enable it for content that is untrusted or may be published accidentally.
+
 ### Code Blocks
 
 Regular fenced code blocks are rendered with:
@@ -414,7 +432,7 @@ Body images now use orientation-aware sizing inside the viewer:
 - Near-square images get an intermediate width.
 
 When local Markdown images are enabled with `markdown.images: "keep"`, standalone image paragraphs are promoted into a dedicated `figure.content-image` wrapper automatically.
-Raw HTML remains available for manual framing when you want a fixed ratio or a specific crop mode.
+Allowlisted raw HTML remains available for manual framing when you want a fixed ratio or a specific crop mode.
 
 Example frame utilities:
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,12 +10,14 @@
         "gray-matter": "latest",
         "markdown-it": "latest",
         "picomatch": "latest",
+        "sanitize-html": "2.17.6",
         "shiki": "latest",
       },
       "devDependencies": {
         "@playwright/test": "latest",
         "@types/markdown-it": "latest",
         "@types/picomatch": "latest",
+        "@types/sanitize-html": "2.16.1",
         "bun-types": "latest",
         "markdownlint": "latest",
       },
@@ -62,6 +64,8 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
+    "@types/sanitize-html": ["@types/sanitize-html@2.16.1", "", { "dependencies": { "htmlparser2": "^10.1" } }, "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
@@ -88,15 +92,29 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
@@ -114,6 +132,8 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -124,11 +144,15 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
+
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "launder": ["launder@1.7.1", "", { "dependencies": { "dayjs": "^1.11.7" } }, "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw=="],
 
     "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
 
@@ -192,17 +216,25 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
     "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
     "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
 
@@ -224,11 +256,15 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "sanitize-html": ["sanitize-html@2.17.6", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^12.0.0", "is-plain-object": "^5.0.0", "launder": "^1.7.1", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
@@ -264,8 +300,22 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "sanitize-html/htmlparser2": ["htmlparser2@12.0.0", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "domutils": "^4.0.2", "entities": "^8.0.0" } }, "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw=="],
+
+    "sanitize-html/htmlparser2/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "sanitize-html/htmlparser2/domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
+
+    "sanitize-html/htmlparser2/domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
+
+    "sanitize-html/htmlparser2/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "sanitize-html/htmlparser2/domutils/dom-serializer": ["dom-serializer@3.1.1", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
 		"gray-matter": "^4.0.3",
 		"markdown-it": "^14.2.0",
 		"picomatch": "^4.0.4",
+		"sanitize-html": "2.17.6",
 		"shiki": "^4.2.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
 		"@types/markdown-it": "^14.1.2",
 		"@types/picomatch": "^4.0.3",
+		"@types/sanitize-html": "2.16.1",
 		"bun-types": "^1.3.14",
 		"markdownlint": "^0.40.0"
 	}

--- a/src/build.ts
+++ b/src/build.ts
@@ -1739,6 +1739,7 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
         options.shikiTheme,
         options.imagePolicy,
         options.wikilinks ? "wikilinks-on" : "wikilinks-off",
+        options.allowUnsafeHtml ? "unsafe-html-v1" : "safe-html-v1",
         wikiSignature,
       ].join("::"),
     );

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ const DEFAULTS = {
   wikilinks: true,
   imagePolicy: "omit-local" as const,
   gfm: true,
+  allowUnsafeHtml: false,
   shikiTheme: "github-dark",
   mermaid: {
     enabled: true,
@@ -314,6 +315,7 @@ export function resolveBuildOptions(
     wikilinks: userConfig.markdown?.wikilinks ?? DEFAULTS.wikilinks,
     imagePolicy: userConfig.markdown?.images ?? DEFAULTS.imagePolicy,
     gfm: userConfig.markdown?.gfm ?? DEFAULTS.gfm,
+    allowUnsafeHtml: userConfig.markdown?.allowUnsafeHtml === true,
     shikiTheme: userConfig.markdown?.highlight?.theme ?? DEFAULTS.shikiTheme,
     mermaid: {
       enabled: normalizeMermaidEnabled(userConfig.markdown?.mermaid?.enabled),

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from "markdown-it";
+import sanitizeHtml from "sanitize-html";
 import { createBundledHighlighter, type HighlighterGeneric } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import { bundledLanguages } from "shiki/langs";
@@ -17,6 +18,102 @@ export interface MarkdownRenderer {
 
 const FENCE_LANG_RE = /^```([\w-+#.]+)/gm;
 const MERMAID_LANG = "mermaid";
+const SAFE_COLOR_VALUE = /^#[0-9a-f]{3,8}$/i;
+const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    "p",
+    "br",
+    "hr",
+    "blockquote",
+    "pre",
+    "code",
+    "strong",
+    "em",
+    "s",
+    "del",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "img",
+    "figure",
+    "figcaption",
+    "div",
+    "span",
+    "button",
+    "details",
+    "summary",
+    "kbd",
+    "mark",
+    "sub",
+    "sup",
+    "dl",
+    "dt",
+    "dd",
+    "abbr",
+    "time",
+  ],
+  allowedAttributes: {
+    "*": ["class"],
+    a: ["href", "title", "target", "rel"],
+    abbr: ["title"],
+    button: ["type", "title", "data-code", "aria-label"],
+    details: ["open"],
+    img: ["src", "alt", "title", "width", "height", "loading"],
+    li: ["value"],
+    ol: ["start"],
+    pre: ["tabindex", "style"],
+    span: ["style"],
+    td: ["colspan", "rowspan"],
+    th: ["colspan", "rowspan", "scope"],
+    time: ["datetime"],
+  },
+  allowedStyles: {
+    pre: {
+      "background-color": [SAFE_COLOR_VALUE],
+      color: [SAFE_COLOR_VALUE],
+    },
+    span: {
+      color: [SAFE_COLOR_VALUE],
+    },
+  },
+  allowedSchemes: ["http", "https", "mailto"],
+  allowedSchemesByTag: {
+    a: ["http", "https", "mailto"],
+    img: ["http", "https"],
+  },
+  allowProtocolRelative: false,
+  disallowedTagsMode: "discard",
+  enforceHtmlBoundary: false,
+  nestingLimit: 100,
+  nonTextTags: ["script", "style", "textarea", "option", "noscript"],
+  transformTags: {
+    a(tagName, attributes) {
+      const attribs = { ...attributes };
+      if (attribs.target === "_blank") {
+        const rel = new Set((attribs.rel ?? "").split(/\s+/).filter(Boolean));
+        rel.add("noopener");
+        rel.add("noreferrer");
+        attribs.rel = Array.from(rel).join(" ");
+      } else {
+        delete attribs.target;
+      }
+      return { tagName, attribs };
+    },
+  },
+};
 type RenderRule = NonNullable<MarkdownIt["renderer"]["rules"]["fence"]>;
 type RenderRuleArgs = Parameters<RenderRule>;
 type RuleTokens = RenderRuleArgs[0];
@@ -165,7 +262,7 @@ function createMarkdownIt<L extends string, T extends string>(
   gfm: boolean,
 ): MarkdownIt {
   const md = new MarkdownIt({
-    // Allow raw HTML in markdown (e.g. <img ... />).
+    // Parse raw HTML so the configured sanitizer can apply one policy to generated and authored markup.
     html: true,
     linkify: true,
     typographer: false,
@@ -311,12 +408,18 @@ export async function createMarkdownRenderer(options: BuildOptions): Promise<Mar
   const loadedLanguages = new Set(highlighter.getLoadedLanguages().map(String));
 
   const md = createMarkdownIt(highlighter, options.shikiTheme, options.gfm);
+  if (options.allowUnsafeHtml) {
+    console.warn(
+      "[security] markdown.allowUnsafeHtml=true disables rendered HTML sanitization. Only use trusted vault content.",
+    );
+  }
 
   return {
     async render(markdown: string, resolver: WikiResolver): Promise<RenderResult> {
       const { markdown: preprocessed, warnings } = preprocessMarkdown(markdown, resolver, options.imagePolicy, options.wikilinks);
       await loadFenceLanguages(highlighter, loadedLanguages, preprocessed);
-      const html = md.render(preprocessed);
+      const renderedHtml = md.render(preprocessed);
+      const html = options.allowUnsafeHtml ? renderedHtml : sanitizeHtml(renderedHtml, SAFE_HTML_OPTIONS);
       return { html, warnings };
     },
   };

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface UserConfig {
     wikilinks?: boolean;
     images?: ImagePolicy;
     gfm?: boolean;
+    allowUnsafeHtml?: boolean;
     highlight?: {
       engine?: "shiki";
       theme?: string;
@@ -79,6 +80,7 @@ export interface BuildOptions {
   wikilinks: boolean;
   imagePolicy: ImagePolicy;
   gfm: boolean;
+  allowUnsafeHtml: boolean;
   shikiTheme: string;
   mermaid: {
     enabled: boolean;

--- a/test-vault/posts/2024/xss-nav-title.md
+++ b/test-vault/posts/2024/xss-nav-title.md
@@ -10,3 +10,9 @@ description: Regression fixture for runtime XSS escaping.
 # Runtime XSS Regression Fixture
 
 이 문서는 런타임 내비게이션 렌더링의 XSS 이스케이프 회귀를 검증하기 위한 테스트 픽스처입니다.
+
+<div class="raw-html-safe"><strong>Allowed raw formatting</strong></div>
+<script>window.__raw_script = 1</script>
+<img class="raw-html-event" src="/missing-xss-fixture.png" alt="event payload" onerror="window.__raw_event = 1" />
+<a class="raw-html-url" href="javascript:window.__raw_url = 1">Unsafe URL</a>
+<iframe src="https://example.com/unsafe-frame"></iframe>

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -202,6 +202,68 @@ test.describe("빌드 회귀 가드", () => {
     }
   });
 
+  test("raw HTML은 기본 sanitize되고 명시적 unsafe 설정에서만 유지된다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-html-sanitize-"));
+    const vaultDir = path.join(workDir, "vault");
+    const safeWorkDir = path.join(workDir, "safe");
+    const unsafeWorkDir = path.join(workDir, "unsafe");
+    const rawPayload = `---
+publish: true
+prefix: SAFE-HTML-01
+category_path: security/html
+title: HTML Policy
+---
+
+<div class="safe-format"><strong>Allowed formatting</strong></div>
+<script>window.__script_payload = 1</script>
+<img src="https://example.com/safe.png" alt="safe" onerror="window.__event_payload = 1" />
+<a href="javascript:window.__url_payload = 1">Unsafe URL</a>
+<iframe src="https://example.com/unsafe"></iframe>
+`;
+
+    try {
+      writeText(path.join(vaultDir, "unsafe.md"), rawPayload);
+      fs.mkdirSync(safeWorkDir, { recursive: true });
+      fs.mkdirSync(unsafeWorkDir, { recursive: true });
+
+      const safeOutDir = path.join(safeWorkDir, "dist");
+      const safeBuild = runCli(safeWorkDir, [cliPath, "build", "--vault", vaultDir, "--out", safeOutDir]);
+      expect(safeBuild.status, safeBuild.output).toBe(0);
+      const safeContent = readDocContentHtml(safeOutDir, "/SAFE-HTML-01/");
+      const safeRoute = fs.readFileSync(path.join(safeOutDir, "SAFE-HTML-01", "index.html"), "utf8");
+      for (const rendered of [safeContent, safeRoute]) {
+        expect(rendered).toContain('<div class="safe-format"><strong>Allowed formatting</strong></div>');
+        expect(rendered).not.toContain("window.__script_payload");
+        expect(rendered).not.toContain("window.__event_payload");
+        expect(rendered).not.toContain("javascript:window.__url_payload");
+        expect(rendered).not.toContain("https://example.com/unsafe");
+      }
+
+      writeText(
+        path.join(unsafeWorkDir, "blog.config.mjs"),
+        "export default { markdown: { allowUnsafeHtml: true } };\n",
+      );
+      const unsafeOutDir = path.join(unsafeWorkDir, "dist");
+      const unsafeBuild = runCli(unsafeWorkDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        unsafeOutDir,
+      ]);
+      expect(unsafeBuild.status, unsafeBuild.output).toBe(0);
+      expect(unsafeBuild.output).toContain("allowUnsafeHtml=true disables rendered HTML sanitization");
+      const unsafeContent = readDocContentHtml(unsafeOutDir, "/SAFE-HTML-01/");
+      expect(unsafeContent).toContain("<script>window.__script_payload = 1</script>");
+      expect(unsafeContent).toContain('onerror="window.__event_payload = 1"');
+      expect(unsafeContent).toContain('href="javascript:window.__url_payload = 1"');
+      expect(unsafeContent).toContain('<iframe src="https://example.com/unsafe"></iframe>');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("CLI 숫자 옵션은 잘못된 값을 거부한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-validation-"));
 

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -32,4 +32,51 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     const xssFlag = await page.evaluate(() => (window as Window & { __xss_title?: number }).__xss_title ?? 0);
     expect(xssFlag).toBe(0);
   });
+
+  test("raw HTML은 직접 route와 client navigation에서 같은 정책으로 sanitize된다", async ({ page }) => {
+    await page.addInitScript(() => {
+      const target = window as Window & {
+        __raw_script?: number;
+        __raw_event?: number;
+        __raw_url?: number;
+      };
+      target.__raw_script = 0;
+      target.__raw_event = 0;
+      target.__raw_url = 0;
+    });
+
+    const assertSanitizedContent = async () => {
+      await expect(page.locator("#viewer-content .raw-html-safe strong")).toHaveText("Allowed raw formatting");
+      await expect(page.locator("#viewer-content script")).toHaveCount(0);
+      await expect(page.locator("#viewer-content iframe")).toHaveCount(0);
+      await expect(page.locator("#viewer-content [onerror]")).toHaveCount(0);
+      await expect(page.locator("#viewer-content .raw-html-url")).not.toHaveAttribute("href", /javascript:/i);
+
+      const flags = await page.evaluate(() => {
+        const target = window as Window & {
+          __raw_script?: number;
+          __raw_event?: number;
+          __raw_url?: number;
+        };
+        return [target.__raw_script ?? 0, target.__raw_event ?? 0, target.__raw_url ?? 0];
+      });
+      expect(flags).toEqual([0, 0, 0]);
+    };
+
+    await page.goto("/BC-XSS-01/");
+    await waitForAppReady(page);
+    await assertSanitizedContent();
+
+    await page.goto("/BC-VO-02/");
+    await waitForAppReady(page);
+    const xssRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"]')
+      .filter({ hasText: "Unsafe" })
+      .first();
+    await expect(xssRow).toBeVisible();
+    await xssRow.click();
+    await expect(page).toHaveURL(/\/BC-XSS-01\/$/);
+    await expect(page.locator("#viewer-title")).toContainText("Unsafe");
+    await assertSanitizedContent();
+  });
 });


### PR DESCRIPTION
## Summary
- Sanitize rendered Markdown HTML with an explicit allowlist before writing fetched content or embedding direct route HTML.
- Block scripts, event handlers, `javascript:` URLs, iframes/SVG, protocol-relative URLs, and arbitrary inline styles by default.
- Preserve standard formatting plus EIAM/Shiki code markup and safe link/image schemes.
- Add explicit `markdown.allowUnsafeHtml: true` opt-out with a security warning and cache-key invalidation.
- Cover default and unsafe modes, direct route rendering, and client navigation.

## Issue #14 Scope
Sub PR 2: Sanitize rendered HTML and make unsafe HTML explicit (#18).

## DnD
- Script, event-handler, JavaScript URL, and iframe payloads are blocked by default.
- Safe formatting, image/figure markup, Mermaid source containers, and Shiki classes/hex color styles remain supported.
- Unsafe mode requires the exact boolean `markdown.allowUnsafeHtml: true` and emits a warning.
- Direct route SSR and fetched client-navigation content share the same sanitized render result.
- Render cache hashes include the HTML policy so older unsanitized output is not reused.
- English/Korean docs describe the allowlist and unsafe-mode risk.

## Verification
- `bun install --frozen-lockfile`: pass, no changes
- `bunx --package typescript tsc --noEmit`: pass
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:1 bun run test:e2e tests/e2e/build-regression.spec.ts --workers=1`: 13 passed
- `bun run test:e2e tests/e2e/runtime-xss-guard.spec.ts --workers=1`: 2 passed
- `bun run test:e2e --workers=1`: 37 passed
- `git diff --check`: pass
- `bun audit`: sanitizer path clean; one pre-existing moderate advisory remains in `gray-matter -> js-yaml@3`
