### PR TITLE
fix: keep private documents out of persistent cache

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,10 @@ title: Work In Progress
 ---
 ```
 
+## 캐시와 비공개 문서
+
+증분 빌드 cache에는 `publish: true`이면서 draft가 아닌 Markdown 본문만 저장됩니다. 비공개 문서와 draft 문서는 persistent cache entry에서 완전히 제외되며, publish/draft 상태가 바뀌면 다음 빌드에서 다시 평가됩니다.
+
 ## 위키링크 지원
 
 위키링크는 아래 순서로 해석됩니다.

--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Example:
 
 The build caches source metadata and output hashes in `.cache/build-index.json`.
 
+Only published, non-draft Markdown source bodies are persisted. Unpublished and draft entries are omitted from the cache, so their content is re-evaluated when needed but never written to persistent build state.
+
 This allows it to:
 
 - skip unchanged rendered content

--- a/src/build.ts
+++ b/src/build.ts
@@ -21,7 +21,7 @@ import {
   toDocId,
 } from "./utils";
 
-const CACHE_VERSION = 4;
+const CACHE_VERSION = 5;
 const CACHE_DIR_NAME = ".cache";
 const CACHE_FILE_NAME = "build-index.json";
 const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
@@ -708,11 +708,11 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
       mtimeMs: stat.mtimeMs,
       size: stat.size,
     };
-    nextSources[relPath] = completeEntry;
-
     if (!completeEntry.publish || completeEntry.draft) {
       continue;
     }
+
+    nextSources[relPath] = completeEntry;
 
     if (!completeEntry.prefix) {
       console.warn(`[publish] Skipped published doc without prefix: ${relPath}`);

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -264,6 +264,121 @@ title: HTML Policy
     }
   });
 
+  test("cache에는 unpublished와 draft Markdown 본문을 저장하지 않는다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-private-cache-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const cachePath = path.join(workDir, ".cache", "build-index.json");
+    const publicPath = path.join(vaultDir, "public.md");
+    const privatePath = path.join(vaultDir, "private.md");
+    const draftPath = path.join(vaultDir, "draft.md");
+
+    try {
+      writeText(
+        publicPath,
+        `---
+publish: true
+prefix: CACHE-PUBLIC
+category_path: cache/public
+title: Public Cache
+---
+
+PUBLIC_CACHE_BODY
+`,
+      );
+      writeText(
+        privatePath,
+        `---
+publish: false
+title: Private Cache
+---
+
+PRIVATE_CACHE_SECRET
+`,
+      );
+      writeText(
+        draftPath,
+        `---
+publish: true
+draft: true
+title: Draft Cache
+---
+
+DRAFT_CACHE_SECRET
+`,
+      );
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+      const firstCache = fs.readFileSync(cachePath, "utf8");
+      expect(firstCache).toContain("PUBLIC_CACHE_BODY");
+      expect(firstCache).not.toContain("PRIVATE_CACHE_SECRET");
+      expect(firstCache).not.toContain("DRAFT_CACHE_SECRET");
+      const firstSources = (JSON.parse(firstCache) as { sources: Record<string, unknown> }).sources;
+      expect(firstSources["public.md"]).toBeDefined();
+      expect(firstSources["private.md"]).toBeUndefined();
+      expect(firstSources["draft.md"]).toBeUndefined();
+
+      const incrementalBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(incrementalBuild.status, incrementalBuild.output).toBe(0);
+      expect(incrementalBuild.output).toContain("total=1 rendered=0 skipped=1");
+
+      writeText(
+        privatePath,
+        `---
+publish: true
+prefix: CACHE-PRIVATE
+category_path: cache/private
+title: Published Private Cache
+---
+
+PRIVATE_CACHE_SECRET
+`,
+      );
+      writeText(
+        publicPath,
+        `---
+publish: false
+prefix: CACHE-PUBLIC
+category_path: cache/public
+title: Private Public Cache
+---
+
+PUBLIC_CACHE_BODY
+`,
+      );
+      writeText(
+        draftPath,
+        `---
+publish: true
+draft: false
+prefix: CACHE-DRAFT
+category_path: cache/draft
+title: Published Draft Cache
+---
+
+DRAFT_CACHE_SECRET
+`,
+      );
+
+      const stateBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(stateBuild.status, stateBuild.output).toBe(0);
+      const manifest = readManifest(outDir) as { docs: Array<{ route: string }> };
+      expect(manifest.docs.map((doc) => doc.route).sort()).toEqual(["/CACHE-DRAFT/", "/CACHE-PRIVATE/"]);
+
+      const nextCache = fs.readFileSync(cachePath, "utf8");
+      expect(nextCache).not.toContain("PUBLIC_CACHE_BODY");
+      expect(nextCache).toContain("PRIVATE_CACHE_SECRET");
+      expect(nextCache).toContain("DRAFT_CACHE_SECRET");
+      const nextSources = (JSON.parse(nextCache) as { sources: Record<string, unknown> }).sources;
+      expect(nextSources["public.md"]).toBeUndefined();
+      expect(nextSources["private.md"]).toBeDefined();
+      expect(nextSources["draft.md"]).toBeDefined();
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("CLI 숫자 옵션은 잘못된 값을 거부한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-validation-"));
 


### PR DESCRIPTION
Part of #14

Addresses #15 by persisting source bodies only for published, non-draft documents. Private and draft sources are re-evaluated without being serialized into build state, and publish/draft transitions remain incremental and correct.

## Done and Done

- [x] Unpublished source bodies are absent from the persistent cache
- [x] Draft source bodies are absent from the persistent cache
- [x] Published sources still reuse incremental cache entries
- [x] Publish/draft transitions add and remove routes correctly
- [x] README documents the privacy boundary

## Verification

- `bunx --package typescript tsc --noEmit`
- `bunx playwright test tests/e2e/build-regression.spec.ts --reporter=line` (14 passed)
- `bun run test:e2e` (38 passed)