### PR TITLE
fix: namespace build cache by vault and output

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -33,9 +33,9 @@ bun run blog [build|dev|clean] [options]
 
 - `bun run build`: 정적 파일 빌드
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
-- `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 EIAM cache index만 삭제
+- `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 
@@ -206,6 +206,8 @@ title: Work In Progress
 ```
 
 ## 캐시와 비공개 문서
+
+빌드 cache는 실행 작업 디렉터리 기준 `.cache/eiam/v1-<namespace>/build-index.json`에 저장됩니다. namespace는 canonical `vaultDir`와 `outDir` 경로 쌍의 안정적인 hash입니다. config를 먼저 해석한 다음 CLI의 `--vault`와 `--out`이 이를 덮어쓰며, 어느 경로든 달라지면 별도 namespace를 선택합니다. cache root 자체를 별도로 재지정하는 옵션은 없습니다. `clean`은 선택된 경로 쌍의 namespace만 삭제합니다.
 
 증분 빌드 cache에는 `publish: true`이면서 draft가 아닌 Markdown 본문만 저장됩니다. 비공개 문서와 draft 문서는 persistent cache entry에서 완전히 제외되며, publish/draft 상태가 바뀌면 다음 빌드에서 다시 평가됩니다.
 

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Notes:
 - Unknown CLI options fail fast.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
-- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and EIAM's `.cache/build-index.json`, preserving unrelated `.cache` data.
+- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 
@@ -210,7 +210,7 @@ Key points:
 - Rendered article bodies are stored separately under `dist/content/`.
 - Runtime assets are content-hashed.
 - Static files declared in config are copied into the same relative paths under `dist/`.
-- Build cache is stored under `.cache/build-index.json`.
+- Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
 ## Config File
 
@@ -503,7 +503,9 @@ Example:
 
 ## Incremental Build and Caching
 
-The build caches source metadata and output hashes in `.cache/build-index.json`.
+The build caches source metadata and output hashes in `.cache/eiam/v1-<namespace>/build-index.json`, relative to the process working directory. The namespace is a stable hash of the canonical, resolved `vaultDir` and `outDir` pair.
+
+Config values are resolved first, with CLI `--vault` and `--out` values taking precedence. Changing either resolved path selects a different namespace; it does not reuse or overwrite the previous pair's cache. The cache root itself has no separate override. `clean` removes only the namespace for the selected pair, never sibling EIAM namespaces or general-purpose `.cache` files.
 
 Only published, non-draft Markdown source bodies are persisted. Unpublished and draft entries are omitted from the cache, so their content is re-evaluated when needed but never written to persistent build state.
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -22,7 +22,8 @@ import {
 } from "./utils";
 
 const CACHE_VERSION = 5;
-const CACHE_DIR_NAME = ".cache";
+const CACHE_ROOT_SEGMENTS = [".cache", "eiam"] as const;
+const CACHE_NAMESPACE_VERSION = 1;
 const CACHE_FILE_NAME = "build-index.json";
 const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
 const OUTPUT_MARKER_FORMAT = "everything-is-a-markdown-output";
@@ -62,12 +63,14 @@ interface BuildResult {
   skippedDocs: number;
 }
 
-function toContentFileName(id: string): string {
-  return `${makeHash(id)}.html`;
+interface CacheLocation {
+  rootDir: string;
+  namespaceDir: string;
+  cachePath: string;
 }
 
-function toCachePath(): string {
-  return path.join(process.cwd(), CACHE_DIR_NAME, CACHE_FILE_NAME);
+function toContentFileName(id: string): string {
+  return `${makeHash(id)}.html`;
 }
 
 function isSamePathOrAncestor(candidate: string, target: string): boolean {
@@ -99,6 +102,22 @@ async function toCanonicalPath(input: string): Promise<string> {
       existingAncestor = parent;
     }
   }
+}
+
+async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocation> {
+  const [vaultRoot, outputRoot] = await Promise.all([
+    toCanonicalPath(options.vaultDir),
+    toCanonicalPath(options.outDir),
+  ]);
+  const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}`)}`;
+  const rootDir = path.join(process.cwd(), ...CACHE_ROOT_SEGMENTS);
+  const namespaceDir = path.join(rootDir, namespace);
+
+  return {
+    rootDir,
+    namespaceDir,
+    cachePath: path.join(namespaceDir, CACHE_FILE_NAME),
+  };
 }
 
 async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<string> {
@@ -176,12 +195,10 @@ async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void>
   }
 }
 
-async function removeLegacyCacheIndex(): Promise<void> {
-  const cachePath = toCachePath();
-  await fs.rm(cachePath, { force: true });
-
+async function removeCacheNamespace(location: CacheLocation): Promise<void> {
+  await fs.rm(location.namespaceDir, { recursive: true, force: true });
   try {
-    await fs.rmdir(path.dirname(cachePath));
+    await fs.rmdir(location.rootDir);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code !== "ENOENT" && code !== "ENOTEMPTY") {
@@ -1620,6 +1637,7 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
 }
 
 export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
+  const cacheLocation = await resolveCacheLocation(options);
   const requestedOutputRoot = path.resolve(options.outDir);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
 
@@ -1640,7 +1658,7 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
     }
   }
 
-  await removeLegacyCacheIndex();
+  await removeCacheNamespace(cacheLocation);
 }
 
 function buildWikiResolutionSignature(doc: DocRecord, lookup: WikiLookup): string {
@@ -1695,7 +1713,7 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
   await prepareOwnedOutputDirectory(options);
   await ensureDir(path.join(options.outDir, "content"));
 
-  const cachePath = toCachePath();
+  const { cachePath } = await resolveCacheLocation(options);
   const previousCache = await readCache(cachePath);
   const canReuseOutputs = await fileExists(path.join(options.outDir, "manifest.json"));
   const previousDocs = canReuseOutputs ? previousCache.docs : {};

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
 
   if (cli.command === "clean") {
     await cleanBuildArtifacts(buildOptions);
-    console.log(`[clean] removed ${buildOptions.outDir} and EIAM cache index`);
+    console.log(`[clean] removed ${buildOptions.outDir} and matching EIAM cache namespace`);
     return;
   }
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -51,6 +51,26 @@ function readManifest(outDir: string): unknown {
   return JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as unknown;
 }
 
+function findCacheIndexPaths(workDir: string): string[] {
+  const cacheRoot = path.join(workDir, ".cache", "eiam");
+  if (!fs.existsSync(cacheRoot)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(cacheRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(cacheRoot, entry.name, "build-index.json"))
+    .filter((cachePath) => fs.existsSync(cachePath))
+    .sort();
+}
+
+function findOnlyCacheIndexPath(workDir: string): string {
+  const cachePaths = findCacheIndexPaths(workDir);
+  expect(cachePaths).toHaveLength(1);
+  return cachePaths[0];
+}
+
 function findFolderNodeByPath(
   nodes: Array<{ type: string; path?: string; children?: Array<{ type: string; path?: string; children?: unknown[] }> }>,
   targetPath: string,
@@ -137,7 +157,7 @@ test.describe("빌드 회귀 가드", () => {
     }
   });
 
-  test("clean은 EIAM 소유 출력과 cache index만 제거한다", async () => {
+  test("clean은 EIAM 소유 출력과 matching cache namespace만 제거한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-clean-"));
     const outDir = path.join(workDir, "dist");
     const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
@@ -146,13 +166,13 @@ test.describe("빌드 회귀 가드", () => {
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
       expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
-      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(true);
+      const cachePath = findOnlyCacheIndexPath(workDir);
 
       writeText(unrelatedCacheFile, "unrelated cache data");
       const clean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
       expect(clean.status, clean.output).toBe(0);
       expect(fs.existsSync(outDir)).toBe(false);
-      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(false);
+      expect(fs.existsSync(cachePath)).toBe(false);
       expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
@@ -197,6 +217,101 @@ test.describe("빌드 회귀 가드", () => {
       expect(cleanCwd.status).not.toBe(0);
       expect(cleanCwd.output).toContain("Refusing dangerous output directory");
       expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("vault와 output 경로 쌍마다 cache namespace를 분리하고 clean은 선택한 namespace만 제거한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cache-namespace-"));
+    const vaultA = path.join(workDir, "vault-a");
+    const vaultB = path.join(workDir, "vault-b");
+    const outA = path.join(workDir, "dist-a");
+    const outB = path.join(workDir, "dist-b");
+    const outAAlternate = path.join(workDir, "dist-a-alternate");
+    const sourceA = path.join(vaultA, "same.md");
+    const sourceB = path.join(vaultB, "same.md");
+    const fixedTime = new Date("2024-01-02T03:04:05.000Z");
+
+    try {
+      const bodyA = `---
+publish: true
+prefix: NS-CACHE-A
+category_path: cache/namespace
+title: Vault A
+---
+
+VAULT_A_BODY
+`;
+      const bodyB = `---
+publish: true
+prefix: NS-CACHE-B
+category_path: cache/namespace
+title: Vault B
+---
+
+VAULT_B_BODY
+`;
+      expect(Buffer.byteLength(bodyA)).toBe(Buffer.byteLength(bodyB));
+      writeText(sourceA, bodyA);
+      writeText(sourceB, bodyB);
+      fs.utimesSync(sourceA, fixedTime, fixedTime);
+      fs.utimesSync(sourceB, fixedTime, fixedTime);
+
+      const buildA = runCli(workDir, [cliPath, "build", "--vault", vaultA, "--out", outA]);
+      expect(buildA.status, buildA.output).toBe(0);
+      expect(buildA.output).toContain("total=1 rendered=1 skipped=0");
+      const [cacheA] = findCacheIndexPaths(workDir);
+      expect(cacheA).toBeDefined();
+      expect(fs.readFileSync(cacheA, "utf8")).toContain("VAULT_A_BODY");
+
+      const buildB = runCli(workDir, [cliPath, "build", "--vault", vaultB, "--out", outB]);
+      expect(buildB.status, buildB.output).toBe(0);
+      const afterBuildB = findCacheIndexPaths(workDir);
+      expect(afterBuildB).toHaveLength(2);
+      const cacheB = afterBuildB.find((cachePath) => cachePath !== cacheA);
+      expect(cacheB).toBeDefined();
+      expect(fs.readFileSync(cacheB!, "utf8")).toContain("VAULT_B_BODY");
+      const manifestB = readManifest(outB) as { docs: Array<{ route: string }> };
+      expect(manifestB.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-B/"]);
+
+      const alternateBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultA,
+        "--out",
+        outAAlternate,
+      ]);
+      expect(alternateBuild.status, alternateBuild.output).toBe(0);
+      const afterAlternate = findCacheIndexPaths(workDir);
+      expect(afterAlternate).toHaveLength(3);
+      const cacheAAlternate = afterAlternate.find(
+        (cachePath) => cachePath !== cacheA && cachePath !== cacheB,
+      );
+      expect(cacheAAlternate).toBeDefined();
+
+      const rebuildA = runCli(workDir, [cliPath, "build", "--vault", vaultA, "--out", outA]);
+      expect(rebuildA.status, rebuildA.output).toBe(0);
+      expect(rebuildA.output).toContain("total=1 rendered=0 skipped=1");
+      const manifestA = readManifest(outA) as { docs: Array<{ route: string }> };
+      expect(manifestA.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
+
+      const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
+      writeText(unrelatedCacheFile, "unrelated cache data");
+      const cleanA = runCli(workDir, [cliPath, "clean", "--vault", vaultA, "--out", outA]);
+      expect(cleanA.status, cleanA.output).toBe(0);
+      expect(fs.existsSync(outA)).toBe(false);
+      expect(fs.existsSync(cacheA)).toBe(false);
+      expect(fs.existsSync(cacheB!)).toBe(true);
+      expect(fs.existsSync(cacheAAlternate!)).toBe(true);
+      expect(fs.existsSync(outB)).toBe(true);
+      expect(fs.existsSync(outAAlternate)).toBe(true);
+      expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
+
+      const rebuildB = runCli(workDir, [cliPath, "build", "--vault", vaultB, "--out", outB]);
+      expect(rebuildB.status, rebuildB.output).toBe(0);
+      expect(rebuildB.output).toContain("total=1 rendered=0 skipped=1");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -268,7 +383,6 @@ title: HTML Policy
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-private-cache-"));
     const vaultDir = path.join(workDir, "vault");
     const outDir = path.join(workDir, "dist");
-    const cachePath = path.join(workDir, ".cache", "build-index.json");
     const publicPath = path.join(vaultDir, "public.md");
     const privatePath = path.join(vaultDir, "private.md");
     const draftPath = path.join(vaultDir, "draft.md");
@@ -310,6 +424,7 @@ DRAFT_CACHE_SECRET
 
       const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(firstBuild.status, firstBuild.output).toBe(0);
+      const cachePath = findOnlyCacheIndexPath(workDir);
       const firstCache = fs.readFileSync(cachePath, "utf8");
       expect(firstCache).toContain("PUBLIC_CACHE_BODY");
       expect(firstCache).not.toContain("PRIVATE_CACHE_SECRET");


### PR DESCRIPTION
Part of #14

Addresses #16 by moving build state into an EIAM-owned cache root and selecting a stable namespace from the canonical vault/output pair.

## Done and Done

- [x] Two vaults built from one cwd use separate cache state
- [x] Two output directories select separate output-hash state
- [x] Same-name, same-size, same-mtime sources cannot cross-reuse another vault cache
- [x] `clean` removes only the selected namespace
- [x] Sibling namespaces and unrelated `.cache` files are preserved
- [x] Cache location and CLI/config override behavior are documented

## Verification

- `bunx --package typescript tsc --noEmit`
- `bunx playwright test tests/e2e/build-regression.spec.ts --reporter=line` (15 passed)
- `bun run test:e2e` (39 passed)