### PR TITLE
fix: fingerprint markdown before cache reuse

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -211,6 +211,8 @@ title: Work In Progress
 
 증분 빌드 cache에는 `publish: true`이면서 draft가 아닌 Markdown 본문만 저장됩니다. 비공개 문서와 draft 문서는 persistent cache entry에서 완전히 제외되며, publish/draft 상태가 바뀌면 다음 빌드에서 다시 평가됩니다.
 
+cache entry를 재사용하기 전에 모든 Markdown 원문을 읽어 SHA-256 fingerprint를 계산합니다. 파일 크기와 mtime을 유지한 채 본문을 교체해도 변경을 감지하며, fingerprint가 같으면 frontmatter parse와 Markdown render는 계속 건너뜁니다. 회귀 테스트는 40개 문서 no-op 빌드에서 `rendered=0`, `skipped=40`, wall-clock 10초 미만을 측정합니다. `bunx playwright test tests/e2e/build-regression.spec.ts --grep "ordinary no-op"`로 실행할 수 있습니다.
+
 ## 위키링크 지원
 
 위키링크는 아래 순서로 해석됩니다.

--- a/README.md
+++ b/README.md
@@ -516,6 +516,8 @@ This allows it to:
 - restore missing hashed runtime assets on a later build
 - remove stale route pages and content files when documents are removed or routes change
 
+Every Markdown source is read and SHA-256 fingerprinted before a cache entry is reused. This catches content replacement even when file size and mtime are preserved. When the fingerprint is unchanged, frontmatter parsing and Markdown rendering are still skipped. The regression suite measures a 40-document no-op build and requires `rendered=0`, `skipped=40`, and under 10 seconds of wall-clock time; run it with `bunx playwright test tests/e2e/build-regression.spec.ts --grep "ordinary no-op"`.
+
 ## Markdown Lint for Published Docs
 
 This repository includes a publish-only Markdown lint command:

--- a/src/build.ts
+++ b/src/build.ts
@@ -21,7 +21,7 @@ import {
   toDocId,
 } from "./utils";
 
-const CACHE_VERSION = 5;
+const CACHE_VERSION = 6;
 const CACHE_ROOT_SEGMENTS = [".cache", "eiam"] as const;
 const CACHE_NAMESPACE_VERSION = 1;
 const CACHE_FILE_NAME = "build-index.json";
@@ -630,11 +630,19 @@ function extractWikiTargets(markdown: string): string[] {
   return Array.from(targets).sort((left, right) => left.localeCompare(right, "ko-KR"));
 }
 
-function toCachedSourceEntry(raw: string, parsed: matter.GrayMatterFile<string>): CachedSourceEntry {
+function makeSourceFingerprint(raw: string): string {
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+function toCachedSourceEntry(
+  raw: string,
+  rawHash: string,
+  parsed: matter.GrayMatterFile<string>,
+): CachedSourceEntry {
   return {
     mtimeMs: 0,
     size: 0,
-    rawHash: makeHash(raw),
+    rawHash,
     publish: parsed.data.publish === true,
     draft: parsed.data.draft === true,
     title: typeof parsed.data.title === "string" && parsed.data.title.trim().length > 0 ? parsed.data.title.trim() : undefined,
@@ -702,14 +710,14 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
 
   for (const { sourcePath, relPath, stat } of fileEntries) {
     const prev = previousSources[relPath];
+    const raw = await Bun.file(sourcePath).text();
+    const rawHash = makeSourceFingerprint(raw);
 
     let entry: CachedSourceEntry;
-    const canReuse = !!prev && prev.mtimeMs === stat.mtimeMs && prev.size === stat.size;
+    const canReuse = !!prev && prev.rawHash === rawHash;
     if (canReuse) {
       entry = prev;
     } else {
-      const raw = await Bun.file(sourcePath).text();
-
       let parsed: matter.GrayMatterFile<string>;
       try {
         parsed = matter(raw);
@@ -717,7 +725,7 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
         throw new Error(`Frontmatter parse failed: ${relPath}\n${(error as Error).message}`);
       }
 
-      entry = toCachedSourceEntry(raw, parsed);
+      entry = toCachedSourceEntry(raw, rawHash, parsed);
     }
 
     const completeEntry: CachedSourceEntry = {

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -317,6 +317,165 @@ VAULT_B_BODY
     }
   });
 
+  test("같은 size와 mtime을 유지한 body, wikilink, frontmatter 변경도 다시 빌드한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-content-fingerprint-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const fixedTime = new Date("2024-02-03T04:05:06.000Z");
+    const mutablePath = path.join(vaultDir, "mutable.md");
+    const linkerPath = path.join(vaultDir, "linker.md");
+    const frontmatterPath = path.join(vaultDir, "frontmatter.md");
+
+    const mutableBefore = `---
+publish: true
+prefix: FP-MUTABLE
+category_path: cache/fingerprint
+title: Mutable
+---
+
+ALPHA
+`;
+    const mutableAfter = mutableBefore.replace("ALPHA", "BRAVO");
+    const linkerBefore = `---
+publish: true
+prefix: FP-LINKER
+category_path: cache/fingerprint
+title: Linker
+---
+
+[[Target A]]
+`;
+    const linkerAfter = linkerBefore.replace("Target A", "Target B");
+    const frontmatterBefore = `---
+publish: true
+prefix: FP-ROUTE-A
+category_path: cache/fingerprint
+title: Frontmatter
+---
+
+UNCHANGED_BODY
+`;
+    const frontmatterAfter = frontmatterBefore.replace("FP-ROUTE-A", "FP-ROUTE-B");
+
+    try {
+      writeText(
+        path.join(vaultDir, "target-a.md"),
+        `---
+publish: true
+prefix: FP-TARGET-A
+category_path: cache/fingerprint
+title: Target A
+---
+
+TARGET_A_BODY
+`,
+      );
+      writeText(
+        path.join(vaultDir, "target-b.md"),
+        `---
+publish: true
+prefix: FP-TARGET-B
+category_path: cache/fingerprint
+title: Target B
+---
+
+TARGET_B_BODY
+`,
+      );
+
+      for (const [sourcePath, before, after] of [
+        [mutablePath, mutableBefore, mutableAfter],
+        [linkerPath, linkerBefore, linkerAfter],
+        [frontmatterPath, frontmatterBefore, frontmatterAfter],
+      ] as const) {
+        expect(Buffer.byteLength(before)).toBe(Buffer.byteLength(after));
+        writeText(sourcePath, before);
+        fs.utimesSync(sourcePath, fixedTime, fixedTime);
+      }
+
+      const initialStats = new Map(
+        [mutablePath, linkerPath, frontmatterPath].map((sourcePath) => [sourcePath, fs.statSync(sourcePath)]),
+      );
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+      expect(readDocContentHtml(outDir, "/FP-MUTABLE/")).toContain("ALPHA");
+      expect(readDocContentHtml(outDir, "/FP-LINKER/")).toContain('href="/FP-TARGET-A/"');
+      expect(fs.existsSync(path.join(outDir, "FP-ROUTE-A", "index.html"))).toBe(true);
+
+      for (const [sourcePath, replacement] of [
+        [mutablePath, mutableAfter],
+        [linkerPath, linkerAfter],
+        [frontmatterPath, frontmatterAfter],
+      ] as const) {
+        writeText(sourcePath, replacement);
+        fs.utimesSync(sourcePath, fixedTime, fixedTime);
+        const previous = initialStats.get(sourcePath)!;
+        const current = fs.statSync(sourcePath);
+        expect(current.size).toBe(previous.size);
+        expect(current.mtimeMs).toBe(previous.mtimeMs);
+      }
+
+      const changedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(changedBuild.status, changedBuild.output).toBe(0);
+      expect(changedBuild.output).toContain("total=5 rendered=3 skipped=2");
+      expect(readDocContentHtml(outDir, "/FP-MUTABLE/")).toContain("BRAVO");
+      const linkerHtml = readDocContentHtml(outDir, "/FP-LINKER/");
+      expect(linkerHtml).toContain('href="/FP-TARGET-B/"');
+      expect(linkerHtml).not.toContain('href="/FP-TARGET-A/"');
+      expect(fs.existsSync(path.join(outDir, "FP-ROUTE-A", "index.html"))).toBe(false);
+      expect(fs.existsSync(path.join(outDir, "FP-ROUTE-B", "index.html"))).toBe(true);
+
+      const manifest = readManifest(outDir) as {
+        docs: Array<{ route: string; backlinks: Array<{ route: string }> }>;
+      };
+      const targetA = manifest.docs.find((doc) => doc.route === "/FP-TARGET-A/");
+      const targetB = manifest.docs.find((doc) => doc.route === "/FP-TARGET-B/");
+      expect(targetA?.backlinks).toEqual([]);
+      expect(targetB?.backlinks.map((backlink) => backlink.route)).toEqual(["/FP-LINKER/"]);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("ordinary no-op 빌드는 fingerprint 후 parse와 render를 건너뛴다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-noop-performance-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const docCount = 40;
+
+    try {
+      for (let index = 0; index < docCount; index += 1) {
+        const id = String(index).padStart(2, "0");
+        writeText(
+          path.join(vaultDir, `doc-${id}.md`),
+          `---
+publish: true
+prefix: PERF-${id}
+category_path: cache/performance
+title: Performance ${id}
+---
+
+PERFORMANCE_BODY_${id}
+`,
+        );
+      }
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+
+      const startedAt = performance.now();
+      const noOpBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      const elapsedMs = performance.now() - startedAt;
+      console.info(`[perf] no-op incremental docs=${docCount} elapsedMs=${elapsedMs.toFixed(1)}`);
+
+      expect(noOpBuild.status, noOpBuild.output).toBe(0);
+      expect(noOpBuild.output).toContain(`total=${docCount} rendered=0 skipped=${docCount}`);
+      expect(elapsedMs).toBeLessThan(10_000);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("raw HTML은 기본 sanitize되고 명시적 unsafe 설정에서만 유지된다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-html-sanitize-"));
     const vaultDir = path.join(workDir, "vault");


### PR DESCRIPTION
Part of #14

Addresses #17 by validating every Markdown source with a SHA-256 content fingerprint before reusing parsed cache state.

## Done and Done

- [x] Same-size, same-mtime body changes are detected
- [x] Same-size, same-mtime wikilink changes refresh links and backlinks
- [x] Same-size, same-mtime frontmatter route changes invalidate stale output
- [x] Unchanged fingerprints still skip frontmatter parsing and Markdown rendering
- [x] A documented 40-document no-op performance guard remains below 10 seconds

## Verification

- `bunx --package typescript tsc --noEmit`
- focused fingerprint/performance tests (2 passed; no-op 550.6 ms)
- build regression suite (17 passed; no-op 569.7 ms)
- `bun run test:e2e` (41 passed; no-op 648.6 ms)