### PR TITLE
fix: reject missing CLI option values

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,8 @@ bun run blog [build|dev|clean] [options]
 - `--recent-limit <n>`: Recent 폴더 문서 수 제한 (정수 `>= 1`, 기본 `5`)
 - `--port <n>`: 개발 서버 포트 (기본 `3000`)
 
+값을 받는 옵션에서 값을 생략하거나 다음 CLI flag를 값 자리에 두면 `[cli] Missing value for <option>` 오류로 즉시 종료합니다. 음수 등 실제 숫자 형태는 값으로 읽은 뒤 기존 숫자 범위 검증을 적용합니다.
+
 ## Markdown Lint (publish 전용)
 
 `publish: true` 문서만 대상으로 Markdown lint를 실행하고, 결과를 JSON 파일로 저장할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Options:
 Notes:
 
 - Unknown CLI options fail fast.
+- Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
 - `clean` refuses broad or unmarked output paths. It removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,27 @@ function normalizeMermaidTheme(value: unknown): string {
   return normalized;
 }
 
+function readOptionValue(
+  args: string[],
+  optionIndex: number,
+  option: string,
+  allowNegativeNumber = false,
+): string {
+  const value = args[optionIndex + 1];
+  const isFlagShaped = !value || value.startsWith("-");
+  const isNegativeNumber =
+    allowNegativeNumber &&
+    typeof value === "string" &&
+    value.startsWith("-") &&
+    !Number.isNaN(Number(value));
+
+  if (!value || (isFlagShaped && !isNegativeNumber)) {
+    throw new Error(`[cli] Missing value for ${option}`);
+  }
+
+  return value;
+}
+
 export function parseCliArgs(argv: string[]): CliArgs {
   const [first] = argv;
   const command = first === "build" || first === "dev" || first === "clean" ? first : "build";
@@ -91,31 +112,38 @@ export function parseCliArgs(argv: string[]): CliArgs {
       continue;
     }
     if (token === "--vault") {
-      parsed.vaultDir = rest[++i];
+      parsed.vaultDir = readOptionValue(rest, i, token);
+      i += 1;
       continue;
     }
     if (token === "--out") {
-      parsed.outDir = rest[++i];
+      parsed.outDir = readOptionValue(rest, i, token);
+      i += 1;
       continue;
     }
     if (token === "--exclude") {
-      parsed.exclude.push(rest[++i]);
+      parsed.exclude.push(readOptionValue(rest, i, token));
+      i += 1;
       continue;
     }
     if (token === "--new-within-days") {
-      parsed.newWithinDays = Number(rest[++i]);
+      parsed.newWithinDays = Number(readOptionValue(rest, i, token, true));
+      i += 1;
       continue;
     }
     if (token === "--recent-limit") {
-      parsed.recentLimit = Number(rest[++i]);
+      parsed.recentLimit = Number(readOptionValue(rest, i, token, true));
+      i += 1;
       continue;
     }
     if (token === "--menu-config") {
-      parsed.menuConfigPath = rest[++i];
+      parsed.menuConfigPath = readOptionValue(rest, i, token);
+      i += 1;
       continue;
     }
     if (token === "--port") {
-      parsed.port = Number(rest[++i]);
+      parsed.port = Number(readOptionValue(rest, i, token, true));
+      i += 1;
       continue;
     }
     throw new Error(`Unknown option: ${token}`);

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -669,6 +669,7 @@ DRAFT_CACHE_SECRET
       ]);
       expect(invalidRecent.status).not.toBe(0);
       expect(invalidRecent.output).toContain("--recent-limit");
+      expect(invalidRecent.output).not.toContain("[cli] Missing value");
 
       const invalidNewWithinDays = runCli(workDir, [
         cliPath,
@@ -682,6 +683,35 @@ DRAFT_CACHE_SECRET
       ]);
       expect(invalidNewWithinDays.status).not.toBe(0);
       expect(invalidNewWithinDays.output).toContain("--new-within-days");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build, dev, clean의 모든 값 옵션은 누락되거나 다음 flag인 값을 거부한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-missing-values-"));
+    const cases = [
+      { command: "build", option: "--vault" },
+      { command: "dev", option: "--out" },
+      { command: "clean", option: "--exclude" },
+      { command: "build", option: "--new-within-days" },
+      { command: "dev", option: "--recent-limit" },
+      { command: "clean", option: "--menu-config" },
+      { command: "dev", option: "--port" },
+    ] as const;
+
+    try {
+      for (const { command, option } of cases) {
+        const expectedError = `[cli] Missing value for ${option}`;
+
+        const omitted = runCli(workDir, [cliPath, command, option]);
+        expect(omitted.status, `${command} ${option}\n${omitted.output}`).not.toBe(0);
+        expect(omitted.output).toContain(expectedError);
+
+        const followedByFlag = runCli(workDir, [cliPath, command, option, "--help"]);
+        expect(followedByFlag.status, `${command} ${option} --help\n${followedByFlag.output}`).not.toBe(0);
+        expect(followedByFlag.output).toContain(expectedError);
+      }
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
Part of #14

Addresses #20 with one shared option-value reader for every value-taking CLI flag.

## Done and Done

- [x] All seven value-taking options reject an omitted value
- [x] A following flag is rejected instead of being consumed as a value
- [x] Errors identify the exact option as `[cli] Missing value for <option>`
- [x] Negative numeric values still reach existing numeric validation
- [x] Regression coverage exercises build, dev, and clean

## Verification

- `bunx --package typescript tsc --noEmit`
- focused CLI regression tests (2 passed)
- build regression suite (18 passed)
- `bun run test:e2e` (42 passed)