### PR TITLE
fix: respect path base in 404 Home link

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -118,6 +118,7 @@ export default config;
 
 - 서브패스 배포(예: `/blog`)를 정식 지원합니다.
 - 내부 라우팅/본문 fetch 링크에 동일한 base path가 적용됩니다.
+- 생성된 `404.html`의 Home 링크도 정규화된 base path를 사용합니다. 예를 들어 `/blog` 배포에서는 `/blog/`로 돌아갑니다.
 - 루트 배포는 빈 문자열(`""`)을 사용합니다.
 
 `markdown.allowUnsafeHtml`:

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ With SEO enabled, the build writes:
 - `sitemap.xml`
 
 `seo.pathBase` is supported for subpath deployments such as `/blog`.
+The generated `404.html` Home action uses the same normalized base, so `/blog` returns to `/blog/` while root deployments continue to use `/`.
 
 Example:
 

--- a/src/build.ts
+++ b/src/build.ts
@@ -1553,7 +1553,7 @@ async function writeShellPages(
   await writeOutputIfChanged(
     context,
     "404.html",
-    render404Html(buildAppShellAssetsForOutput("404.html", runtimeAssets)),
+    render404Html(buildAppShellAssetsForOutput("404.html", runtimeAssets), toPathWithBase("/", pathBase)),
   );
 
   for (const doc of docs) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -354,7 +354,7 @@ ${initialManifestScript}
 `;
 }
 
-export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS): string {
+export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS, homeHref = "/"): string {
   const symbolFontStylesheet =
     "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
 
@@ -378,7 +378,7 @@ export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS): string {
       </div>
       <h1>404</h1>
       <p>요청한 문서를 찾을 수 없습니다.</p>
-      <a href="/" class="not-found-link">
+      <a href="${escapeHtmlAttribute(homeHref)}" class="not-found-link">
         <span class="material-symbols-outlined">home</span>
         홈으로 이동
       </a>

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -103,6 +103,31 @@ test.describe("pathBase 정식 지원", () => {
   const cliPath = path.join(repoRoot, "src/cli.ts");
   const vaultPath = path.join(repoRoot, "test-vault");
 
+  test("생성된 404 Home 링크는 root와 정규화된 nested pathBase를 따른다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-404-home-"));
+    const outDir = path.join(workDir, "dist");
+    const configPath = path.join(workDir, "blog.config.mjs");
+
+    try {
+      const rootBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(rootBuild.status, rootBuild.output).toBe(0);
+      const rootNotFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+      expect(rootNotFoundHtml).toContain('<a href="/" class="not-found-link">');
+
+      fs.writeFileSync(
+        configPath,
+        'export default { seo: { siteUrl: "https://example.com", pathBase: " docs/guides/ " } };',
+        "utf8",
+      );
+      const nestedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(nestedBuild.status, nestedBuild.output).toBe(0);
+      const nestedNotFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+      expect(nestedNotFoundHtml).toContain('<a href="/docs/guides/" class="not-found-link">');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("서브패스(/blog)에서 라우팅/내부 링크/본문 fetch가 정상 동작한다", async ({ page }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-path-base-"));
     const outDir = path.join(workDir, "dist");
@@ -126,6 +151,8 @@ test.describe("pathBase 정식 지원", () => {
       "9999",
     ]);
     expect(build.status, build.output).toBe(0);
+    const notFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+    expect(notFoundHtml).toContain('<a href="/blog/" class="not-found-link">');
 
     const server = await startStaticServer(outDir, pathBase);
     try {
@@ -145,6 +172,20 @@ test.describe("pathBase 정식 지원", () => {
       await expect(page).toHaveURL(/\/blog\/BC-VO-02\/$/);
       await expect(page.locator("#viewer-title")).toHaveText("Setup Guide");
       await expect(page.locator("#viewer-nav .nav-link-next")).toHaveAttribute("href", "/blog/BC-XSS-01/");
+
+      const notFoundResponse = await page.goto(`${server.baseUrl}/blog/missing-document/`);
+      expect(notFoundResponse?.status()).toBe(404);
+      await expect(page).toHaveURL(`${server.baseUrl}/blog/missing-document/`);
+      const homeLink = page.locator(".not-found-link");
+      await expect(homeLink).toHaveAttribute("href", "/blog/");
+      const homeRequestPromise = page.waitForRequest(
+        (request) => request.isNavigationRequest() && request.url() === `${server.baseUrl}/blog/`,
+      );
+      await homeLink.click();
+      const homeRequest = await homeRequestPromise;
+      expect(homeRequest.url()).toBe(`${server.baseUrl}/blog/`);
+      await expect(page.locator(".app-root")).toBeVisible();
+      expect(new URL(page.url()).pathname).toMatch(/^\/blog\//);
     } finally {
       await server.close();
       fs.rmSync(workDir, { recursive: true, force: true });


### PR DESCRIPTION
Part of #14

Addresses #19 by passing the normalized deployment base into generated 404 rendering.

## Done and Done

- [x] Root deployments keep Home at `/`
- [x] `/blog` deployments use `/blog/`
- [x] Normalized nested values such as ` docs/guides/ ` use `/docs/guides/`
- [x] Home href is attribute-escaped
- [x] E2E verifies a 404 Home click requests the deployed root and loads the app inside the base

## Verification

- `bunx --package typescript tsc --noEmit`
- pathBase E2E (2 passed)
- `bun run test:e2e` (43 passed)