### PR TITLE
test: stabilize pathBase E2E under parallel load

### DIFF
--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -104,6 +104,7 @@ test.describe("pathBase 정식 지원", () => {
   const vaultPath = path.join(repoRoot, "test-vault");
 
   test("생성된 404 Home 링크는 root와 정규화된 nested pathBase를 따른다", async () => {
+    test.setTimeout(60_000);
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-404-home-"));
     const outDir = path.join(workDir, "dist");
     const configPath = path.join(workDir, "blog.config.mjs");
@@ -129,6 +130,7 @@ test.describe("pathBase 정식 지원", () => {
   });
 
   test("서브패스(/blog)에서 라우팅/내부 링크/본문 fetch가 정상 동작한다", async ({ page }) => {
+    test.setTimeout(60_000);
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-path-base-"));
     const outDir = path.join(workDir, "dist");
     const configPath = path.join(workDir, "blog.config.mjs");


### PR DESCRIPTION
Part of #14

Follow-up to #58 after the integrated 4-worker run showed the two cold-build pathBase tests can exceed the global 30-second timeout under contention.

## Done and Done

- [x] Keep every root, nested-base, 404 href, navigation-request, and app-load assertion unchanged
- [x] Scope a 60-second budget only to the two pathBase integration tests
- [x] Preserve the global timeout for all other tests

## Verification

- `bun run test:e2e` (43 passed, 4 workers)
- pathBase tests completed in 31.7s and 35.8s under the integrated load