### PR TITLE
feat: harden safety, privacy, security, and correctness

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -118,6 +118,7 @@ export default config;
 
 - 서브패스 배포(예: `/blog`)를 정식 지원합니다.
 - 내부 라우팅/본문 fetch 링크에 동일한 base path가 적용됩니다.
+- 생성된 `404.html`의 Home 링크도 정규화된 base path를 사용합니다. 예를 들어 `/blog` 배포에서는 `/blog/`로 돌아갑니다.
 - 루트 배포는 빈 문자열(`""`)을 사용합니다.
 
 `markdown.allowUnsafeHtml`:

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 vault/output pair와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component와 cache namespace도 거부합니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component, namespace, index도 거부합니다. `staticPaths`는 output 밖으로 벗어나거나 예약된 `.eiam-output.json` 마커와 충돌할 수 없습니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 
@@ -106,6 +106,7 @@ export default config;
 - 볼트 기준 상대 경로 배열
 - 폴더와 파일 모두 지정 가능
 - 지정한 경로의 파일들을 `dist`에 같은 상대 경로로 복사
+- output 밖으로 벗어나거나 예약된 `.eiam-output.json` 소유권 마커와 충돌하는 경로는 거부
 - 예: 볼트 `assets/og.png` -> `dist/assets/og.png`
 
 `pinnedMenu`:

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 vault/output pair와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 legacy EIAM cache index인 `.cache/build-index.json`만 제거하고, sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component도 거부합니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component와 cache namespace도 거부합니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 clean 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component도 거부합니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -106,7 +106,7 @@ export default config;
 - 볼트 기준 상대 경로 배열
 - 폴더와 파일 모두 지정 가능
 - 지정한 경로의 파일들을 `dist`에 같은 상대 경로로 복사
-- output 밖으로 벗어나거나 예약된 `.eiam-output.json` 소유권 마커와 충돌하는 경로는 거부
+- vault root로 정규화되거나 output 밖으로 벗어나거나 예약된 `.eiam-output.json` 소유권 마커와 충돌하는 경로는 거부
 - 예: 볼트 `assets/og.png` -> `dist/assets/og.png`
 
 `pinnedMenu`:

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component도 거부합니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component도 거부합니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -33,9 +33,9 @@ bun run blog [build|dev|clean] [options]
 
 - `bun run build`: 정적 파일 빌드
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
-- `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 EIAM cache index만 삭제
+- `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 
@@ -206,6 +206,8 @@ title: Work In Progress
 ```
 
 ## 캐시와 비공개 문서
+
+빌드 cache는 실행 작업 디렉터리 기준 `.cache/eiam/v1-<namespace>/build-index.json`에 저장됩니다. namespace는 canonical `vaultDir`와 `outDir` 경로 쌍의 안정적인 hash입니다. config를 먼저 해석한 다음 CLI의 `--vault`와 `--out`이 이를 덮어쓰며, 어느 경로든 달라지면 별도 namespace를 선택합니다. cache root 자체를 별도로 재지정하는 옵션은 없습니다. `clean`은 선택된 경로 쌍의 namespace만 삭제합니다.
 
 증분 빌드 cache에는 `publish: true`이면서 draft가 아닌 Markdown 본문만 저장됩니다. 비공개 문서와 draft 문서는 persistent cache entry에서 완전히 제외되며, publish/draft 상태가 바뀌면 다음 빌드에서 다시 평가됩니다.
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 legacy EIAM cache index인 `.cache/build-index.json`만 제거하고, sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하고, sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -205,6 +205,10 @@ title: Work In Progress
 ---
 ```
 
+## 캐시와 비공개 문서
+
+증분 빌드 cache에는 `publish: true`이면서 draft가 아닌 Markdown 본문만 저장됩니다. 비공개 문서와 draft 문서는 persistent cache entry에서 완전히 제외되며, publish/draft 상태가 바뀌면 다음 빌드에서 다시 평가됩니다.
+
 ## 위키링크 지원
 
 위키링크는 아래 순서로 해석됩니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -211,6 +211,8 @@ title: Work In Progress
 
 증분 빌드 cache에는 `publish: true`이면서 draft가 아닌 Markdown 본문만 저장됩니다. 비공개 문서와 draft 문서는 persistent cache entry에서 완전히 제외되며, publish/draft 상태가 바뀌면 다음 빌드에서 다시 평가됩니다.
 
+cache entry를 재사용하기 전에 모든 Markdown 원문을 읽어 SHA-256 fingerprint를 계산합니다. 파일 크기와 mtime을 유지한 채 본문을 교체해도 변경을 감지하며, fingerprint가 같으면 frontmatter parse와 Markdown render는 계속 건너뜁니다. 회귀 테스트는 40개 문서 no-op 빌드에서 `rendered=0`, `skipped=40`, wall-clock 10초 미만을 측정합니다. `bunx playwright test tests/e2e/build-regression.spec.ts --grep "ordinary no-op"`로 실행할 수 있습니다.
+
 ## 위키링크 지원
 
 위키링크는 아래 순서로 해석됩니다.

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, symlink인 cache path component, namespace, index도 거부합니다. `staticPaths`는 output 밖으로 벗어나거나 예약된 `.eiam-output.json` 마커와 충돌할 수 없습니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 두 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리, cache root를 포함하거나 그 안에 놓인 경로는 출력으로 사용하지 않으며, symlink인 cache path component, namespace, index도 거부합니다. `staticPaths`는 output 밖으로 벗어나거나 예약된 `.eiam-output.json` 마커와 충돌할 수 없습니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output과 예약 static path를 거부하는 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -35,7 +35,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
 
-빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하고, sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리와 cache root를 포함하는 경로는 출력으로 사용하지 않으며, `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 clean 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -33,7 +33,9 @@ bun run blog [build|dev|clean] [options]
 
 - `bun run build`: 정적 파일 빌드
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
-- `bun run clean`: `dist`와 `.cache` 삭제
+- `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 EIAM cache index만 삭제
+
+빌드는 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록합니다. 비어 있지 않은 미소유 디렉터리는 출력 경로로 사용하지 않으며, `clean`도 광범위한 경로나 마커가 없는 디렉터리를 삭제하지 않습니다. 일반 `.cache`의 다른 파일은 보존합니다.
 
 자주 쓰는 옵션:
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -87,6 +87,7 @@ const config = {
     defaultOgImage: "/assets/og.png",
   },
   markdown: {
+    allowUnsafeHtml: false,
     mermaid: {
       enabled: true,
       cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
@@ -116,6 +117,13 @@ export default config;
 - 서브패스 배포(예: `/blog`)를 정식 지원합니다.
 - 내부 라우팅/본문 fetch 링크에 동일한 base path가 적용됩니다.
 - 루트 배포는 빈 문자열(`""`)을 사용합니다.
+
+`markdown.allowUnsafeHtml`:
+
+- 기본값은 `false`이며, 렌더된 HTML을 직접 route와 client navigation용 본문 모두에서 sanitize합니다.
+- 일반 Markdown 서식, 표, 이미지, figure/details, EIAM/Shiki 코드 마크업, 안전한 URL과 Shiki 색상 스타일은 유지합니다.
+- script, 이벤트 핸들러, `javascript:` URL, iframe, SVG, 임의 style은 제거합니다.
+- 신뢰할 수 있는 볼트에서만 `true`로 명시할 수 있으며, 이 경우 임의의 client-side 코드가 실행될 수 있습니다.
 
 예시:
 
@@ -265,6 +273,7 @@ Mermaid fence는 일반 코드 블록 UI와 분리된 전용 컨테이너(`.merm
 
 ```ts
 markdown: {
+  allowUnsafeHtml: false, // true면 렌더 HTML sanitize를 비활성화하므로 신뢰된 볼트에서만 사용
   mermaid: {
     enabled: true, // false면 코드 블록만 표시
     cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js", // http/https 또는 /, ./, ../ 경로

--- a/README.ko.md
+++ b/README.ko.md
@@ -46,6 +46,8 @@ bun run blog [build|dev|clean] [options]
 - `--recent-limit <n>`: Recent 폴더 문서 수 제한 (정수 `>= 1`, 기본 `5`)
 - `--port <n>`: 개발 서버 포트 (기본 `3000`)
 
+값을 받는 옵션에서 값을 생략하거나 다음 CLI flag를 값 자리에 두면 `[cli] Missing value for <option>` 오류로 즉시 종료합니다. 음수 등 실제 숫자 형태는 값으로 읽은 뒤 기존 숫자 범위 검증을 적용합니다.
+
 ## Markdown Lint (publish 전용)
 
 `publish: true` 문서만 대상으로 Markdown lint를 실행하고, 결과를 JSON 파일로 저장할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Notes:
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
-- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema. Cache-root-containing output paths are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when `clean` must reject a pre-marker output directory. Cache-root-containing output paths are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Notes:
 - Invalid numeric options fail fast.
 - Builds validate and read the vault before marking a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
 - `dev` aborts before starting its watcher or server when the initial build cannot claim the output safely; later rebuild failures are logged without stopping an already-safe server.
-- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths, symlinked cache path components, and symlinked cache namespaces are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths, symlinked cache components/namespaces/indexes, and static paths that collide with the reserved `.eiam-output.json` marker are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 
@@ -295,6 +295,7 @@ export default {
 - Must be vault-relative
 - Can point to either a file or a directory
 - Are copied as-is into the output directory
+- Must not escape the output directory or collide with the reserved `.eiam-output.json` ownership marker
 - Invalid or missing paths are skipped with a warning
 
 ### `pinnedMenu`

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Notes:
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
-- Build migration and `clean` remove the exact legacy EIAM cache index at `.cache/build-index.json`. `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema. Cache-root-containing output paths are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -516,6 +516,8 @@ This allows it to:
 - restore missing hashed runtime assets on a later build
 - remove stale route pages and content files when documents are removed or routes change
 
+Every Markdown source is read and SHA-256 fingerprinted before a cache entry is reused. This catches content replacement even when file size and mtime are preserved. When the fingerprint is unchanged, frontmatter parsing and Markdown rendering are still skipped. The regression suite measures a 40-document no-op build and requires `rendered=0`, `skipped=40`, and under 10 seconds of wall-clock time; run it with `bunx playwright test tests/e2e/build-regression.spec.ts --grep "ordinary no-op"`.
+
 ## Markdown Lint for Published Docs
 
 This repository includes a publish-only Markdown lint command:

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Notes:
 - Unknown CLI options fail fast.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
-- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and EIAM's `.cache/build-index.json`, preserving unrelated `.cache` data.
+- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 
@@ -210,7 +210,7 @@ Key points:
 - Rendered article bodies are stored separately under `dist/content/`.
 - Runtime assets are content-hashed.
 - Static files declared in config are copied into the same relative paths under `dist/`.
-- Build cache is stored under `.cache/build-index.json`.
+- Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
 ## Config File
 
@@ -503,7 +503,9 @@ Example:
 
 ## Incremental Build and Caching
 
-The build caches source metadata and output hashes in `.cache/build-index.json`.
+The build caches source metadata and output hashes in `.cache/eiam/v1-<namespace>/build-index.json`, relative to the process working directory. The namespace is a stable hash of the canonical, resolved `vaultDir` and `outDir` pair.
+
+Config values are resolved first, with CLI `--vault` and `--out` values taking precedence. Changing either resolved path selects a different namespace; it does not reuse or overwrite the previous pair's cache. The cache root itself has no separate override. `clean` removes only the namespace for the selected pair, never sibling EIAM namespaces or general-purpose `.cache` files.
 
 Only published, non-draft Markdown source bodies are persisted. Unpublished and draft entries are omitted from the cache, so their content is re-evaluated when needed but never written to persistent build state.
 

--- a/README.md
+++ b/README.md
@@ -116,7 +116,8 @@ Notes:
 
 - Unknown CLI options fail fast.
 - Invalid numeric options fail fast.
-- `clean` removes both the output directory and `.cache`.
+- Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
+- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and EIAM's `.cache/build-index.json`, preserving unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -241,6 +241,7 @@ export default {
     wikilinks: true,
     images: "omit-local",
     gfm: true,
+    allowUnsafeHtml: false,
     highlight: {
       engine: "shiki",
       theme: "github-dark",
@@ -282,6 +283,7 @@ export default {
 - `markdown.wikilinks`: enable or disable wikilink resolution.
 - `markdown.images`: `"keep"` or `"omit-local"`.
 - `markdown.gfm`: enable or disable GFM table/strikethrough support.
+- `markdown.allowUnsafeHtml`: disables rendered HTML sanitization only when explicitly set to `true`; default `false`.
 - `markdown.highlight.theme`: Shiki theme.
 - `markdown.mermaid.*`: Mermaid runtime settings.
 - `seo.*`: canonical URL, social metadata, sitemap, robots, and path-base behavior.
@@ -370,6 +372,22 @@ Remote URLs are kept even when `"omit-local"` is used.
 
 This rule also applies to Obsidian-style image embeds such as `![[image.png]]`.
 
+### Raw HTML safety
+
+Rendered HTML is sanitized by default before it is written to fetched content files or embedded in direct route pages. The allowlist keeps standard Markdown formatting, tables, images, figures, details, and EIAM/Shiki code markup. It permits classes, safe link/image URLs (`http`, `https`, `mailto`, and relative paths), and Shiki's hex `color`/`background-color` styles. Scripts, event-handler attributes, `javascript:` URLs, iframes, SVG, and arbitrary inline styles are removed.
+
+Trusted vaults can opt out explicitly:
+
+```ts
+export default {
+  markdown: {
+    allowUnsafeHtml: true,
+  },
+};
+```
+
+This setting allows arbitrary authored HTML and can execute client-side code. Do not enable it for content that is untrusted or may be published accidentally.
+
 ### Code Blocks
 
 Regular fenced code blocks are rendered with:
@@ -414,7 +432,7 @@ Body images now use orientation-aware sizing inside the viewer:
 - Near-square images get an intermediate width.
 
 When local Markdown images are enabled with `markdown.images: "keep"`, standalone image paragraphs are promoted into a dedicated `figure.content-image` wrapper automatically.
-Raw HTML remains available for manual framing when you want a fixed ratio or a specific crop mode.
+Allowlisted raw HTML remains available for manual framing when you want a fixed ratio or a specific crop mode.
 
 Example frame utilities:
 

--- a/README.md
+++ b/README.md
@@ -494,6 +494,7 @@ With SEO enabled, the build writes:
 - `sitemap.xml`
 
 `seo.pathBase` is supported for subpath deployments such as `/blog`.
+The generated `404.html` Home action uses the same normalized base, so `/blog` returns to `/blog/` while root deployments continue to use `/`.
 
 Example:
 

--- a/README.md
+++ b/README.md
@@ -295,7 +295,7 @@ export default {
 - Must be vault-relative
 - Can point to either a file or a directory
 - Are copied as-is into the output directory
-- Must not escape the output directory or collide with the reserved `.eiam-output.json` ownership marker
+- Must not normalize to the vault root, escape the output directory, or collide with the reserved `.eiam-output.json` ownership marker
 - Invalid or missing paths are skipped with a warning
 
 ### `pinnedMenu`

--- a/README.md
+++ b/README.md
@@ -117,9 +117,9 @@ Notes:
 - Unknown CLI options fail fast.
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
-- Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
+- Builds validate and read the vault before marking a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
 - `dev` aborts before starting its watcher or server when the initial build cannot claim the output safely; later rebuild failures are logged without stopping an already-safe server.
-- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths and symlinked cache path components are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths, symlinked cache path components, and symlinked cache namespaces are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -119,7 +119,7 @@ Notes:
 - Invalid numeric options fail fast.
 - Builds validate and read the vault before marking a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
 - `dev` aborts before starting its watcher or server when the initial build cannot claim the output safely; later rebuild failures are logged without stopping an already-safe server.
-- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths, symlinked cache components/namespaces/indexes, and static paths that collide with the reserved `.eiam-output.json` marker are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory or reserved static path. Outputs that contain or sit inside the cache root, symlinked cache components/namespaces/indexes, and static paths that collide with the reserved `.eiam-output.json` marker are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -115,6 +115,7 @@ Options:
 Notes:
 
 - Unknown CLI options fail fast.
+- Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
 - `clean` refuses broad or unmarked output paths. It removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.

--- a/README.md
+++ b/README.md
@@ -117,7 +117,7 @@ Notes:
 - Unknown CLI options fail fast.
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
-- Builds mark a dedicated output directory with `.eiam-output.json` and refuse to claim a non-empty unmarked directory.
+- Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to the canonical vault/output cache namespace, and refuse to claim a non-empty unmarked or mismatched directory.
 - `clean` refuses broad or unmarked output paths. It removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter

--- a/README.md
+++ b/README.md
@@ -505,6 +505,8 @@ Example:
 
 The build caches source metadata and output hashes in `.cache/build-index.json`.
 
+Only published, non-draft Markdown source bodies are persisted. Unpublished and draft entries are omitted from the cache, so their content is re-evaluated when needed but never written to persistent build state.
+
 This allows it to:
 
 - skip unchanged rendered content

--- a/README.md
+++ b/README.md
@@ -117,8 +117,8 @@ Notes:
 - Unknown CLI options fail fast.
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
-- Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to the canonical vault/output cache namespace, and refuse to claim a non-empty unmarked or mismatched directory.
-- `clean` refuses broad or unmarked output paths. It removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
+- Build migration and `clean` remove the exact legacy EIAM cache index at `.cache/build-index.json`. `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/README.md
+++ b/README.md
@@ -118,6 +118,7 @@ Notes:
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
+- `dev` aborts before starting its watcher or server when the initial build cannot claim the output safely; later rebuild failures are logged without stopping an already-safe server.
 - Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths and symlinked cache path components are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter

--- a/README.md
+++ b/README.md
@@ -118,7 +118,7 @@ Notes:
 - Every value-taking option fails with `[cli] Missing value for <option>` when its value is omitted or the next argument is another flag.
 - Invalid numeric options fail fast.
 - Builds mark a dedicated output directory with `.eiam-output.json`, bind that marker to a cache namespace derived from the canonical vault, output, and cache-root paths, and refuse to claim a non-empty unmarked or mismatched directory.
-- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when `clean` must reject a pre-marker output directory. Cache-root-containing output paths are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
+- Build migration and `clean` remove `.cache/build-index.json` only when it matches a historical EIAM cache schema, including when either command must reject a pre-marker output directory. Cache-root-containing output paths and symlinked cache path components are rejected; `clean` otherwise removes only the marked output directory and its matching EIAM cache namespace, preserving sibling namespaces and unrelated `.cache` data.
 
 ## Frontmatter
 

--- a/bun.lock
+++ b/bun.lock
@@ -10,12 +10,14 @@
         "gray-matter": "latest",
         "markdown-it": "latest",
         "picomatch": "latest",
+        "sanitize-html": "2.17.6",
         "shiki": "latest",
       },
       "devDependencies": {
         "@playwright/test": "latest",
         "@types/markdown-it": "latest",
         "@types/picomatch": "latest",
+        "@types/sanitize-html": "2.16.1",
         "bun-types": "latest",
         "markdownlint": "latest",
       },
@@ -62,6 +64,8 @@
 
     "@types/picomatch": ["@types/picomatch@4.0.3", "", {}, "sha512-iG0T6+nYJ9FAPmx9SsUlnwcq1ZVRuCXcVEvWnntoPlrOpwtSTKNDC9uVAxTsC3PUvJ+99n4RpAcNgBbHX3JSnQ=="],
 
+    "@types/sanitize-html": ["@types/sanitize-html@2.16.1", "", { "dependencies": { "htmlparser2": "^10.1" } }, "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA=="],
+
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
@@ -88,15 +92,29 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
+
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
     "dequal": ["dequal@2.0.3", "", {}, "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA=="],
 
     "devlop": ["devlop@1.1.0", "", { "dependencies": { "dequal": "^2.0.0" } }, "sha512-RWmIqhcFf1lRYBvNmr7qTNuyCt/7/ns2jbpp1+PalgE/rDQcBT0fioSMUpJ93irlUhC5hrg4cYqe6U+0ImW0rA=="],
 
+    "dom-serializer": ["dom-serializer@2.0.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.2", "entities": "^4.2.0" } }, "sha512-wIkAryiqt/nV5EQKqQpo3SToSOV9J0DnbJqwK7Wv/Trc92zIAYZ4FlMu+JPFW1DfGFt81ZTCGgDEabffXeLyJg=="],
+
+    "domelementtype": ["domelementtype@2.3.0", "", {}, "sha512-OLETBj6w0OsagBwdXnPdN0cnMfF9opN69co+7ZrbfPGrdpPVNBUj02spi6B1N7wChLQiPn4CSH/zJvXw56gmHw=="],
+
+    "domhandler": ["domhandler@5.0.3", "", { "dependencies": { "domelementtype": "^2.3.0" } }, "sha512-cgwlv/1iFQiFnU96XXgROh8xTeetsnJiDsTc7TYCLFd9+/WNkIqPTxiM/8pSd8VIrhXGTf1Ny1q1hquVqDJB5w=="],
+
+    "domutils": ["domutils@3.2.2", "", { "dependencies": { "dom-serializer": "^2.0.0", "domelementtype": "^2.3.0", "domhandler": "^5.0.3" } }, "sha512-6kZKyUajlDuqlHKVX1w7gyslj9MPIXzIFiz/rGu35uC1wMi+kMhQwGhl4lt9unC9Vb9INnY9Z3/ZA3+FhASLaw=="],
+
     "entities": ["entities@4.5.0", "", {}, "sha512-V0hjH4dGPh9Ao5p0MoRY6BVqtwCjhz6vI5LT8AJ55H+4g9/4vbHx1I54fS0XuclLhDHArPQCiMjDxjaL8fPxhw=="],
+
+    "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
@@ -114,6 +132,8 @@
 
     "html-void-elements": ["html-void-elements@3.0.0", "", {}, "sha512-bEqo66MRXsUGxWHV5IP0PUiAWwoEjba4VCzg0LjFJBpchPaTfyfCKTG6bc5F8ucKec3q5y6qOdGyYTSBEvhCrg=="],
 
+    "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -124,11 +144,15 @@
 
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
+    "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
+
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
     "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
+
+    "launder": ["launder@1.7.1", "", { "dependencies": { "dayjs": "^1.11.7" } }, "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw=="],
 
     "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
 
@@ -192,17 +216,25 @@
 
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
+    "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
+    "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
+
+    "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
+
     "picomatch": ["picomatch@4.0.4", "", {}, "sha512-QP88BAKvMam/3NxH6vj2o21R6MjxZUAd6nlwAS/pnGvN9IVLocLHxGYIzFhg6fUQ+5th6P4dv4eW9jX3DSIj7A=="],
 
     "playwright": ["playwright@1.60.0", "", { "dependencies": { "playwright-core": "1.60.0" }, "optionalDependencies": { "fsevents": "2.3.2" }, "bin": { "playwright": "cli.js" } }, "sha512-hheHdokM8cdqCb0lcE3s+zT4t4W+vvjpGxsZlDnikarzx8tSzMebh3UiFtgqwFwnTnjYQcsyMF8ei2mCO/tpeA=="],
 
     "playwright-core": ["playwright-core@1.60.0", "", { "bin": { "playwright-core": "cli.js" } }, "sha512-9bW6zvX/m0lEbgTKJ6YppOKx8H3VOPBMOCFh2irXFOT4BbHgrx5hPjwJYLT40Lu+4qtD36qKc/Hn56StUW57IA=="],
+
+    "postcss": ["postcss@8.5.19", "", { "dependencies": { "nanoid": "^3.3.12", "picocolors": "^1.1.1", "source-map-js": "^1.2.1" } }, "sha512-Mz8SaolMd8nB+G13WkORcxQKHZ/NE4xXevtkJHVuG+guo9/wYKlIMTKAqGdEmYOXR2ijPjTYNHssizdaVSUNdQ=="],
 
     "preact": ["preact@11.0.0-beta.0", "", {}, "sha512-IcODoASASYwJ9kxz7+MJeiJhvLriwSb4y4mHIyxdgaRZp6kPUud7xytrk/6GZw8U3y6EFJaRb5wi9SrEK+8+lg=="],
 
@@ -224,11 +256,15 @@
 
     "regex-utilities": ["regex-utilities@2.3.0", "", {}, "sha512-8VhliFJAWRaUiVvREIiW2NXXTmHs4vMNnSzuJVhscgmGav3g9VDxLrQndI3dZZVVdp0ZO/5v0xmX516/7M9cng=="],
 
+    "sanitize-html": ["sanitize-html@2.17.6", "", { "dependencies": { "deepmerge": "^4.2.2", "escape-string-regexp": "^4.0.0", "htmlparser2": "^12.0.0", "is-plain-object": "^5.0.0", "launder": "^1.7.1", "parse-srcset": "^1.0.2", "postcss": "^8.3.11" } }, "sha512-M4bo9tfv1yfhQZZKkc6dL07ALrGJtfvNOuhX3hU9AVPR/uPQ+nKOJBqTYc7LfMQblTW04mtSWDJWEyLvygJsLA=="],
+
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
     "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
+
+    "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
 
@@ -264,8 +300,22 @@
 
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
 
+    "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
+
     "js-yaml/argparse": ["argparse@1.0.10", "", { "dependencies": { "sprintf-js": "~1.0.2" } }, "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg=="],
 
     "parse-entities/@types/unist": ["@types/unist@2.0.11", "", {}, "sha512-CmBKiL6NNo/OqgmMn95Fk9Whlp2mtvIv+KNpQKN2F4SjvrEesubTRWGYSg+BnWZOnlCaSTU1sMpsBOzgbYhnsA=="],
+
+    "sanitize-html/htmlparser2": ["htmlparser2@12.0.0", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "domutils": "^4.0.2", "entities": "^8.0.0" } }, "sha512-Tz7u1i95/g2x2jz81+x0FBVhBhY5aRTvD3tXXdFaljuNdzDLJ8UGNRrTcj2cgQvAg3iW/h77Fz15nLW0L0CrZw=="],
+
+    "sanitize-html/htmlparser2/domelementtype": ["domelementtype@3.0.0", "", {}, "sha512-umCQid3jKbDmVjx8jGaW7uUykm4DEUeyV21hPxNMo2nV955DhUThwqyOIDtreepP31hl84X7G5U9ZfsWvIB3Pg=="],
+
+    "sanitize-html/htmlparser2/domhandler": ["domhandler@6.0.1", "", { "dependencies": { "domelementtype": "^3.0.0" } }, "sha512-gYzvtM72ZtxQO0T048kd6HWSbbGCNOUwcnfQ01cqIJ4X2IYKFFHZ5mKvrQETcFXxsRObZulDaKmy//R7TPtsBg=="],
+
+    "sanitize-html/htmlparser2/domutils": ["domutils@4.0.2", "", { "dependencies": { "dom-serializer": "^3.0.0", "domelementtype": "^3.0.0", "domhandler": "^6.0.0" } }, "sha512-qI4JLRKnSzqFqr7hAlS5xQDusBCjKSEG4t4+7aNrIQMHBcsC2TGEhuyABJdYkgSewL57PNLYEiibY2iPKhKpaA=="],
+
+    "sanitize-html/htmlparser2/entities": ["entities@8.0.0", "", {}, "sha512-zwfzJecQ/Uej6tusMqwAqU/6KL2XaB2VZ2Jg54Je6ahNBGNH6Ek6g3jjNCF0fG9EWQKGZNddNjU5F1ZQn/sBnA=="],
+
+    "sanitize-html/htmlparser2/domutils/dom-serializer": ["dom-serializer@3.1.1", "", { "dependencies": { "domelementtype": "^3.0.0", "domhandler": "^6.0.0", "entities": "^8.0.0" } }, "sha512-4MEa38/QexBob6gFNwu+EGdWvhJ1OKuNwdYY3Y3NyeWDQfnGeDYQUDfIRzWu5B5gsv03so2Uxd28YC6zrsx3Lw=="],
   }
 }

--- a/package.json
+++ b/package.json
@@ -31,12 +31,14 @@
 		"gray-matter": "^4.0.3",
 		"markdown-it": "^14.2.0",
 		"picomatch": "^4.0.4",
+		"sanitize-html": "2.17.6",
 		"shiki": "^4.2.0"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",
 		"@types/markdown-it": "^14.1.2",
 		"@types/picomatch": "^4.0.3",
+		"@types/sanitize-html": "2.16.1",
 		"bun-types": "^1.3.14",
 		"markdownlint": "^0.40.0"
 	}

--- a/src/build.ts
+++ b/src/build.ts
@@ -884,8 +884,6 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
       continue;
     }
 
-    nextSources[relPath] = completeEntry;
-
     if (!completeEntry.prefix) {
       console.warn(`[publish] Skipped published doc without prefix: ${relPath}`);
       continue;
@@ -896,6 +894,7 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
       continue;
     }
 
+    nextSources[relPath] = completeEntry;
     docs.push(toDocRecord(sourcePath, relPath, completeEntry, newThreshold));
   }
 
@@ -1381,6 +1380,9 @@ async function copyOutputFileIfChanged(
 
 function assertSafeStaticOutputPath(relOutputPath: string): void {
   const normalized = path.posix.normalize(toPosixPath(relOutputPath));
+  if (normalized === ".") {
+    throw new Error(`[safety] Refusing static path that resolves to the vault root: ${relOutputPath}`);
+  }
   if (normalized === ".." || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
     throw new Error(`[safety] Refusing static output path outside the output directory: ${relOutputPath}`);
   }

--- a/src/build.ts
+++ b/src/build.ts
@@ -1714,6 +1714,7 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
   const cacheLocation = await resolveCacheLocation(options);
   const requestedOutputRoot = path.resolve(options.outDir);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
+  await removeLegacyCacheIndex();
   let hasOwnedOutput = false;
 
   try {
@@ -1733,7 +1734,6 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
     }
   }
 
-  await removeLegacyCacheIndex();
   if (hasOwnedOutput) {
     await fs.rm(requestedOutputRoot, { recursive: true, force: true });
   }

--- a/src/build.ts
+++ b/src/build.ts
@@ -22,7 +22,8 @@ import {
 } from "./utils";
 
 const CACHE_VERSION = 5;
-const CACHE_DIR_NAME = ".cache";
+const CACHE_ROOT_SEGMENTS = [".cache", "eiam"] as const;
+const CACHE_NAMESPACE_VERSION = 1;
 const CACHE_FILE_NAME = "build-index.json";
 const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
 const OUTPUT_MARKER_FORMAT = "everything-is-a-markdown-output";
@@ -62,12 +63,14 @@ interface BuildResult {
   skippedDocs: number;
 }
 
-function toContentFileName(id: string): string {
-  return `${makeHash(id)}.html`;
+interface CacheLocation {
+  rootDir: string;
+  namespaceDir: string;
+  cachePath: string;
 }
 
-function toCachePath(): string {
-  return path.join(process.cwd(), CACHE_DIR_NAME, CACHE_FILE_NAME);
+function toContentFileName(id: string): string {
+  return `${makeHash(id)}.html`;
 }
 
 function isSamePathOrAncestor(candidate: string, target: string): boolean {
@@ -99,6 +102,22 @@ async function toCanonicalPath(input: string): Promise<string> {
       existingAncestor = parent;
     }
   }
+}
+
+async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocation> {
+  const [vaultRoot, outputRoot] = await Promise.all([
+    toCanonicalPath(options.vaultDir),
+    toCanonicalPath(options.outDir),
+  ]);
+  const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}`)}`;
+  const rootDir = path.join(process.cwd(), ...CACHE_ROOT_SEGMENTS);
+  const namespaceDir = path.join(rootDir, namespace);
+
+  return {
+    rootDir,
+    namespaceDir,
+    cachePath: path.join(namespaceDir, CACHE_FILE_NAME),
+  };
 }
 
 async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<string> {
@@ -176,12 +195,10 @@ async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void>
   }
 }
 
-async function removeLegacyCacheIndex(): Promise<void> {
-  const cachePath = toCachePath();
-  await fs.rm(cachePath, { force: true });
-
+async function removeCacheNamespace(location: CacheLocation): Promise<void> {
+  await fs.rm(location.namespaceDir, { recursive: true, force: true });
   try {
-    await fs.rmdir(path.dirname(cachePath));
+    await fs.rmdir(location.rootDir);
   } catch (error) {
     const code = (error as NodeJS.ErrnoException).code;
     if (code !== "ENOENT" && code !== "ENOTEMPTY") {
@@ -1620,6 +1637,7 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
 }
 
 export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
+  const cacheLocation = await resolveCacheLocation(options);
   const requestedOutputRoot = path.resolve(options.outDir);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
 
@@ -1640,7 +1658,7 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
     }
   }
 
-  await removeLegacyCacheIndex();
+  await removeCacheNamespace(cacheLocation);
 }
 
 function buildWikiResolutionSignature(doc: DocRecord, lookup: WikiLookup): string {
@@ -1695,7 +1713,7 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
   await prepareOwnedOutputDirectory(options);
   await ensureDir(path.join(options.outDir, "content"));
 
-  const cachePath = toCachePath();
+  const { cachePath } = await resolveCacheLocation(options);
   const previousCache = await readCache(cachePath);
   const canReuseOutputs = await fileExists(path.join(options.outDir, "manifest.json"));
   const previousDocs = canReuseOutputs ? previousCache.docs : {};

--- a/src/build.ts
+++ b/src/build.ts
@@ -146,6 +146,27 @@ async function assertSafeCacheNamespace(namespaceDir: string): Promise<void> {
   }
 }
 
+async function assertSafeCacheIndex(cachePath: string): Promise<void> {
+  try {
+    const cacheStat = await fs.lstat(cachePath);
+    if (cacheStat.isSymbolicLink()) {
+      throw new Error(`[safety] Refusing symlinked cache index: ${cachePath}`);
+    }
+    if (!cacheStat.isFile()) {
+      throw new Error(`[safety] Cache index must be a real file: ${cachePath}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
+async function assertSafeCacheLocation(location: CacheLocation): Promise<void> {
+  await assertSafeCacheNamespace(location.namespaceDir);
+  await assertSafeCacheIndex(location.cachePath);
+}
+
 async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocation> {
   const [vaultRoot, outputRoot, rootDir] = await Promise.all([
     toCanonicalPath(options.vaultDir),
@@ -154,14 +175,15 @@ async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocatio
   ]);
   const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}\0${rootDir}`)}`;
   const namespaceDir = path.join(rootDir, namespace);
-  await assertSafeCacheNamespace(namespaceDir);
-
-  return {
+  const location = {
     namespace,
     rootDir,
     namespaceDir,
     cachePath: path.join(namespaceDir, CACHE_FILE_NAME),
   };
+  await assertSafeCacheLocation(location);
+
+  return location;
 }
 
 async function assertSafeOutputRoot(outDir: string, vaultDir: string, cacheRoot: string): Promise<string> {
@@ -285,7 +307,7 @@ async function removeLegacyCacheIndex(): Promise<void> {
 }
 
 async function removeCacheNamespace(location: CacheLocation): Promise<void> {
-  await assertSafeCacheNamespace(location.namespaceDir);
+  await assertSafeCacheLocation(location);
   await fs.rm(location.namespaceDir, { recursive: true, force: true });
   try {
     await fs.rmdir(location.rootDir);
@@ -437,7 +459,7 @@ function normalizeCachedSources(value: unknown): BuildCache["sources"] {
 }
 
 async function readCache(location: CacheLocation): Promise<BuildCache> {
-  await assertSafeCacheNamespace(location.namespaceDir);
+  await assertSafeCacheLocation(location);
   const file = Bun.file(location.cachePath);
   if (!(await file.exists())) {
     return createEmptyCache();
@@ -461,9 +483,9 @@ async function readCache(location: CacheLocation): Promise<BuildCache> {
 }
 
 async function writeCache(location: CacheLocation, cache: BuildCache): Promise<void> {
-  await assertSafeCacheNamespace(location.namespaceDir);
+  await assertSafeCacheLocation(location);
   await ensureDir(location.namespaceDir);
-  await assertSafeCacheNamespace(location.namespaceDir);
+  await assertSafeCacheLocation(location);
   await Bun.write(location.cachePath, `${JSON.stringify(cache, null, 2)}\n`);
 }
 
@@ -1341,6 +1363,7 @@ async function copyOutputFileIfChanged(
   relOutputPath: string,
   sourcePath: string,
 ): Promise<void> {
+  assertSafeStaticOutputPath(relOutputPath);
   const bytes = new Uint8Array(await Bun.file(sourcePath).arrayBuffer());
   const outputHash = crypto.createHash("sha1").update(bytes).digest("hex");
   context.nextHashes[relOutputPath] = outputHash;
@@ -1353,6 +1376,22 @@ async function copyOutputFileIfChanged(
 
   await ensureDir(path.dirname(outputPath));
   await Bun.write(outputPath, bytes);
+}
+
+function assertSafeStaticOutputPath(relOutputPath: string): void {
+  const normalized = path.posix.normalize(toPosixPath(relOutputPath));
+  if (normalized === ".." || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
+    throw new Error(`[safety] Refusing static output path outside the output directory: ${relOutputPath}`);
+  }
+  if (normalized === OUTPUT_MARKER_FILE_NAME || normalized.startsWith(`${OUTPUT_MARKER_FILE_NAME}/`)) {
+    throw new Error(`[safety] Refusing reserved static output path: ${relOutputPath}`);
+  }
+}
+
+function assertSafeStaticPaths(options: BuildOptions): void {
+  for (const staticPath of options.staticPaths) {
+    assertSafeStaticOutputPath(staticPath);
+  }
 }
 
 async function listFilesRecursively(baseDir: string): Promise<string[]> {
@@ -1847,6 +1886,7 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
+  assertSafeStaticPaths(options);
   const cacheLocation = await resolveCacheLocation(options);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
   await removeLegacyCacheIndex();

--- a/src/build.ts
+++ b/src/build.ts
@@ -130,6 +130,22 @@ async function resolveCacheRoot(): Promise<string> {
   return candidate;
 }
 
+async function assertSafeCacheNamespace(namespaceDir: string): Promise<void> {
+  try {
+    const namespaceStat = await fs.lstat(namespaceDir);
+    if (namespaceStat.isSymbolicLink()) {
+      throw new Error(`[safety] Refusing symlinked cache namespace: ${namespaceDir}`);
+    }
+    if (!namespaceStat.isDirectory()) {
+      throw new Error(`[safety] Cache namespace must be a real directory: ${namespaceDir}`);
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+}
+
 async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocation> {
   const [vaultRoot, outputRoot, rootDir] = await Promise.all([
     toCanonicalPath(options.vaultDir),
@@ -138,6 +154,7 @@ async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocatio
   ]);
   const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}\0${rootDir}`)}`;
   const namespaceDir = path.join(rootDir, namespace);
+  await assertSafeCacheNamespace(namespaceDir);
 
   return {
     namespace,
@@ -202,6 +219,21 @@ async function prepareOwnedOutputDirectory(
   cacheLocation: CacheLocation,
   outputRoot: string,
 ): Promise<void> {
+  await assertClaimableOutputDirectory(options, cacheLocation, outputRoot);
+
+  const requestedOutputRoot = path.resolve(options.outDir);
+  await fs.mkdir(requestedOutputRoot, { recursive: true });
+
+  if (!(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
+    await writeOutputMarker(outputRoot, cacheLocation.namespace);
+  }
+}
+
+async function assertClaimableOutputDirectory(
+  options: BuildOptions,
+  cacheLocation: CacheLocation,
+  outputRoot: string,
+): Promise<void> {
   const requestedOutputRoot = path.resolve(options.outDir);
 
   try {
@@ -220,11 +252,6 @@ async function prepareOwnedOutputDirectory(
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
-    await fs.mkdir(requestedOutputRoot, { recursive: true });
-  }
-
-  if (!(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
-    await writeOutputMarker(outputRoot, cacheLocation.namespace);
   }
 }
 
@@ -258,6 +285,7 @@ async function removeLegacyCacheIndex(): Promise<void> {
 }
 
 async function removeCacheNamespace(location: CacheLocation): Promise<void> {
+  await assertSafeCacheNamespace(location.namespaceDir);
   await fs.rm(location.namespaceDir, { recursive: true, force: true });
   try {
     await fs.rmdir(location.rootDir);
@@ -408,8 +436,9 @@ function normalizeCachedSources(value: unknown): BuildCache["sources"] {
   return normalized;
 }
 
-async function readCache(cachePath: string): Promise<BuildCache> {
-  const file = Bun.file(cachePath);
+async function readCache(location: CacheLocation): Promise<BuildCache> {
+  await assertSafeCacheNamespace(location.namespaceDir);
+  const file = Bun.file(location.cachePath);
   if (!(await file.exists())) {
     return createEmptyCache();
   }
@@ -431,9 +460,11 @@ async function readCache(cachePath: string): Promise<BuildCache> {
   }
 }
 
-async function writeCache(cachePath: string, cache: BuildCache): Promise<void> {
-  await ensureDir(path.dirname(cachePath));
-  await Bun.write(cachePath, `${JSON.stringify(cache, null, 2)}\n`);
+async function writeCache(location: CacheLocation, cache: BuildCache): Promise<void> {
+  await assertSafeCacheNamespace(location.namespaceDir);
+  await ensureDir(location.namespaceDir);
+  await assertSafeCacheNamespace(location.namespaceDir);
+  await Bun.write(location.cachePath, `${JSON.stringify(cache, null, 2)}\n`);
 }
 
 async function walkMarkdownFiles(
@@ -1819,16 +1850,17 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
   const cacheLocation = await resolveCacheLocation(options);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
   await removeLegacyCacheIndex();
-  await prepareOwnedOutputDirectory(options, cacheLocation, outputRoot);
-  await ensureDir(path.join(options.outDir, "content"));
+  await assertClaimableOutputDirectory(options, cacheLocation, outputRoot);
 
-  const { cachePath } = cacheLocation;
-  const previousCache = await readCache(cachePath);
+  const previousCache = await readCache(cacheLocation);
   const canReuseOutputs = await fileExists(path.join(options.outDir, "manifest.json"));
   const previousDocs = canReuseOutputs ? previousCache.docs : {};
   const previousOutputHashes = canReuseOutputs ? previousCache.outputHashes : {};
   const { docs, nextSources } = await readPublishedDocs(options, previousCache.sources);
   docs.sort((a, b) => a.relNoExt.localeCompare(b.relNoExt, "ko-KR"));
+
+  await prepareOwnedOutputDirectory(options, cacheLocation, outputRoot);
+  await ensureDir(path.join(options.outDir, "content"));
 
   await cleanRemovedOutputs(options.outDir, previousCache, docs);
   const outputContext: OutputWriteContext = {
@@ -1908,7 +1940,7 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
   await writeSeoArtifacts(outputContext, docs, options);
   await removeStaleOutputs(outputContext);
 
-  await writeCache(cachePath, nextCache);
+  await writeCache(cacheLocation, nextCache);
 
   return {
     totalDocs: docs.length,

--- a/src/build.ts
+++ b/src/build.ts
@@ -196,7 +196,8 @@ async function assertSafeOutputRoot(outDir: string, vaultDir: string, cacheRoot:
     outputRoot === filesystemRoot ||
     isSamePathOrAncestor(outputRoot, cwd) ||
     isSamePathOrAncestor(outputRoot, vaultRoot) ||
-    isSamePathOrAncestor(outputRoot, cacheRoot)
+    isSamePathOrAncestor(outputRoot, cacheRoot) ||
+    isSamePathOrAncestor(cacheRoot, outputRoot)
   ) {
     throw new Error(
       `[safety] Refusing dangerous output directory: ${outputRoot}. Choose a dedicated child directory.`,
@@ -1886,10 +1887,10 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
-  assertSafeStaticPaths(options);
   const cacheLocation = await resolveCacheLocation(options);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
   await removeLegacyCacheIndex();
+  assertSafeStaticPaths(options);
   await assertClaimableOutputDirectory(options, cacheLocation, outputRoot);
 
   const previousCache = await readCache(cacheLocation);

--- a/src/build.ts
+++ b/src/build.ts
@@ -1553,7 +1553,7 @@ async function writeShellPages(
   await writeOutputIfChanged(
     context,
     "404.html",
-    render404Html(buildAppShellAssetsForOutput("404.html", runtimeAssets)),
+    render404Html(buildAppShellAssetsForOutput("404.html", runtimeAssets), toPathWithBase("/", pathBase)),
   );
 
   for (const doc of docs) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -27,7 +27,7 @@ const CACHE_NAMESPACE_VERSION = 1;
 const CACHE_FILE_NAME = "build-index.json";
 const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
 const OUTPUT_MARKER_FORMAT = "everything-is-a-markdown-output";
-const OUTPUT_MARKER_VERSION = 1;
+const OUTPUT_MARKER_VERSION = 2;
 const DEFAULT_BRANCH = "dev";
 const DEFAULT_SITE_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 const DEFAULT_SITE_TITLE = "File-System Blog";
@@ -64,6 +64,7 @@ interface BuildResult {
 }
 
 interface CacheLocation {
+  namespace: string;
   rootDir: string;
   namespaceDir: string;
   cachePath: string;
@@ -114,6 +115,7 @@ async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocatio
   const namespaceDir = path.join(rootDir, namespace);
 
   return {
+    namespace,
     rootDir,
     namespaceDir,
     cachePath: path.join(namespaceDir, CACHE_FILE_NAME),
@@ -139,7 +141,7 @@ async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<s
   return outputRoot;
 }
 
-async function hasValidOutputMarker(outputRoot: string): Promise<boolean> {
+async function hasValidOutputMarker(outputRoot: string, cacheNamespace: string): Promise<boolean> {
   const markerPath = path.join(outputRoot, OUTPUT_MARKER_FILE_NAME);
 
   try {
@@ -152,22 +154,24 @@ async function hasValidOutputMarker(outputRoot: string): Promise<boolean> {
     return (
       isRecord(parsed) &&
       parsed.format === OUTPUT_MARKER_FORMAT &&
-      parsed.version === OUTPUT_MARKER_VERSION
+      parsed.version === OUTPUT_MARKER_VERSION &&
+      parsed.cacheNamespace === cacheNamespace
     );
   } catch {
     return false;
   }
 }
 
-async function writeOutputMarker(outputRoot: string): Promise<void> {
+async function writeOutputMarker(outputRoot: string, cacheNamespace: string): Promise<void> {
   const marker = {
     format: OUTPUT_MARKER_FORMAT,
     version: OUTPUT_MARKER_VERSION,
+    cacheNamespace,
   };
   await Bun.write(path.join(outputRoot, OUTPUT_MARKER_FILE_NAME), `${JSON.stringify(marker, null, 2)}\n`);
 }
 
-async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void> {
+async function prepareOwnedOutputDirectory(options: BuildOptions, cacheNamespace: string): Promise<void> {
   const requestedOutputRoot = path.resolve(options.outDir);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
 
@@ -178,9 +182,9 @@ async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void>
     }
 
     const entries = await fs.readdir(outputRoot);
-    if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot))) {
+    if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot, cacheNamespace))) {
       throw new Error(
-        `[safety] Refusing non-empty output directory without a valid ${OUTPUT_MARKER_FILE_NAME}: ${outputRoot}`,
+        `[safety] Refusing non-empty output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output pair: ${outputRoot}`,
       );
     }
   } catch (error) {
@@ -190,8 +194,8 @@ async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void>
     await fs.mkdir(requestedOutputRoot, { recursive: true });
   }
 
-  if (!(await hasValidOutputMarker(outputRoot))) {
-    await writeOutputMarker(outputRoot);
+  if (!(await hasValidOutputMarker(outputRoot, cacheNamespace))) {
+    await writeOutputMarker(outputRoot, cacheNamespace);
   }
 }
 
@@ -1654,9 +1658,9 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
     if (!outputStat.isDirectory() || outputStat.isSymbolicLink()) {
       throw new Error(`[safety] Refusing to clean non-directory output path: ${outputRoot}`);
     }
-    if (!(await hasValidOutputMarker(outputRoot))) {
+    if (!(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
       throw new Error(
-        `[safety] Refusing to clean output directory without a valid ${OUTPUT_MARKER_FILE_NAME}: ${outputRoot}`,
+        `[safety] Refusing to clean output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output pair: ${outputRoot}`,
       );
     }
     await fs.rm(requestedOutputRoot, { recursive: true, force: true });
@@ -1718,10 +1722,11 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
-  await prepareOwnedOutputDirectory(options);
+  const cacheLocation = await resolveCacheLocation(options);
+  await prepareOwnedOutputDirectory(options, cacheLocation.namespace);
   await ensureDir(path.join(options.outDir, "content"));
 
-  const { cachePath } = await resolveCacheLocation(options);
+  const { cachePath } = cacheLocation;
   const previousCache = await readCache(cachePath);
   const canReuseOutputs = await fileExists(path.join(options.outDir, "manifest.json"));
   const previousDocs = canReuseOutputs ? previousCache.docs : {};

--- a/src/build.ts
+++ b/src/build.ts
@@ -21,7 +21,7 @@ import {
   toDocId,
 } from "./utils";
 
-const CACHE_VERSION = 4;
+const CACHE_VERSION = 5;
 const CACHE_DIR_NAME = ".cache";
 const CACHE_FILE_NAME = "build-index.json";
 const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
@@ -708,11 +708,11 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
       mtimeMs: stat.mtimeMs,
       size: stat.size,
     };
-    nextSources[relPath] = completeEntry;
-
     if (!completeEntry.publish || completeEntry.draft) {
       continue;
     }
+
+    nextSources[relPath] = completeEntry;
 
     if (!completeEntry.prefix) {
       console.warn(`[publish] Skipped published doc without prefix: ${relPath}`);

--- a/src/build.ts
+++ b/src/build.ts
@@ -21,7 +21,7 @@ import {
   toDocId,
 } from "./utils";
 
-const CACHE_VERSION = 5;
+const CACHE_VERSION = 6;
 const CACHE_ROOT_SEGMENTS = [".cache", "eiam"] as const;
 const CACHE_NAMESPACE_VERSION = 1;
 const CACHE_FILE_NAME = "build-index.json";
@@ -630,11 +630,19 @@ function extractWikiTargets(markdown: string): string[] {
   return Array.from(targets).sort((left, right) => left.localeCompare(right, "ko-KR"));
 }
 
-function toCachedSourceEntry(raw: string, parsed: matter.GrayMatterFile<string>): CachedSourceEntry {
+function makeSourceFingerprint(raw: string): string {
+  return crypto.createHash("sha256").update(raw).digest("hex");
+}
+
+function toCachedSourceEntry(
+  raw: string,
+  rawHash: string,
+  parsed: matter.GrayMatterFile<string>,
+): CachedSourceEntry {
   return {
     mtimeMs: 0,
     size: 0,
-    rawHash: makeHash(raw),
+    rawHash,
     publish: parsed.data.publish === true,
     draft: parsed.data.draft === true,
     title: typeof parsed.data.title === "string" && parsed.data.title.trim().length > 0 ? parsed.data.title.trim() : undefined,
@@ -702,14 +710,14 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
 
   for (const { sourcePath, relPath, stat } of fileEntries) {
     const prev = previousSources[relPath];
+    const raw = await Bun.file(sourcePath).text();
+    const rawHash = makeSourceFingerprint(raw);
 
     let entry: CachedSourceEntry;
-    const canReuse = !!prev && prev.mtimeMs === stat.mtimeMs && prev.size === stat.size;
+    const canReuse = !!prev && prev.rawHash === rawHash;
     if (canReuse) {
       entry = prev;
     } else {
-      const raw = await Bun.file(sourcePath).text();
-
       let parsed: matter.GrayMatterFile<string>;
       try {
         parsed = matter(raw);
@@ -717,7 +725,7 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
         throw new Error(`Frontmatter parse failed: ${relPath}\n${(error as Error).message}`);
       }
 
-      entry = toCachedSourceEntry(raw, parsed);
+      entry = toCachedSourceEntry(raw, rawHash, parsed);
     }
 
     const completeEntry: CachedSourceEntry = {

--- a/src/build.ts
+++ b/src/build.ts
@@ -1739,6 +1739,7 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
         options.shikiTheme,
         options.imagePolicy,
         options.wikilinks ? "wikilinks-on" : "wikilinks-off",
+        options.allowUnsafeHtml ? "unsafe-html-v1" : "safe-html-v1",
         wikiSignature,
       ].join("::"),
     );

--- a/src/build.ts
+++ b/src/build.ts
@@ -23,8 +23,9 @@ import {
 
 const CACHE_VERSION = 6;
 const CACHE_ROOT_SEGMENTS = [".cache", "eiam"] as const;
-const CACHE_NAMESPACE_VERSION = 1;
+const CACHE_NAMESPACE_VERSION = 2;
 const CACHE_FILE_NAME = "build-index.json";
+const LEGACY_CACHE_PATH_SEGMENTS = [".cache", CACHE_FILE_NAME] as const;
 const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
 const OUTPUT_MARKER_FORMAT = "everything-is-a-markdown-output";
 const OUTPUT_MARKER_VERSION = 2;
@@ -106,12 +107,12 @@ async function toCanonicalPath(input: string): Promise<string> {
 }
 
 async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocation> {
-  const [vaultRoot, outputRoot] = await Promise.all([
+  const [vaultRoot, outputRoot, rootDir] = await Promise.all([
     toCanonicalPath(options.vaultDir),
     toCanonicalPath(options.outDir),
+    toCanonicalPath(path.join(process.cwd(), ...CACHE_ROOT_SEGMENTS)),
   ]);
-  const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}`)}`;
-  const rootDir = path.join(process.cwd(), ...CACHE_ROOT_SEGMENTS);
+  const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}\0${rootDir}`)}`;
   const namespaceDir = path.join(rootDir, namespace);
 
   return {
@@ -184,7 +185,7 @@ async function prepareOwnedOutputDirectory(options: BuildOptions, cacheNamespace
     const entries = await fs.readdir(outputRoot);
     if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot, cacheNamespace))) {
       throw new Error(
-        `[safety] Refusing non-empty output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output pair: ${outputRoot}`,
+        `[safety] Refusing non-empty output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output/cache-root context: ${outputRoot}`,
       );
     }
   } catch (error) {
@@ -196,6 +197,21 @@ async function prepareOwnedOutputDirectory(options: BuildOptions, cacheNamespace
 
   if (!(await hasValidOutputMarker(outputRoot, cacheNamespace))) {
     await writeOutputMarker(outputRoot, cacheNamespace);
+  }
+}
+
+async function removeLegacyCacheIndex(): Promise<void> {
+  const legacyCachePath = path.join(process.cwd(), ...LEGACY_CACHE_PATH_SEGMENTS);
+
+  try {
+    const legacyCacheStat = await fs.lstat(legacyCachePath);
+    if (legacyCacheStat.isFile() || legacyCacheStat.isSymbolicLink()) {
+      await fs.rm(legacyCachePath, { force: true });
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
   }
 }
 
@@ -1649,6 +1665,7 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
 }
 
 export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
+  await removeLegacyCacheIndex();
   const cacheLocation = await resolveCacheLocation(options);
   const requestedOutputRoot = path.resolve(options.outDir);
   const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
@@ -1660,7 +1677,7 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
     }
     if (!(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
       throw new Error(
-        `[safety] Refusing to clean output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output pair: ${outputRoot}`,
+        `[safety] Refusing to clean output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output/cache-root context: ${outputRoot}`,
       );
     }
     await fs.rm(requestedOutputRoot, { recursive: true, force: true });
@@ -1722,6 +1739,7 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
+  await removeLegacyCacheIndex();
   const cacheLocation = await resolveCacheLocation(options);
   await prepareOwnedOutputDirectory(options, cacheLocation.namespace);
   await ensureDir(path.join(options.outDir, "content"));

--- a/src/build.ts
+++ b/src/build.ts
@@ -123,7 +123,7 @@ async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocatio
   };
 }
 
-async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<string> {
+async function assertSafeOutputRoot(outDir: string, vaultDir: string, cacheRoot: string): Promise<string> {
   const outputRoot = await toCanonicalPath(outDir);
   const filesystemRoot = path.parse(outputRoot).root;
   const cwd = await toCanonicalPath(process.cwd());
@@ -132,7 +132,8 @@ async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<s
   if (
     outputRoot === filesystemRoot ||
     isSamePathOrAncestor(outputRoot, cwd) ||
-    isSamePathOrAncestor(outputRoot, vaultRoot)
+    isSamePathOrAncestor(outputRoot, vaultRoot) ||
+    isSamePathOrAncestor(outputRoot, cacheRoot)
   ) {
     throw new Error(
       `[safety] Refusing dangerous output directory: ${outputRoot}. Choose a dedicated child directory.`,
@@ -172,9 +173,9 @@ async function writeOutputMarker(outputRoot: string, cacheNamespace: string): Pr
   await Bun.write(path.join(outputRoot, OUTPUT_MARKER_FILE_NAME), `${JSON.stringify(marker, null, 2)}\n`);
 }
 
-async function prepareOwnedOutputDirectory(options: BuildOptions, cacheNamespace: string): Promise<void> {
+async function prepareOwnedOutputDirectory(options: BuildOptions, cacheLocation: CacheLocation): Promise<void> {
   const requestedOutputRoot = path.resolve(options.outDir);
-  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
 
   try {
     const outputStat = await fs.lstat(requestedOutputRoot);
@@ -183,7 +184,7 @@ async function prepareOwnedOutputDirectory(options: BuildOptions, cacheNamespace
     }
 
     const entries = await fs.readdir(outputRoot);
-    if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot, cacheNamespace))) {
+    if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
       throw new Error(
         `[safety] Refusing non-empty output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output/cache-root context: ${outputRoot}`,
       );
@@ -195,8 +196,8 @@ async function prepareOwnedOutputDirectory(options: BuildOptions, cacheNamespace
     await fs.mkdir(requestedOutputRoot, { recursive: true });
   }
 
-  if (!(await hasValidOutputMarker(outputRoot, cacheNamespace))) {
-    await writeOutputMarker(outputRoot, cacheNamespace);
+  if (!(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
+    await writeOutputMarker(outputRoot, cacheLocation.namespace);
   }
 }
 
@@ -205,7 +206,21 @@ async function removeLegacyCacheIndex(): Promise<void> {
 
   try {
     const legacyCacheStat = await fs.lstat(legacyCachePath);
-    if (legacyCacheStat.isFile() || legacyCacheStat.isSymbolicLink()) {
+    if (!legacyCacheStat.isFile() || legacyCacheStat.isSymbolicLink()) {
+      return;
+    }
+
+    let parsed: unknown;
+    try {
+      parsed = JSON.parse(await fs.readFile(legacyCachePath, "utf8")) as unknown;
+    } catch (error) {
+      if (error instanceof SyntaxError) {
+        return;
+      }
+      throw error;
+    }
+
+    if (isLegacyEiamCacheIndex(parsed)) {
       await fs.rm(legacyCachePath, { force: true });
     }
   } catch (error) {
@@ -233,6 +248,37 @@ function createEmptyCache(): BuildCache {
 
 function isRecord(value: unknown): value is Record<string, unknown> {
   return typeof value === "object" && value !== null;
+}
+
+function hasExactRecordKeys(value: Record<string, unknown>, expectedKeys: string[]): boolean {
+  const actualKeys = Object.keys(value).sort();
+  return (
+    actualKeys.length === expectedKeys.length && actualKeys.every((key, index) => key === expectedKeys[index])
+  );
+}
+
+function isPlainRecord(value: unknown): value is Record<string, unknown> {
+  return isRecord(value) && !Array.isArray(value);
+}
+
+function isLegacyEiamCacheIndex(value: unknown): boolean {
+  if (!isPlainRecord(value) || !Number.isInteger(value.version)) {
+    return false;
+  }
+
+  if (value.version === 1) {
+    return hasExactRecordKeys(value, ["docs", "version"]) && isPlainRecord(value.docs);
+  }
+
+  return (
+    typeof value.version === "number" &&
+    value.version >= 2 &&
+    value.version <= 5 &&
+    hasExactRecordKeys(value, ["docs", "outputHashes", "sources", "version"]) &&
+    isPlainRecord(value.sources) &&
+    isPlainRecord(value.docs) &&
+    isPlainRecord(value.outputHashes)
+  );
 }
 
 function normalizeCachedDocIndex(value: unknown): BuildCache["docs"] {
@@ -1665,10 +1711,10 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
 }
 
 export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
-  await removeLegacyCacheIndex();
   const cacheLocation = await resolveCacheLocation(options);
   const requestedOutputRoot = path.resolve(options.outDir);
-  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
+  let hasOwnedOutput = false;
 
   try {
     const outputStat = await fs.lstat(requestedOutputRoot);
@@ -1680,13 +1726,17 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
         `[safety] Refusing to clean output directory without a matching ${OUTPUT_MARKER_FILE_NAME} for the requested vault/output/cache-root context: ${outputRoot}`,
       );
     }
-    await fs.rm(requestedOutputRoot, { recursive: true, force: true });
+    hasOwnedOutput = true;
   } catch (error) {
     if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
       throw error;
     }
   }
 
+  await removeLegacyCacheIndex();
+  if (hasOwnedOutput) {
+    await fs.rm(requestedOutputRoot, { recursive: true, force: true });
+  }
   await removeCacheNamespace(cacheLocation);
 }
 
@@ -1739,9 +1789,9 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
-  await removeLegacyCacheIndex();
   const cacheLocation = await resolveCacheLocation(options);
-  await prepareOwnedOutputDirectory(options, cacheLocation.namespace);
+  await prepareOwnedOutputDirectory(options, cacheLocation);
+  await removeLegacyCacheIndex();
   await ensureDir(path.join(options.outDir, "content"));
 
   const { cachePath } = cacheLocation;

--- a/src/build.ts
+++ b/src/build.ts
@@ -106,11 +106,35 @@ async function toCanonicalPath(input: string): Promise<string> {
   }
 }
 
+async function resolveCacheRoot(): Promise<string> {
+  const canonicalCwd = await toCanonicalPath(process.cwd());
+  let candidate = canonicalCwd;
+
+  for (const segment of CACHE_ROOT_SEGMENTS) {
+    candidate = path.join(candidate, segment);
+    try {
+      const candidateStat = await fs.lstat(candidate);
+      if (candidateStat.isSymbolicLink()) {
+        throw new Error(`[safety] Refusing symlinked cache path: ${candidate}`);
+      }
+      if (!candidateStat.isDirectory()) {
+        throw new Error(`[safety] Cache path component must be a real directory: ${candidate}`);
+      }
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+    }
+  }
+
+  return candidate;
+}
+
 async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocation> {
   const [vaultRoot, outputRoot, rootDir] = await Promise.all([
     toCanonicalPath(options.vaultDir),
     toCanonicalPath(options.outDir),
-    toCanonicalPath(path.join(process.cwd(), ...CACHE_ROOT_SEGMENTS)),
+    resolveCacheRoot(),
   ]);
   const namespace = `v${CACHE_NAMESPACE_VERSION}-${makeHash(`${vaultRoot}\0${outputRoot}\0${rootDir}`)}`;
   const namespaceDir = path.join(rootDir, namespace);
@@ -173,9 +197,12 @@ async function writeOutputMarker(outputRoot: string, cacheNamespace: string): Pr
   await Bun.write(path.join(outputRoot, OUTPUT_MARKER_FILE_NAME), `${JSON.stringify(marker, null, 2)}\n`);
 }
 
-async function prepareOwnedOutputDirectory(options: BuildOptions, cacheLocation: CacheLocation): Promise<void> {
+async function prepareOwnedOutputDirectory(
+  options: BuildOptions,
+  cacheLocation: CacheLocation,
+  outputRoot: string,
+): Promise<void> {
   const requestedOutputRoot = path.resolve(options.outDir);
-  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
 
   try {
     const outputStat = await fs.lstat(requestedOutputRoot);
@@ -1790,8 +1817,9 @@ function buildBacklinksByDocId(
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
   const cacheLocation = await resolveCacheLocation(options);
-  await prepareOwnedOutputDirectory(options, cacheLocation);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
   await removeLegacyCacheIndex();
+  await prepareOwnedOutputDirectory(options, cacheLocation, outputRoot);
   await ensureDir(path.join(options.outDir, "content"));
 
   const { cachePath } = cacheLocation;

--- a/src/build.ts
+++ b/src/build.ts
@@ -24,6 +24,9 @@ import {
 const CACHE_VERSION = 4;
 const CACHE_DIR_NAME = ".cache";
 const CACHE_FILE_NAME = "build-index.json";
+const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
+const OUTPUT_MARKER_FORMAT = "everything-is-a-markdown-output";
+const OUTPUT_MARKER_VERSION = 1;
 const DEFAULT_BRANCH = "dev";
 const DEFAULT_SITE_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 const DEFAULT_SITE_TITLE = "File-System Blog";
@@ -65,6 +68,126 @@ function toContentFileName(id: string): string {
 
 function toCachePath(): string {
   return path.join(process.cwd(), CACHE_DIR_NAME, CACHE_FILE_NAME);
+}
+
+function isSamePathOrAncestor(candidate: string, target: string): boolean {
+  const relative = path.relative(candidate, target);
+  return (
+    relative === "" ||
+    (!path.isAbsolute(relative) && relative !== ".." && !relative.startsWith(`..${path.sep}`))
+  );
+}
+
+async function toCanonicalPath(input: string): Promise<string> {
+  let existingAncestor = path.resolve(input);
+  const missingSegments: string[] = [];
+
+  while (true) {
+    try {
+      const canonicalAncestor = await fs.realpath(existingAncestor);
+      return path.join(canonicalAncestor, ...missingSegments);
+    } catch (error) {
+      if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+        throw error;
+      }
+
+      const parent = path.dirname(existingAncestor);
+      if (parent === existingAncestor) {
+        return path.resolve(input);
+      }
+      missingSegments.unshift(path.basename(existingAncestor));
+      existingAncestor = parent;
+    }
+  }
+}
+
+async function assertSafeOutputRoot(outDir: string, vaultDir: string): Promise<string> {
+  const outputRoot = await toCanonicalPath(outDir);
+  const filesystemRoot = path.parse(outputRoot).root;
+  const cwd = await toCanonicalPath(process.cwd());
+  const vaultRoot = await toCanonicalPath(vaultDir);
+
+  if (
+    outputRoot === filesystemRoot ||
+    isSamePathOrAncestor(outputRoot, cwd) ||
+    isSamePathOrAncestor(outputRoot, vaultRoot)
+  ) {
+    throw new Error(
+      `[safety] Refusing dangerous output directory: ${outputRoot}. Choose a dedicated child directory.`,
+    );
+  }
+
+  return outputRoot;
+}
+
+async function hasValidOutputMarker(outputRoot: string): Promise<boolean> {
+  const markerPath = path.join(outputRoot, OUTPUT_MARKER_FILE_NAME);
+
+  try {
+    const markerStat = await fs.lstat(markerPath);
+    if (!markerStat.isFile() || markerStat.isSymbolicLink()) {
+      return false;
+    }
+
+    const parsed = (await Bun.file(markerPath).json()) as unknown;
+    return (
+      isRecord(parsed) &&
+      parsed.format === OUTPUT_MARKER_FORMAT &&
+      parsed.version === OUTPUT_MARKER_VERSION
+    );
+  } catch {
+    return false;
+  }
+}
+
+async function writeOutputMarker(outputRoot: string): Promise<void> {
+  const marker = {
+    format: OUTPUT_MARKER_FORMAT,
+    version: OUTPUT_MARKER_VERSION,
+  };
+  await Bun.write(path.join(outputRoot, OUTPUT_MARKER_FILE_NAME), `${JSON.stringify(marker, null, 2)}\n`);
+}
+
+async function prepareOwnedOutputDirectory(options: BuildOptions): Promise<void> {
+  const requestedOutputRoot = path.resolve(options.outDir);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
+
+  try {
+    const outputStat = await fs.lstat(requestedOutputRoot);
+    if (!outputStat.isDirectory() || outputStat.isSymbolicLink()) {
+      throw new Error(`[safety] Output path must be a real directory: ${outputRoot}`);
+    }
+
+    const entries = await fs.readdir(outputRoot);
+    if (entries.length > 0 && !(await hasValidOutputMarker(outputRoot))) {
+      throw new Error(
+        `[safety] Refusing non-empty output directory without a valid ${OUTPUT_MARKER_FILE_NAME}: ${outputRoot}`,
+      );
+    }
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+    await fs.mkdir(requestedOutputRoot, { recursive: true });
+  }
+
+  if (!(await hasValidOutputMarker(outputRoot))) {
+    await writeOutputMarker(outputRoot);
+  }
+}
+
+async function removeLegacyCacheIndex(): Promise<void> {
+  const cachePath = toCachePath();
+  await fs.rm(cachePath, { force: true });
+
+  try {
+    await fs.rmdir(path.dirname(cachePath));
+  } catch (error) {
+    const code = (error as NodeJS.ErrnoException).code;
+    if (code !== "ENOENT" && code !== "ENOTEMPTY") {
+      throw error;
+    }
+  }
 }
 
 function createEmptyCache(): BuildCache {
@@ -1496,10 +1619,28 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
   }
 }
 
-export async function cleanBuildArtifacts(outDir: string): Promise<void> {
-  const cachePath = toCachePath();
-  await fs.rm(outDir, { recursive: true, force: true });
-  await fs.rm(path.dirname(cachePath), { recursive: true, force: true });
+export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
+  const requestedOutputRoot = path.resolve(options.outDir);
+  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir);
+
+  try {
+    const outputStat = await fs.lstat(requestedOutputRoot);
+    if (!outputStat.isDirectory() || outputStat.isSymbolicLink()) {
+      throw new Error(`[safety] Refusing to clean non-directory output path: ${outputRoot}`);
+    }
+    if (!(await hasValidOutputMarker(outputRoot))) {
+      throw new Error(
+        `[safety] Refusing to clean output directory without a valid ${OUTPUT_MARKER_FILE_NAME}: ${outputRoot}`,
+      );
+    }
+    await fs.rm(requestedOutputRoot, { recursive: true, force: true });
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code !== "ENOENT") {
+      throw error;
+    }
+  }
+
+  await removeLegacyCacheIndex();
 }
 
 function buildWikiResolutionSignature(doc: DocRecord, lookup: WikiLookup): string {
@@ -1551,7 +1692,7 @@ function buildBacklinksByDocId(
 }
 
 export async function buildSite(options: BuildOptions): Promise<BuildResult> {
-  await ensureDir(options.outDir);
+  await prepareOwnedOutputDirectory(options);
   await ensureDir(path.join(options.outDir, "content"));
 
   const cachePath = toCachePath();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -17,7 +17,7 @@ async function main(): Promise<void> {
 
   if (cli.command === "clean") {
     await cleanBuildArtifacts(buildOptions);
-    console.log(`[clean] removed ${buildOptions.outDir} and EIAM cache index`);
+    console.log(`[clean] removed ${buildOptions.outDir} and matching EIAM cache namespace`);
     return;
   }
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -16,8 +16,8 @@ async function main(): Promise<void> {
   const buildOptions = resolveBuildOptions(cli, userConfig, pinnedMenu);
 
   if (cli.command === "clean") {
-    await cleanBuildArtifacts(buildOptions.outDir);
-    console.log(`[clean] removed ${buildOptions.outDir} and .cache`);
+    await cleanBuildArtifacts(buildOptions);
+    console.log(`[clean] removed ${buildOptions.outDir} and EIAM cache index`);
     return;
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -73,6 +73,27 @@ function normalizeMermaidTheme(value: unknown): string {
   return normalized;
 }
 
+function readOptionValue(
+  args: string[],
+  optionIndex: number,
+  option: string,
+  allowNegativeNumber = false,
+): string {
+  const value = args[optionIndex + 1];
+  const isFlagShaped = !value || value.startsWith("-");
+  const isNegativeNumber =
+    allowNegativeNumber &&
+    typeof value === "string" &&
+    value.startsWith("-") &&
+    !Number.isNaN(Number(value));
+
+  if (!value || (isFlagShaped && !isNegativeNumber)) {
+    throw new Error(`[cli] Missing value for ${option}`);
+  }
+
+  return value;
+}
+
 export function parseCliArgs(argv: string[]): CliArgs {
   const [first] = argv;
   const command = first === "build" || first === "dev" || first === "clean" ? first : "build";
@@ -91,31 +112,38 @@ export function parseCliArgs(argv: string[]): CliArgs {
       continue;
     }
     if (token === "--vault") {
-      parsed.vaultDir = rest[++i];
+      parsed.vaultDir = readOptionValue(rest, i, token);
+      i += 1;
       continue;
     }
     if (token === "--out") {
-      parsed.outDir = rest[++i];
+      parsed.outDir = readOptionValue(rest, i, token);
+      i += 1;
       continue;
     }
     if (token === "--exclude") {
-      parsed.exclude.push(rest[++i]);
+      parsed.exclude.push(readOptionValue(rest, i, token));
+      i += 1;
       continue;
     }
     if (token === "--new-within-days") {
-      parsed.newWithinDays = Number(rest[++i]);
+      parsed.newWithinDays = Number(readOptionValue(rest, i, token, true));
+      i += 1;
       continue;
     }
     if (token === "--recent-limit") {
-      parsed.recentLimit = Number(rest[++i]);
+      parsed.recentLimit = Number(readOptionValue(rest, i, token, true));
+      i += 1;
       continue;
     }
     if (token === "--menu-config") {
-      parsed.menuConfigPath = rest[++i];
+      parsed.menuConfigPath = readOptionValue(rest, i, token);
+      i += 1;
       continue;
     }
     if (token === "--port") {
-      parsed.port = Number(rest[++i]);
+      parsed.port = Number(readOptionValue(rest, i, token, true));
+      i += 1;
       continue;
     }
     throw new Error(`Unknown option: ${token}`);

--- a/src/config.ts
+++ b/src/config.ts
@@ -24,6 +24,7 @@ const DEFAULTS = {
   wikilinks: true,
   imagePolicy: "omit-local" as const,
   gfm: true,
+  allowUnsafeHtml: false,
   shikiTheme: "github-dark",
   mermaid: {
     enabled: true,
@@ -314,6 +315,7 @@ export function resolveBuildOptions(
     wikilinks: userConfig.markdown?.wikilinks ?? DEFAULTS.wikilinks,
     imagePolicy: userConfig.markdown?.images ?? DEFAULTS.imagePolicy,
     gfm: userConfig.markdown?.gfm ?? DEFAULTS.gfm,
+    allowUnsafeHtml: userConfig.markdown?.allowUnsafeHtml === true,
     shikiTheme: userConfig.markdown?.highlight?.theme ?? DEFAULTS.shikiTheme,
     mermaid: {
       enabled: normalizeMermaidEnabled(userConfig.markdown?.mermaid?.enabled),

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -48,7 +48,7 @@ export async function runDev(options: BuildOptions, devOptions: DevOptions): Pro
   let runningBuild = false;
   let queuedBuild = false;
 
-  const buildOnce = async () => {
+  const buildOnce = async (failFast = false) => {
     if (runningBuild) {
       queuedBuild = true;
       return;
@@ -59,6 +59,9 @@ export async function runDev(options: BuildOptions, devOptions: DevOptions): Pro
       const result = await buildSite(options);
       console.log(`[build] total=${result.totalDocs} rendered=${result.renderedDocs} skipped=${result.skippedDocs}`);
     } catch (error) {
+      if (failFast) {
+        throw error;
+      }
       console.error("[build] failed", error);
     } finally {
       runningBuild = false;
@@ -69,7 +72,7 @@ export async function runDev(options: BuildOptions, devOptions: DevOptions): Pro
     }
   };
 
-  await buildOnce();
+  await buildOnce(true);
 
   const watcher = chokidar.watch(options.vaultDir, {
     ignoreInitial: true,

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -98,7 +98,7 @@ const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
   disallowedTagsMode: "discard",
   enforceHtmlBoundary: false,
   nestingLimit: 100,
-  nonTextTags: ["script", "style", "textarea", "option", "noscript"],
+  nonTextTags: ["script", "style", "textarea", "option", "noscript", "xmp"],
   transformTags: {
     a(tagName, attributes) {
       const attribs = { ...attributes };

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,4 +1,5 @@
 import MarkdownIt from "markdown-it";
+import sanitizeHtml from "sanitize-html";
 import { createBundledHighlighter, type HighlighterGeneric } from "shiki/core";
 import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
 import { bundledLanguages } from "shiki/langs";
@@ -17,6 +18,102 @@ export interface MarkdownRenderer {
 
 const FENCE_LANG_RE = /^```([\w-+#.]+)/gm;
 const MERMAID_LANG = "mermaid";
+const SAFE_COLOR_VALUE = /^#[0-9a-f]{3,8}$/i;
+const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
+  allowedTags: [
+    "p",
+    "br",
+    "hr",
+    "blockquote",
+    "pre",
+    "code",
+    "strong",
+    "em",
+    "s",
+    "del",
+    "a",
+    "ul",
+    "ol",
+    "li",
+    "h1",
+    "h2",
+    "h3",
+    "h4",
+    "h5",
+    "h6",
+    "table",
+    "thead",
+    "tbody",
+    "tr",
+    "th",
+    "td",
+    "img",
+    "figure",
+    "figcaption",
+    "div",
+    "span",
+    "button",
+    "details",
+    "summary",
+    "kbd",
+    "mark",
+    "sub",
+    "sup",
+    "dl",
+    "dt",
+    "dd",
+    "abbr",
+    "time",
+  ],
+  allowedAttributes: {
+    "*": ["class"],
+    a: ["href", "title", "target", "rel"],
+    abbr: ["title"],
+    button: ["type", "title", "data-code", "aria-label"],
+    details: ["open"],
+    img: ["src", "alt", "title", "width", "height", "loading"],
+    li: ["value"],
+    ol: ["start"],
+    pre: ["tabindex", "style"],
+    span: ["style"],
+    td: ["colspan", "rowspan"],
+    th: ["colspan", "rowspan", "scope"],
+    time: ["datetime"],
+  },
+  allowedStyles: {
+    pre: {
+      "background-color": [SAFE_COLOR_VALUE],
+      color: [SAFE_COLOR_VALUE],
+    },
+    span: {
+      color: [SAFE_COLOR_VALUE],
+    },
+  },
+  allowedSchemes: ["http", "https", "mailto"],
+  allowedSchemesByTag: {
+    a: ["http", "https", "mailto"],
+    img: ["http", "https"],
+  },
+  allowProtocolRelative: false,
+  disallowedTagsMode: "discard",
+  enforceHtmlBoundary: false,
+  nestingLimit: 100,
+  nonTextTags: ["script", "style", "textarea", "option", "noscript"],
+  transformTags: {
+    a(tagName, attributes) {
+      const attribs = { ...attributes };
+      if (attribs.target === "_blank") {
+        const rel = new Set((attribs.rel ?? "").split(/\s+/).filter(Boolean));
+        rel.add("noopener");
+        rel.add("noreferrer");
+        attribs.rel = Array.from(rel).join(" ");
+      } else {
+        delete attribs.target;
+      }
+      return { tagName, attribs };
+    },
+  },
+};
 type RenderRule = NonNullable<MarkdownIt["renderer"]["rules"]["fence"]>;
 type RenderRuleArgs = Parameters<RenderRule>;
 type RuleTokens = RenderRuleArgs[0];
@@ -165,7 +262,7 @@ function createMarkdownIt<L extends string, T extends string>(
   gfm: boolean,
 ): MarkdownIt {
   const md = new MarkdownIt({
-    // Allow raw HTML in markdown (e.g. <img ... />).
+    // Parse raw HTML so the configured sanitizer can apply one policy to generated and authored markup.
     html: true,
     linkify: true,
     typographer: false,
@@ -311,12 +408,18 @@ export async function createMarkdownRenderer(options: BuildOptions): Promise<Mar
   const loadedLanguages = new Set(highlighter.getLoadedLanguages().map(String));
 
   const md = createMarkdownIt(highlighter, options.shikiTheme, options.gfm);
+  if (options.allowUnsafeHtml) {
+    console.warn(
+      "[security] markdown.allowUnsafeHtml=true disables rendered HTML sanitization. Only use trusted vault content.",
+    );
+  }
 
   return {
     async render(markdown: string, resolver: WikiResolver): Promise<RenderResult> {
       const { markdown: preprocessed, warnings } = preprocessMarkdown(markdown, resolver, options.imagePolicy, options.wikilinks);
       await loadFenceLanguages(highlighter, loadedLanguages, preprocessed);
-      const html = md.render(preprocessed);
+      const renderedHtml = md.render(preprocessed);
+      const html = options.allowUnsafeHtml ? renderedHtml : sanitizeHtml(renderedHtml, SAFE_HTML_OPTIONS);
       return { html, warnings };
     },
   };

--- a/src/template.ts
+++ b/src/template.ts
@@ -354,7 +354,7 @@ ${initialManifestScript}
 `;
 }
 
-export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS): string {
+export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS, homeHref = "/"): string {
   const symbolFontStylesheet =
     "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
 
@@ -378,7 +378,7 @@ export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS): string {
       </div>
       <h1>404</h1>
       <p>요청한 문서를 찾을 수 없습니다.</p>
-      <a href="/" class="not-found-link">
+      <a href="${escapeHtmlAttribute(homeHref)}" class="not-found-link">
         <span class="material-symbols-outlined">home</span>
         홈으로 이동
       </a>

--- a/src/types.ts
+++ b/src/types.ts
@@ -54,6 +54,7 @@ export interface UserConfig {
     wikilinks?: boolean;
     images?: ImagePolicy;
     gfm?: boolean;
+    allowUnsafeHtml?: boolean;
     highlight?: {
       engine?: "shiki";
       theme?: string;
@@ -79,6 +80,7 @@ export interface BuildOptions {
   wikilinks: boolean;
   imagePolicy: ImagePolicy;
   gfm: boolean;
+  allowUnsafeHtml: boolean;
   shikiTheme: string;
   mermaid: {
     enabled: boolean;

--- a/test-vault/posts/2024/xss-nav-title.md
+++ b/test-vault/posts/2024/xss-nav-title.md
@@ -10,3 +10,9 @@ description: Regression fixture for runtime XSS escaping.
 # Runtime XSS Regression Fixture
 
 이 문서는 런타임 내비게이션 렌더링의 XSS 이스케이프 회귀를 검증하기 위한 테스트 픽스처입니다.
+
+<div class="raw-html-safe"><strong>Allowed raw formatting</strong></div>
+<script>window.__raw_script = 1</script>
+<img class="raw-html-event" src="/missing-xss-fixture.png" alt="event payload" onerror="window.__raw_event = 1" />
+<a class="raw-html-url" href="javascript:window.__raw_url = 1">Unsafe URL</a>
+<iframe src="https://example.com/unsafe-frame"></iframe>

--- a/test-vault/posts/2024/xss-nav-title.md
+++ b/test-vault/posts/2024/xss-nav-title.md
@@ -15,4 +15,5 @@ description: Regression fixture for runtime XSS escaping.
 <script>window.__raw_script = 1</script>
 <img class="raw-html-event" src="/missing-xss-fixture.png" alt="event payload" onerror="window.__raw_event = 1" />
 <a class="raw-html-url" href="javascript:window.__raw_url = 1">Unsafe URL</a>
+<xmp><img class="raw-html-xmp" src="/missing-xmp-fixture.png" onerror="window.__raw_xmp = 1">XMP_RAW_TEXT_SECRET</xmp>
 <iframe src="https://example.com/unsafe-frame"></iframe>

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -137,6 +137,71 @@ test.describe("빌드 회귀 가드", () => {
     }
   });
 
+  test("clean은 EIAM 소유 출력과 cache index만 제거한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-clean-"));
+    const outDir = path.join(workDir, "dist");
+    const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
+
+    try {
+      const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(build.status, build.output).toBe(0);
+      expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
+      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(true);
+
+      writeText(unrelatedCacheFile, "unrelated cache data");
+      const clean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
+      expect(clean.status, clean.output).toBe(0);
+      expect(fs.existsSync(outDir)).toBe(false);
+      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(false);
+      expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build와 clean은 broad 또는 미소유 출력 디렉터리를 거부한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-output-"));
+    const unownedOutDir = path.join(workDir, "unowned");
+    const unownedSentinel = path.join(unownedOutDir, "keep.txt");
+    const cwdSentinel = path.join(workDir, "cwd-keep.txt");
+
+    try {
+      writeText(unownedSentinel, "do not remove");
+      writeText(cwdSentinel, "keep cwd");
+
+      const buildIntoUnowned = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        unownedOutDir,
+      ]);
+      expect(buildIntoUnowned.status).not.toBe(0);
+      expect(buildIntoUnowned.output).toContain("Refusing non-empty output directory");
+      expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+
+      const cleanUnowned = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        unownedOutDir,
+      ]);
+      expect(cleanUnowned.status).not.toBe(0);
+      expect(cleanUnowned.output).toContain("Refusing to clean output directory");
+      expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+
+      const cleanCwd = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", workDir]);
+      expect(cleanCwd.status).not.toBe(0);
+      expect(cleanCwd.output).toContain("Refusing dangerous output directory");
+      expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("CLI 숫자 옵션은 잘못된 값을 거부한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-validation-"));
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -162,9 +162,15 @@ test.describe("빌드 회귀 가드", () => {
     const outDir = path.join(workDir, "dist");
     const legacyCacheFile = path.join(workDir, ".cache", "build-index.json");
     const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
+    const legacyCacheContents = `${JSON.stringify({
+      version: 4,
+      sources: {},
+      docs: {},
+      outputHashes: {},
+    })}\n`;
 
     try {
-      writeText(legacyCacheFile, "legacy private cache body");
+      writeText(legacyCacheFile, legacyCacheContents);
       writeText(unrelatedCacheFile, "unrelated cache data");
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
@@ -180,13 +186,19 @@ test.describe("빌드 회귀 가드", () => {
       expect(marker.cacheNamespace).toMatch(/^v2-[a-f0-9]{40}$/);
       const cachePath = findOnlyCacheIndexPath(workDir);
 
-      writeText(legacyCacheFile, "legacy private cache body recreated before clean");
+      writeText(legacyCacheFile, legacyCacheContents);
       const clean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
       expect(clean.status, clean.output).toBe(0);
       expect(fs.existsSync(outDir)).toBe(false);
       expect(fs.existsSync(cachePath)).toBe(false);
       expect(fs.existsSync(legacyCacheFile)).toBe(false);
       expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
+
+      const foreignLegacyNamedContents = `${JSON.stringify({ tool: "another-cache", entries: ["keep"] })}\n`;
+      writeText(legacyCacheFile, foreignLegacyNamedContents);
+      const repeatedClean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
+      expect(repeatedClean.status, repeatedClean.output).toBe(0);
+      expect(fs.readFileSync(legacyCacheFile, "utf8")).toBe(foreignLegacyNamedContents);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -197,10 +209,13 @@ test.describe("빌드 회귀 가드", () => {
     const unownedOutDir = path.join(workDir, "unowned");
     const unownedSentinel = path.join(unownedOutDir, "keep.txt");
     const cwdSentinel = path.join(workDir, "cwd-keep.txt");
+    const foreignLegacyNamedCache = path.join(workDir, ".cache", "build-index.json");
+    const foreignLegacyNamedContents = `${JSON.stringify({ tool: "another-cache", entries: ["keep"] })}\n`;
 
     try {
       writeText(unownedSentinel, "do not remove");
       writeText(cwdSentinel, "keep cwd");
+      writeText(foreignLegacyNamedCache, foreignLegacyNamedContents);
 
       const buildIntoUnowned = runCli(workDir, [
         cliPath,
@@ -213,6 +228,7 @@ test.describe("빌드 회귀 가드", () => {
       expect(buildIntoUnowned.status).not.toBe(0);
       expect(buildIntoUnowned.output).toContain("Refusing non-empty output directory");
       expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+      expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
 
       const cleanUnowned = runCli(workDir, [
         cliPath,
@@ -225,11 +241,41 @@ test.describe("빌드 회귀 가드", () => {
       expect(cleanUnowned.status).not.toBe(0);
       expect(cleanUnowned.output).toContain("Refusing to clean output directory");
       expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+      expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
+
+      for (const cacheContainingOutDir of [
+        path.join(workDir, ".cache"),
+        path.join(workDir, ".cache", "eiam"),
+      ]) {
+        const buildIntoCacheRoot = runCli(workDir, [
+          cliPath,
+          "build",
+          "--vault",
+          vaultPath,
+          "--out",
+          cacheContainingOutDir,
+        ]);
+        expect(buildIntoCacheRoot.status).not.toBe(0);
+        expect(buildIntoCacheRoot.output).toContain("Refusing dangerous output directory");
+
+        const cleanCacheRoot = runCli(workDir, [
+          cliPath,
+          "clean",
+          "--vault",
+          vaultPath,
+          "--out",
+          cacheContainingOutDir,
+        ]);
+        expect(cleanCacheRoot.status).not.toBe(0);
+        expect(cleanCacheRoot.output).toContain("Refusing dangerous output directory");
+        expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
+      }
 
       const cleanCwd = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", workDir]);
       expect(cleanCwd.status).not.toBe(0);
       expect(cleanCwd.output).toContain("Refusing dangerous output directory");
       expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
+      expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -165,7 +165,14 @@ test.describe("빌드 회귀 가드", () => {
     try {
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
-      expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
+      const markerPath = path.join(outDir, ".eiam-output.json");
+      expect(fs.existsSync(markerPath)).toBe(true);
+      const marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as {
+        version: number;
+        cacheNamespace: string;
+      };
+      expect(marker.version).toBe(2);
+      expect(marker.cacheNamespace).toMatch(/^v1-[a-f0-9]{40}$/);
       const cachePath = findOnlyCacheIndexPath(workDir);
 
       writeText(unrelatedCacheFile, "unrelated cache data");
@@ -264,6 +271,21 @@ VAULT_B_BODY
       const [cacheA] = findCacheIndexPaths(workDir);
       expect(cacheA).toBeDefined();
       expect(fs.readFileSync(cacheA, "utf8")).toContain("VAULT_A_BODY");
+
+      const markerAPath = path.join(outA, ".eiam-output.json");
+      const markerABefore = fs.readFileSync(markerAPath, "utf8");
+      const wrongVaultBuild = runCli(workDir, [cliPath, "build", "--vault", vaultB, "--out", outA]);
+      expect(wrongVaultBuild.status).not.toBe(0);
+      expect(wrongVaultBuild.output).toContain("matching .eiam-output.json");
+      expect(fs.readFileSync(markerAPath, "utf8")).toBe(markerABefore);
+      const manifestAfterWrongBuild = readManifest(outA) as { docs: Array<{ route: string }> };
+      expect(manifestAfterWrongBuild.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
+
+      const wrongVaultClean = runCli(workDir, [cliPath, "clean", "--vault", vaultB, "--out", outA]);
+      expect(wrongVaultClean.status).not.toBe(0);
+      expect(wrongVaultClean.output).toContain("matching .eiam-output.json");
+      expect(fs.existsSync(outA)).toBe(true);
+      expect(fs.existsSync(cacheA)).toBe(true);
 
       const buildB = runCli(workDir, [cliPath, "build", "--vault", vaultB, "--out", outB]);
       expect(buildB.status, buildB.output).toBe(0);

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -382,6 +382,42 @@ test.describe("빌드 회귀 가드", () => {
       expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe("keep external namespace data");
 
       fs.unlinkSync(symlinkedNamespace);
+
+      const externalCacheIndex = path.join(workDir, "external-cache-index.json");
+      const symlinkedCacheIndex = path.join(symlinkedNamespace, "build-index.json");
+      writeText(externalCacheIndex, "keep external cache index data");
+      fs.mkdirSync(symlinkedNamespace, { recursive: true });
+      fs.symlinkSync(externalCacheIndex, symlinkedCacheIndex, "file");
+
+      const buildWithSymlinkedCacheIndex = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        namespaceGuardOutDir,
+      ]);
+      expect(buildWithSymlinkedCacheIndex.status).not.toBe(0);
+      expect(buildWithSymlinkedCacheIndex.output).toContain("Refusing symlinked cache index");
+      expect(fs.existsSync(namespaceGuardOutDir)).toBe(false);
+      expect(fs.lstatSync(symlinkedCacheIndex).isSymbolicLink()).toBe(true);
+      expect(fs.readFileSync(externalCacheIndex, "utf8")).toBe("keep external cache index data");
+
+      const cleanWithSymlinkedCacheIndex = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        namespaceGuardOutDir,
+      ]);
+      expect(cleanWithSymlinkedCacheIndex.status).not.toBe(0);
+      expect(cleanWithSymlinkedCacheIndex.output).toContain("Refusing symlinked cache index");
+      expect(fs.lstatSync(symlinkedCacheIndex).isSymbolicLink()).toBe(true);
+      expect(fs.readFileSync(externalCacheIndex, "utf8")).toBe("keep external cache index data");
+
+      fs.unlinkSync(symlinkedCacheIndex);
+      fs.rmdirSync(symlinkedNamespace);
       fs.rmdirSync(cacheRoot);
 
       const externalCacheTarget = path.join(workDir, "external-cache-target");
@@ -415,6 +451,57 @@ test.describe("빌드 회귀 가드", () => {
       expect(cleanWithSymlinkedCache.output).toContain("Refusing symlinked cache path");
       expect(fs.readdirSync(externalCacheTarget)).toEqual([]);
       expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("staticPaths는 output 소유권 marker를 덮어쓸 수 없다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-static-marker-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const configPath = path.join(workDir, "blog.config.mjs");
+    const sourceMarker = path.join(vaultDir, ".eiam-output.json");
+
+    try {
+      writeText(
+        path.join(vaultDir, "post.md"),
+        `---
+publish: true
+prefix: STATIC-MARKER
+category_path: safety/static
+title: Static Marker
+---
+
+STATIC_MARKER_BODY
+`,
+      );
+      writeText(sourceMarker, '{"foreign":"marker"}\n');
+
+      for (const staticPath of [".eiam-output.json", "assets/../.eiam-output.json"]) {
+        writeText(configPath, `export default { staticPaths: [${JSON.stringify(staticPath)}] };\n`);
+        const rejectedBuild = runCli(workDir, [
+          cliPath,
+          "build",
+          "--vault",
+          vaultDir,
+          "--out",
+          outDir,
+        ]);
+        expect(rejectedBuild.status).not.toBe(0);
+        expect(rejectedBuild.output).toContain("Refusing reserved static output path");
+        expect(fs.existsSync(outDir)).toBe(false);
+        expect(findCacheIndexPaths(workDir)).toEqual([]);
+        expect(fs.readFileSync(sourceMarker, "utf8")).toBe('{"foreign":"marker"}\n');
+      }
+
+      writeText(configPath, "export default {};\n");
+      const correctedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(correctedBuild.status, correctedBuild.output).toBe(0);
+      const outputMarker = JSON.parse(fs.readFileSync(path.join(outDir, ".eiam-output.json"), "utf8")) as {
+        format: string;
+      };
+      expect(outputMarker.format).toBe("everything-is-a-markdown-output");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -23,10 +23,11 @@ function extractRuntimeAssetPath(html: string, extension: "js" | "css"): string 
   return match[0];
 }
 
-function runCli(cwd: string, args: string[]): CliResult {
+function runCli(cwd: string, args: string[], timeout?: number): CliResult {
   const result = spawnSync("bun", args, {
     cwd,
     encoding: "utf8",
+    timeout,
   });
 
   return {
@@ -258,6 +259,17 @@ test.describe("빌드 회귀 가드", () => {
       ]);
       expect(buildIntoUnowned.status).not.toBe(0);
       expect(buildIntoUnowned.output).toContain("Refusing non-empty output directory");
+      expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
+      expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
+
+      const devIntoUnowned = runCli(
+        workDir,
+        [cliPath, "dev", "--vault", vaultPath, "--out", unownedOutDir, "--port", "49231"],
+        5_000,
+      );
+      expect(devIntoUnowned.status).not.toBeNull();
+      expect(devIntoUnowned.status).not.toBe(0);
+      expect(devIntoUnowned.output).toContain("Refusing non-empty output directory");
       expect(fs.readFileSync(unownedSentinel, "utf8")).toBe("do not remove");
       expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -216,6 +216,20 @@ test.describe("빌드 회귀 가드", () => {
       expect(preMarkerClean.output).toContain("matching .eiam-output.json");
       expect(fs.existsSync(legacyCacheFile)).toBe(false);
       expect(fs.readFileSync(preMarkerSentinel, "utf8")).toBe("keep legacy output");
+
+      writeText(legacyCacheFile, legacyCacheContents);
+      const preMarkerBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        preMarkerOutDir,
+      ]);
+      expect(preMarkerBuild.status).not.toBe(0);
+      expect(preMarkerBuild.output).toContain("matching .eiam-output.json");
+      expect(fs.existsSync(legacyCacheFile)).toBe(false);
+      expect(fs.readFileSync(preMarkerSentinel, "utf8")).toBe("keep legacy output");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -292,6 +306,38 @@ test.describe("빌드 회귀 가드", () => {
       expect(cleanCwd.status).not.toBe(0);
       expect(cleanCwd.output).toContain("Refusing dangerous output directory");
       expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
+      expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
+
+      const externalCacheTarget = path.join(workDir, "external-cache-target");
+      const symlinkedCacheRoot = path.join(workDir, ".cache", "eiam");
+      const symlinkGuardOutDir = path.join(workDir, "symlink-guard-dist");
+      fs.mkdirSync(externalCacheTarget, { recursive: true });
+      fs.symlinkSync(externalCacheTarget, symlinkedCacheRoot, "dir");
+
+      const buildWithSymlinkedCache = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        symlinkGuardOutDir,
+      ]);
+      expect(buildWithSymlinkedCache.status).not.toBe(0);
+      expect(buildWithSymlinkedCache.output).toContain("Refusing symlinked cache path");
+      expect(fs.existsSync(symlinkGuardOutDir)).toBe(false);
+      expect(fs.readdirSync(externalCacheTarget)).toEqual([]);
+
+      const cleanWithSymlinkedCache = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        symlinkGuardOutDir,
+      ]);
+      expect(cleanWithSymlinkedCache.status).not.toBe(0);
+      expect(cleanWithSymlinkedCache.output).toContain("Refusing symlinked cache path");
+      expect(fs.readdirSync(externalCacheTarget)).toEqual([]);
       expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -289,6 +289,7 @@ test.describe("빌드 회귀 가드", () => {
       for (const cacheContainingOutDir of [
         path.join(workDir, ".cache"),
         path.join(workDir, ".cache", "eiam"),
+        path.join(workDir, ".cache", "eiam", "v2-foreign", "site"),
       ]) {
         const buildIntoCacheRoot = runCli(workDir, [
           cliPath,
@@ -462,6 +463,13 @@ test.describe("빌드 회귀 가드", () => {
     const outDir = path.join(workDir, "dist");
     const configPath = path.join(workDir, "blog.config.mjs");
     const sourceMarker = path.join(vaultDir, ".eiam-output.json");
+    const legacyCacheFile = path.join(workDir, ".cache", "build-index.json");
+    const legacyCacheContents = `${JSON.stringify({
+      version: 5,
+      sources: {},
+      docs: {},
+      outputHashes: {},
+    })}\n`;
 
     try {
       writeText(
@@ -479,6 +487,7 @@ STATIC_MARKER_BODY
       writeText(sourceMarker, '{"foreign":"marker"}\n');
 
       for (const staticPath of [".eiam-output.json", "assets/../.eiam-output.json"]) {
+        writeText(legacyCacheFile, legacyCacheContents);
         writeText(configPath, `export default { staticPaths: [${JSON.stringify(staticPath)}] };\n`);
         const rejectedBuild = runCli(workDir, [
           cliPath,
@@ -492,6 +501,7 @@ STATIC_MARKER_BODY
         expect(rejectedBuild.output).toContain("Refusing reserved static output path");
         expect(fs.existsSync(outDir)).toBe(false);
         expect(findCacheIndexPaths(workDir)).toEqual([]);
+        expect(fs.existsSync(legacyCacheFile)).toBe(false);
         expect(fs.readFileSync(sourceMarker, "utf8")).toBe('{"foreign":"marker"}\n');
       }
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -878,6 +878,7 @@ title: HTML Policy
 <img src="https://example.com/safe.png" alt="safe" onerror="window.__event_payload = 1" />
 <a href="javascript:window.__url_payload = 1">Unsafe URL</a>
 <iframe src="https://example.com/unsafe"></iframe>
+<xmp><img src=x onerror="window.__xmp_payload = 1">XMP_RAW_TEXT_SECRET</xmp>
 `;
 
     try {
@@ -896,6 +897,8 @@ title: HTML Policy
         expect(rendered).not.toContain("window.__event_payload");
         expect(rendered).not.toContain("javascript:window.__url_payload");
         expect(rendered).not.toContain("https://example.com/unsafe");
+        expect(rendered).not.toContain("window.__xmp_payload");
+        expect(rendered).not.toContain("XMP_RAW_TEXT_SECRET");
       }
 
       writeText(
@@ -918,6 +921,8 @@ title: HTML Policy
       expect(unsafeContent).toContain('onerror="window.__event_payload = 1"');
       expect(unsafeContent).toContain('href="javascript:window.__url_payload = 1"');
       expect(unsafeContent).toContain('<iframe src="https://example.com/unsafe"></iframe>');
+      expect(unsafeContent).toContain('onerror="window.__xmp_payload = 1"');
+      expect(unsafeContent).toContain("XMP_RAW_TEXT_SECRET");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -202,6 +202,68 @@ test.describe("빌드 회귀 가드", () => {
     }
   });
 
+  test("raw HTML은 기본 sanitize되고 명시적 unsafe 설정에서만 유지된다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-html-sanitize-"));
+    const vaultDir = path.join(workDir, "vault");
+    const safeWorkDir = path.join(workDir, "safe");
+    const unsafeWorkDir = path.join(workDir, "unsafe");
+    const rawPayload = `---
+publish: true
+prefix: SAFE-HTML-01
+category_path: security/html
+title: HTML Policy
+---
+
+<div class="safe-format"><strong>Allowed formatting</strong></div>
+<script>window.__script_payload = 1</script>
+<img src="https://example.com/safe.png" alt="safe" onerror="window.__event_payload = 1" />
+<a href="javascript:window.__url_payload = 1">Unsafe URL</a>
+<iframe src="https://example.com/unsafe"></iframe>
+`;
+
+    try {
+      writeText(path.join(vaultDir, "unsafe.md"), rawPayload);
+      fs.mkdirSync(safeWorkDir, { recursive: true });
+      fs.mkdirSync(unsafeWorkDir, { recursive: true });
+
+      const safeOutDir = path.join(safeWorkDir, "dist");
+      const safeBuild = runCli(safeWorkDir, [cliPath, "build", "--vault", vaultDir, "--out", safeOutDir]);
+      expect(safeBuild.status, safeBuild.output).toBe(0);
+      const safeContent = readDocContentHtml(safeOutDir, "/SAFE-HTML-01/");
+      const safeRoute = fs.readFileSync(path.join(safeOutDir, "SAFE-HTML-01", "index.html"), "utf8");
+      for (const rendered of [safeContent, safeRoute]) {
+        expect(rendered).toContain('<div class="safe-format"><strong>Allowed formatting</strong></div>');
+        expect(rendered).not.toContain("window.__script_payload");
+        expect(rendered).not.toContain("window.__event_payload");
+        expect(rendered).not.toContain("javascript:window.__url_payload");
+        expect(rendered).not.toContain("https://example.com/unsafe");
+      }
+
+      writeText(
+        path.join(unsafeWorkDir, "blog.config.mjs"),
+        "export default { markdown: { allowUnsafeHtml: true } };\n",
+      );
+      const unsafeOutDir = path.join(unsafeWorkDir, "dist");
+      const unsafeBuild = runCli(unsafeWorkDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        unsafeOutDir,
+      ]);
+      expect(unsafeBuild.status, unsafeBuild.output).toBe(0);
+      expect(unsafeBuild.output).toContain("allowUnsafeHtml=true disables rendered HTML sanitization");
+      const unsafeContent = readDocContentHtml(unsafeOutDir, "/SAFE-HTML-01/");
+      expect(unsafeContent).toContain("<script>window.__script_payload = 1</script>");
+      expect(unsafeContent).toContain('onerror="window.__event_payload = 1"');
+      expect(unsafeContent).toContain('href="javascript:window.__url_payload = 1"');
+      expect(unsafeContent).toContain('<iframe src="https://example.com/unsafe"></iframe>');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("CLI 숫자 옵션은 잘못된 값을 거부한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-validation-"));
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -51,6 +51,26 @@ function readManifest(outDir: string): unknown {
   return JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as unknown;
 }
 
+function findCacheIndexPaths(workDir: string): string[] {
+  const cacheRoot = path.join(workDir, ".cache", "eiam");
+  if (!fs.existsSync(cacheRoot)) {
+    return [];
+  }
+
+  return fs
+    .readdirSync(cacheRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory())
+    .map((entry) => path.join(cacheRoot, entry.name, "build-index.json"))
+    .filter((cachePath) => fs.existsSync(cachePath))
+    .sort();
+}
+
+function findOnlyCacheIndexPath(workDir: string): string {
+  const cachePaths = findCacheIndexPaths(workDir);
+  expect(cachePaths).toHaveLength(1);
+  return cachePaths[0];
+}
+
 function findFolderNodeByPath(
   nodes: Array<{ type: string; path?: string; children?: Array<{ type: string; path?: string; children?: unknown[] }> }>,
   targetPath: string,
@@ -137,7 +157,7 @@ test.describe("빌드 회귀 가드", () => {
     }
   });
 
-  test("clean은 EIAM 소유 출력과 cache index만 제거한다", async () => {
+  test("clean은 EIAM 소유 출력과 matching cache namespace만 제거한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-clean-"));
     const outDir = path.join(workDir, "dist");
     const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
@@ -146,13 +166,13 @@ test.describe("빌드 회귀 가드", () => {
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
       expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
-      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(true);
+      const cachePath = findOnlyCacheIndexPath(workDir);
 
       writeText(unrelatedCacheFile, "unrelated cache data");
       const clean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
       expect(clean.status, clean.output).toBe(0);
       expect(fs.existsSync(outDir)).toBe(false);
-      expect(fs.existsSync(path.join(workDir, ".cache", "build-index.json"))).toBe(false);
+      expect(fs.existsSync(cachePath)).toBe(false);
       expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
@@ -197,6 +217,101 @@ test.describe("빌드 회귀 가드", () => {
       expect(cleanCwd.status).not.toBe(0);
       expect(cleanCwd.output).toContain("Refusing dangerous output directory");
       expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("vault와 output 경로 쌍마다 cache namespace를 분리하고 clean은 선택한 namespace만 제거한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cache-namespace-"));
+    const vaultA = path.join(workDir, "vault-a");
+    const vaultB = path.join(workDir, "vault-b");
+    const outA = path.join(workDir, "dist-a");
+    const outB = path.join(workDir, "dist-b");
+    const outAAlternate = path.join(workDir, "dist-a-alternate");
+    const sourceA = path.join(vaultA, "same.md");
+    const sourceB = path.join(vaultB, "same.md");
+    const fixedTime = new Date("2024-01-02T03:04:05.000Z");
+
+    try {
+      const bodyA = `---
+publish: true
+prefix: NS-CACHE-A
+category_path: cache/namespace
+title: Vault A
+---
+
+VAULT_A_BODY
+`;
+      const bodyB = `---
+publish: true
+prefix: NS-CACHE-B
+category_path: cache/namespace
+title: Vault B
+---
+
+VAULT_B_BODY
+`;
+      expect(Buffer.byteLength(bodyA)).toBe(Buffer.byteLength(bodyB));
+      writeText(sourceA, bodyA);
+      writeText(sourceB, bodyB);
+      fs.utimesSync(sourceA, fixedTime, fixedTime);
+      fs.utimesSync(sourceB, fixedTime, fixedTime);
+
+      const buildA = runCli(workDir, [cliPath, "build", "--vault", vaultA, "--out", outA]);
+      expect(buildA.status, buildA.output).toBe(0);
+      expect(buildA.output).toContain("total=1 rendered=1 skipped=0");
+      const [cacheA] = findCacheIndexPaths(workDir);
+      expect(cacheA).toBeDefined();
+      expect(fs.readFileSync(cacheA, "utf8")).toContain("VAULT_A_BODY");
+
+      const buildB = runCli(workDir, [cliPath, "build", "--vault", vaultB, "--out", outB]);
+      expect(buildB.status, buildB.output).toBe(0);
+      const afterBuildB = findCacheIndexPaths(workDir);
+      expect(afterBuildB).toHaveLength(2);
+      const cacheB = afterBuildB.find((cachePath) => cachePath !== cacheA);
+      expect(cacheB).toBeDefined();
+      expect(fs.readFileSync(cacheB!, "utf8")).toContain("VAULT_B_BODY");
+      const manifestB = readManifest(outB) as { docs: Array<{ route: string }> };
+      expect(manifestB.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-B/"]);
+
+      const alternateBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultA,
+        "--out",
+        outAAlternate,
+      ]);
+      expect(alternateBuild.status, alternateBuild.output).toBe(0);
+      const afterAlternate = findCacheIndexPaths(workDir);
+      expect(afterAlternate).toHaveLength(3);
+      const cacheAAlternate = afterAlternate.find(
+        (cachePath) => cachePath !== cacheA && cachePath !== cacheB,
+      );
+      expect(cacheAAlternate).toBeDefined();
+
+      const rebuildA = runCli(workDir, [cliPath, "build", "--vault", vaultA, "--out", outA]);
+      expect(rebuildA.status, rebuildA.output).toBe(0);
+      expect(rebuildA.output).toContain("total=1 rendered=0 skipped=1");
+      const manifestA = readManifest(outA) as { docs: Array<{ route: string }> };
+      expect(manifestA.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
+
+      const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
+      writeText(unrelatedCacheFile, "unrelated cache data");
+      const cleanA = runCli(workDir, [cliPath, "clean", "--vault", vaultA, "--out", outA]);
+      expect(cleanA.status, cleanA.output).toBe(0);
+      expect(fs.existsSync(outA)).toBe(false);
+      expect(fs.existsSync(cacheA)).toBe(false);
+      expect(fs.existsSync(cacheB!)).toBe(true);
+      expect(fs.existsSync(cacheAAlternate!)).toBe(true);
+      expect(fs.existsSync(outB)).toBe(true);
+      expect(fs.existsSync(outAAlternate)).toBe(true);
+      expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
+
+      const rebuildB = runCli(workDir, [cliPath, "build", "--vault", vaultB, "--out", outB]);
+      expect(rebuildB.status, rebuildB.output).toBe(0);
+      expect(rebuildB.output).toContain("total=1 rendered=0 skipped=1");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -268,7 +383,6 @@ title: HTML Policy
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-private-cache-"));
     const vaultDir = path.join(workDir, "vault");
     const outDir = path.join(workDir, "dist");
-    const cachePath = path.join(workDir, ".cache", "build-index.json");
     const publicPath = path.join(vaultDir, "public.md");
     const privatePath = path.join(vaultDir, "private.md");
     const draftPath = path.join(vaultDir, "draft.md");
@@ -310,6 +424,7 @@ DRAFT_CACHE_SECRET
 
       const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(firstBuild.status, firstBuild.output).toBe(0);
+      const cachePath = findOnlyCacheIndexPath(workDir);
       const firstCache = fs.readFileSync(cachePath, "utf8");
       expect(firstCache).toContain("PUBLIC_CACHE_BODY");
       expect(firstCache).not.toContain("PRIVATE_CACHE_SECRET");

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -320,6 +320,70 @@ test.describe("빌드 회귀 가드", () => {
       expect(fs.readFileSync(cwdSentinel, "utf8")).toBe("keep cwd");
       expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
 
+      const namespaceGuardOutDir = path.join(workDir, "namespace-guard-dist");
+      const namespaceSeedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        namespaceGuardOutDir,
+      ]);
+      expect(namespaceSeedBuild.status, namespaceSeedBuild.output).toBe(0);
+      const namespaceMarker = JSON.parse(
+        fs.readFileSync(path.join(namespaceGuardOutDir, ".eiam-output.json"), "utf8"),
+      ) as { cacheNamespace: string };
+      expect(namespaceMarker.cacheNamespace).toMatch(/^v2-[a-f0-9]{40}$/);
+
+      const namespaceSeedClean = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        namespaceGuardOutDir,
+      ]);
+      expect(namespaceSeedClean.status, namespaceSeedClean.output).toBe(0);
+      expect(fs.existsSync(namespaceGuardOutDir)).toBe(false);
+
+      const cacheRoot = path.join(workDir, ".cache", "eiam");
+      const externalNamespaceTarget = path.join(workDir, "external-namespace-target");
+      const externalNamespaceSentinel = path.join(externalNamespaceTarget, "keep.txt");
+      const symlinkedNamespace = path.join(cacheRoot, namespaceMarker.cacheNamespace);
+      writeText(externalNamespaceSentinel, "keep external namespace data");
+      fs.mkdirSync(cacheRoot, { recursive: true });
+      fs.symlinkSync(externalNamespaceTarget, symlinkedNamespace, "dir");
+
+      const buildWithSymlinkedNamespace = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        namespaceGuardOutDir,
+      ]);
+      expect(buildWithSymlinkedNamespace.status).not.toBe(0);
+      expect(buildWithSymlinkedNamespace.output).toContain("Refusing symlinked cache namespace");
+      expect(fs.existsSync(namespaceGuardOutDir)).toBe(false);
+      expect(fs.lstatSync(symlinkedNamespace).isSymbolicLink()).toBe(true);
+      expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe("keep external namespace data");
+
+      const cleanWithSymlinkedNamespace = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        namespaceGuardOutDir,
+      ]);
+      expect(cleanWithSymlinkedNamespace.status).not.toBe(0);
+      expect(cleanWithSymlinkedNamespace.output).toContain("Refusing symlinked cache namespace");
+      expect(fs.lstatSync(symlinkedNamespace).isSymbolicLink()).toBe(true);
+      expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe("keep external namespace data");
+
+      fs.unlinkSync(symlinkedNamespace);
+      fs.rmdirSync(cacheRoot);
+
       const externalCacheTarget = path.join(workDir, "external-cache-target");
       const symlinkedCacheRoot = path.join(workDir, ".cache", "eiam");
       const symlinkGuardOutDir = path.join(workDir, "symlink-guard-dist");
@@ -351,6 +415,32 @@ test.describe("빌드 회귀 가드", () => {
       expect(cleanWithSymlinkedCache.output).toContain("Refusing symlinked cache path");
       expect(fs.readdirSync(externalCacheTarget)).toEqual([]);
       expect(fs.readFileSync(foreignLegacyNamedCache, "utf8")).toBe(foreignLegacyNamedContents);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("실패한 첫 build는 vault 검증 전에 output을 claim하지 않는다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-invalid-vault-output-"));
+    const missingVaultDir = path.join(workDir, "missing-vault");
+    const outDir = path.join(workDir, "dist");
+
+    try {
+      const failedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        missingVaultDir,
+        "--out",
+        outDir,
+      ]);
+      expect(failedBuild.status).not.toBe(0);
+      expect(fs.existsSync(outDir)).toBe(false);
+      expect(findCacheIndexPaths(workDir)).toEqual([]);
+
+      const correctedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(correctedBuild.status, correctedBuild.output).toBe(0);
+      expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -317,6 +317,165 @@ VAULT_B_BODY
     }
   });
 
+  test("같은 size와 mtime을 유지한 body, wikilink, frontmatter 변경도 다시 빌드한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-content-fingerprint-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const fixedTime = new Date("2024-02-03T04:05:06.000Z");
+    const mutablePath = path.join(vaultDir, "mutable.md");
+    const linkerPath = path.join(vaultDir, "linker.md");
+    const frontmatterPath = path.join(vaultDir, "frontmatter.md");
+
+    const mutableBefore = `---
+publish: true
+prefix: FP-MUTABLE
+category_path: cache/fingerprint
+title: Mutable
+---
+
+ALPHA
+`;
+    const mutableAfter = mutableBefore.replace("ALPHA", "BRAVO");
+    const linkerBefore = `---
+publish: true
+prefix: FP-LINKER
+category_path: cache/fingerprint
+title: Linker
+---
+
+[[Target A]]
+`;
+    const linkerAfter = linkerBefore.replace("Target A", "Target B");
+    const frontmatterBefore = `---
+publish: true
+prefix: FP-ROUTE-A
+category_path: cache/fingerprint
+title: Frontmatter
+---
+
+UNCHANGED_BODY
+`;
+    const frontmatterAfter = frontmatterBefore.replace("FP-ROUTE-A", "FP-ROUTE-B");
+
+    try {
+      writeText(
+        path.join(vaultDir, "target-a.md"),
+        `---
+publish: true
+prefix: FP-TARGET-A
+category_path: cache/fingerprint
+title: Target A
+---
+
+TARGET_A_BODY
+`,
+      );
+      writeText(
+        path.join(vaultDir, "target-b.md"),
+        `---
+publish: true
+prefix: FP-TARGET-B
+category_path: cache/fingerprint
+title: Target B
+---
+
+TARGET_B_BODY
+`,
+      );
+
+      for (const [sourcePath, before, after] of [
+        [mutablePath, mutableBefore, mutableAfter],
+        [linkerPath, linkerBefore, linkerAfter],
+        [frontmatterPath, frontmatterBefore, frontmatterAfter],
+      ] as const) {
+        expect(Buffer.byteLength(before)).toBe(Buffer.byteLength(after));
+        writeText(sourcePath, before);
+        fs.utimesSync(sourcePath, fixedTime, fixedTime);
+      }
+
+      const initialStats = new Map(
+        [mutablePath, linkerPath, frontmatterPath].map((sourcePath) => [sourcePath, fs.statSync(sourcePath)]),
+      );
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+      expect(readDocContentHtml(outDir, "/FP-MUTABLE/")).toContain("ALPHA");
+      expect(readDocContentHtml(outDir, "/FP-LINKER/")).toContain('href="/FP-TARGET-A/"');
+      expect(fs.existsSync(path.join(outDir, "FP-ROUTE-A", "index.html"))).toBe(true);
+
+      for (const [sourcePath, replacement] of [
+        [mutablePath, mutableAfter],
+        [linkerPath, linkerAfter],
+        [frontmatterPath, frontmatterAfter],
+      ] as const) {
+        writeText(sourcePath, replacement);
+        fs.utimesSync(sourcePath, fixedTime, fixedTime);
+        const previous = initialStats.get(sourcePath)!;
+        const current = fs.statSync(sourcePath);
+        expect(current.size).toBe(previous.size);
+        expect(current.mtimeMs).toBe(previous.mtimeMs);
+      }
+
+      const changedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(changedBuild.status, changedBuild.output).toBe(0);
+      expect(changedBuild.output).toContain("total=5 rendered=3 skipped=2");
+      expect(readDocContentHtml(outDir, "/FP-MUTABLE/")).toContain("BRAVO");
+      const linkerHtml = readDocContentHtml(outDir, "/FP-LINKER/");
+      expect(linkerHtml).toContain('href="/FP-TARGET-B/"');
+      expect(linkerHtml).not.toContain('href="/FP-TARGET-A/"');
+      expect(fs.existsSync(path.join(outDir, "FP-ROUTE-A", "index.html"))).toBe(false);
+      expect(fs.existsSync(path.join(outDir, "FP-ROUTE-B", "index.html"))).toBe(true);
+
+      const manifest = readManifest(outDir) as {
+        docs: Array<{ route: string; backlinks: Array<{ route: string }> }>;
+      };
+      const targetA = manifest.docs.find((doc) => doc.route === "/FP-TARGET-A/");
+      const targetB = manifest.docs.find((doc) => doc.route === "/FP-TARGET-B/");
+      expect(targetA?.backlinks).toEqual([]);
+      expect(targetB?.backlinks.map((backlink) => backlink.route)).toEqual(["/FP-LINKER/"]);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("ordinary no-op 빌드는 fingerprint 후 parse와 render를 건너뛴다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-noop-performance-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const docCount = 40;
+
+    try {
+      for (let index = 0; index < docCount; index += 1) {
+        const id = String(index).padStart(2, "0");
+        writeText(
+          path.join(vaultDir, `doc-${id}.md`),
+          `---
+publish: true
+prefix: PERF-${id}
+category_path: cache/performance
+title: Performance ${id}
+---
+
+PERFORMANCE_BODY_${id}
+`,
+        );
+      }
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+
+      const startedAt = performance.now();
+      const noOpBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      const elapsedMs = performance.now() - startedAt;
+      console.info(`[perf] no-op incremental docs=${docCount} elapsedMs=${elapsedMs.toFixed(1)}`);
+
+      expect(noOpBuild.status, noOpBuild.output).toBe(0);
+      expect(noOpBuild.output).toContain(`total=${docCount} rendered=0 skipped=${docCount}`);
+      expect(elapsedMs).toBeLessThan(10_000);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("raw HTML은 기본 sanitize되고 명시적 unsafe 설정에서만 유지된다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-html-sanitize-"));
     const vaultDir = path.join(workDir, "vault");

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -264,6 +264,121 @@ title: HTML Policy
     }
   });
 
+  test("cache에는 unpublished와 draft Markdown 본문을 저장하지 않는다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-private-cache-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const cachePath = path.join(workDir, ".cache", "build-index.json");
+    const publicPath = path.join(vaultDir, "public.md");
+    const privatePath = path.join(vaultDir, "private.md");
+    const draftPath = path.join(vaultDir, "draft.md");
+
+    try {
+      writeText(
+        publicPath,
+        `---
+publish: true
+prefix: CACHE-PUBLIC
+category_path: cache/public
+title: Public Cache
+---
+
+PUBLIC_CACHE_BODY
+`,
+      );
+      writeText(
+        privatePath,
+        `---
+publish: false
+title: Private Cache
+---
+
+PRIVATE_CACHE_SECRET
+`,
+      );
+      writeText(
+        draftPath,
+        `---
+publish: true
+draft: true
+title: Draft Cache
+---
+
+DRAFT_CACHE_SECRET
+`,
+      );
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+      const firstCache = fs.readFileSync(cachePath, "utf8");
+      expect(firstCache).toContain("PUBLIC_CACHE_BODY");
+      expect(firstCache).not.toContain("PRIVATE_CACHE_SECRET");
+      expect(firstCache).not.toContain("DRAFT_CACHE_SECRET");
+      const firstSources = (JSON.parse(firstCache) as { sources: Record<string, unknown> }).sources;
+      expect(firstSources["public.md"]).toBeDefined();
+      expect(firstSources["private.md"]).toBeUndefined();
+      expect(firstSources["draft.md"]).toBeUndefined();
+
+      const incrementalBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(incrementalBuild.status, incrementalBuild.output).toBe(0);
+      expect(incrementalBuild.output).toContain("total=1 rendered=0 skipped=1");
+
+      writeText(
+        privatePath,
+        `---
+publish: true
+prefix: CACHE-PRIVATE
+category_path: cache/private
+title: Published Private Cache
+---
+
+PRIVATE_CACHE_SECRET
+`,
+      );
+      writeText(
+        publicPath,
+        `---
+publish: false
+prefix: CACHE-PUBLIC
+category_path: cache/public
+title: Private Public Cache
+---
+
+PUBLIC_CACHE_BODY
+`,
+      );
+      writeText(
+        draftPath,
+        `---
+publish: true
+draft: false
+prefix: CACHE-DRAFT
+category_path: cache/draft
+title: Published Draft Cache
+---
+
+DRAFT_CACHE_SECRET
+`,
+      );
+
+      const stateBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(stateBuild.status, stateBuild.output).toBe(0);
+      const manifest = readManifest(outDir) as { docs: Array<{ route: string }> };
+      expect(manifest.docs.map((doc) => doc.route).sort()).toEqual(["/CACHE-DRAFT/", "/CACHE-PRIVATE/"]);
+
+      const nextCache = fs.readFileSync(cachePath, "utf8");
+      expect(nextCache).not.toContain("PUBLIC_CACHE_BODY");
+      expect(nextCache).toContain("PRIVATE_CACHE_SECRET");
+      expect(nextCache).toContain("DRAFT_CACHE_SECRET");
+      const nextSources = (JSON.parse(nextCache) as { sources: Record<string, unknown> }).sources;
+      expect(nextSources["public.md"]).toBeUndefined();
+      expect(nextSources["private.md"]).toBeDefined();
+      expect(nextSources["draft.md"]).toBeDefined();
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("CLI 숫자 옵션은 잘못된 값을 거부한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-validation-"));
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -669,6 +669,7 @@ DRAFT_CACHE_SECRET
       ]);
       expect(invalidRecent.status).not.toBe(0);
       expect(invalidRecent.output).toContain("--recent-limit");
+      expect(invalidRecent.output).not.toContain("[cli] Missing value");
 
       const invalidNewWithinDays = runCli(workDir, [
         cliPath,
@@ -682,6 +683,35 @@ DRAFT_CACHE_SECRET
       ]);
       expect(invalidNewWithinDays.status).not.toBe(0);
       expect(invalidNewWithinDays.output).toContain("--new-within-days");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build, dev, clean의 모든 값 옵션은 누락되거나 다음 flag인 값을 거부한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-cli-missing-values-"));
+    const cases = [
+      { command: "build", option: "--vault" },
+      { command: "dev", option: "--out" },
+      { command: "clean", option: "--exclude" },
+      { command: "build", option: "--new-within-days" },
+      { command: "dev", option: "--recent-limit" },
+      { command: "clean", option: "--menu-config" },
+      { command: "dev", option: "--port" },
+    ] as const;
+
+    try {
+      for (const { command, option } of cases) {
+        const expectedError = `[cli] Missing value for ${option}`;
+
+        const omitted = runCli(workDir, [cliPath, command, option]);
+        expect(omitted.status, `${command} ${option}\n${omitted.output}`).not.toBe(0);
+        expect(omitted.output).toContain(expectedError);
+
+        const followedByFlag = runCli(workDir, [cliPath, command, option, "--help"]);
+        expect(followedByFlag.status, `${command} ${option} --help\n${followedByFlag.output}`).not.toBe(0);
+        expect(followedByFlag.output).toContain(expectedError);
+      }
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -199,6 +199,23 @@ test.describe("빌드 회귀 가드", () => {
       const repeatedClean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
       expect(repeatedClean.status, repeatedClean.output).toBe(0);
       expect(fs.readFileSync(legacyCacheFile, "utf8")).toBe(foreignLegacyNamedContents);
+
+      const preMarkerOutDir = path.join(workDir, "pre-marker-dist");
+      const preMarkerSentinel = path.join(preMarkerOutDir, "keep.txt");
+      writeText(preMarkerSentinel, "keep legacy output");
+      writeText(legacyCacheFile, legacyCacheContents);
+      const preMarkerClean = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        preMarkerOutDir,
+      ]);
+      expect(preMarkerClean.status).not.toBe(0);
+      expect(preMarkerClean.output).toContain("matching .eiam-output.json");
+      expect(fs.existsSync(legacyCacheFile)).toBe(false);
+      expect(fs.readFileSync(preMarkerSentinel, "utf8")).toBe("keep legacy output");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -485,8 +485,23 @@ STATIC_MARKER_BODY
 `,
       );
       writeText(sourceMarker, '{"foreign":"marker"}\n');
+      writeText(
+        path.join(vaultDir, "private.md"),
+        `---
+publish: false
+title: Private Static Source
+---
 
-      for (const staticPath of [".eiam-output.json", "assets/../.eiam-output.json"]) {
+PRIVATE_STATIC_SOURCE_SECRET
+`,
+      );
+      fs.mkdirSync(path.join(vaultDir, "assets"), { recursive: true });
+
+      for (const [staticPath, expectedError] of [
+        [".eiam-output.json", "Refusing reserved static output path"],
+        ["assets/../.eiam-output.json", "Refusing reserved static output path"],
+        ["assets/..", "Refusing static path that resolves to the vault root"],
+      ] as const) {
         writeText(legacyCacheFile, legacyCacheContents);
         writeText(configPath, `export default { staticPaths: [${JSON.stringify(staticPath)}] };\n`);
         const rejectedBuild = runCli(workDir, [
@@ -498,11 +513,14 @@ STATIC_MARKER_BODY
           outDir,
         ]);
         expect(rejectedBuild.status).not.toBe(0);
-        expect(rejectedBuild.output).toContain("Refusing reserved static output path");
+        expect(rejectedBuild.output).toContain(expectedError);
         expect(fs.existsSync(outDir)).toBe(false);
         expect(findCacheIndexPaths(workDir)).toEqual([]);
         expect(fs.existsSync(legacyCacheFile)).toBe(false);
         expect(fs.readFileSync(sourceMarker, "utf8")).toBe('{"foreign":"marker"}\n');
+        expect(fs.readFileSync(path.join(vaultDir, "private.md"), "utf8")).toContain(
+          "PRIVATE_STATIC_SOURCE_SECRET",
+        );
       }
 
       writeText(configPath, "export default {};\n");
@@ -912,6 +930,8 @@ title: HTML Policy
     const publicPath = path.join(vaultDir, "public.md");
     const privatePath = path.join(vaultDir, "private.md");
     const draftPath = path.join(vaultDir, "draft.md");
+    const missingPrefixPath = path.join(vaultDir, "missing-prefix.md");
+    const missingCategoryPath = path.join(vaultDir, "missing-category.md");
 
     try {
       writeText(
@@ -947,6 +967,28 @@ title: Draft Cache
 DRAFT_CACHE_SECRET
 `,
       );
+      writeText(
+        missingPrefixPath,
+        `---
+publish: true
+category_path: cache/missing-prefix
+title: Missing Prefix Cache
+---
+
+MISSING_PREFIX_CACHE_SECRET
+`,
+      );
+      writeText(
+        missingCategoryPath,
+        `---
+publish: true
+prefix: CACHE-MISSING-CATEGORY
+title: Missing Category Cache
+---
+
+MISSING_CATEGORY_CACHE_SECRET
+`,
+      );
 
       const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(firstBuild.status, firstBuild.output).toBe(0);
@@ -955,10 +997,14 @@ DRAFT_CACHE_SECRET
       expect(firstCache).toContain("PUBLIC_CACHE_BODY");
       expect(firstCache).not.toContain("PRIVATE_CACHE_SECRET");
       expect(firstCache).not.toContain("DRAFT_CACHE_SECRET");
+      expect(firstCache).not.toContain("MISSING_PREFIX_CACHE_SECRET");
+      expect(firstCache).not.toContain("MISSING_CATEGORY_CACHE_SECRET");
       const firstSources = (JSON.parse(firstCache) as { sources: Record<string, unknown> }).sources;
       expect(firstSources["public.md"]).toBeDefined();
       expect(firstSources["private.md"]).toBeUndefined();
       expect(firstSources["draft.md"]).toBeUndefined();
+      expect(firstSources["missing-prefix.md"]).toBeUndefined();
+      expect(firstSources["missing-category.md"]).toBeUndefined();
 
       const incrementalBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(incrementalBuild.status, incrementalBuild.output).toBe(0);
@@ -1011,10 +1057,14 @@ DRAFT_CACHE_SECRET
       expect(nextCache).not.toContain("PUBLIC_CACHE_BODY");
       expect(nextCache).toContain("PRIVATE_CACHE_SECRET");
       expect(nextCache).toContain("DRAFT_CACHE_SECRET");
+      expect(nextCache).not.toContain("MISSING_PREFIX_CACHE_SECRET");
+      expect(nextCache).not.toContain("MISSING_CATEGORY_CACHE_SECRET");
       const nextSources = (JSON.parse(nextCache) as { sources: Record<string, unknown> }).sources;
       expect(nextSources["public.md"]).toBeUndefined();
       expect(nextSources["private.md"]).toBeDefined();
       expect(nextSources["draft.md"]).toBeDefined();
+      expect(nextSources["missing-prefix.md"]).toBeUndefined();
+      expect(nextSources["missing-category.md"]).toBeUndefined();
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -160,11 +160,16 @@ test.describe("빌드 회귀 가드", () => {
   test("clean은 EIAM 소유 출력과 matching cache namespace만 제거한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-safe-clean-"));
     const outDir = path.join(workDir, "dist");
+    const legacyCacheFile = path.join(workDir, ".cache", "build-index.json");
     const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
 
     try {
+      writeText(legacyCacheFile, "legacy private cache body");
+      writeText(unrelatedCacheFile, "unrelated cache data");
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
+      expect(fs.existsSync(legacyCacheFile)).toBe(false);
+      expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
       const markerPath = path.join(outDir, ".eiam-output.json");
       expect(fs.existsSync(markerPath)).toBe(true);
       const marker = JSON.parse(fs.readFileSync(markerPath, "utf8")) as {
@@ -172,14 +177,15 @@ test.describe("빌드 회귀 가드", () => {
         cacheNamespace: string;
       };
       expect(marker.version).toBe(2);
-      expect(marker.cacheNamespace).toMatch(/^v1-[a-f0-9]{40}$/);
+      expect(marker.cacheNamespace).toMatch(/^v2-[a-f0-9]{40}$/);
       const cachePath = findOnlyCacheIndexPath(workDir);
 
-      writeText(unrelatedCacheFile, "unrelated cache data");
+      writeText(legacyCacheFile, "legacy private cache body recreated before clean");
       const clean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
       expect(clean.status, clean.output).toBe(0);
       expect(fs.existsSync(outDir)).toBe(false);
       expect(fs.existsSync(cachePath)).toBe(false);
+      expect(fs.existsSync(legacyCacheFile)).toBe(false);
       expect(fs.readFileSync(unrelatedCacheFile, "utf8")).toBe("unrelated cache data");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
@@ -236,6 +242,7 @@ test.describe("빌드 회귀 가드", () => {
     const outA = path.join(workDir, "dist-a");
     const outB = path.join(workDir, "dist-b");
     const outAAlternate = path.join(workDir, "dist-a-alternate");
+    const alternateCwd = path.join(workDir, "alternate-cwd");
     const sourceA = path.join(vaultA, "same.md");
     const sourceB = path.join(vaultB, "same.md");
     const fixedTime = new Date("2024-01-02T03:04:05.000Z");
@@ -262,6 +269,7 @@ VAULT_B_BODY
       expect(Buffer.byteLength(bodyA)).toBe(Buffer.byteLength(bodyB));
       writeText(sourceA, bodyA);
       writeText(sourceB, bodyB);
+      fs.mkdirSync(alternateCwd, { recursive: true });
       fs.utimesSync(sourceA, fixedTime, fixedTime);
       fs.utimesSync(sourceB, fixedTime, fixedTime);
 
@@ -284,6 +292,35 @@ VAULT_B_BODY
       const wrongVaultClean = runCli(workDir, [cliPath, "clean", "--vault", vaultB, "--out", outA]);
       expect(wrongVaultClean.status).not.toBe(0);
       expect(wrongVaultClean.output).toContain("matching .eiam-output.json");
+      expect(fs.existsSync(outA)).toBe(true);
+      expect(fs.existsSync(cacheA)).toBe(true);
+
+      const wrongCwdBuild = runCli(alternateCwd, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultA,
+        "--out",
+        outA,
+      ]);
+      expect(wrongCwdBuild.status).not.toBe(0);
+      expect(wrongCwdBuild.output).toContain("matching .eiam-output.json");
+      expect(fs.readFileSync(markerAPath, "utf8")).toBe(markerABefore);
+      expect(fs.existsSync(path.join(alternateCwd, ".cache", "eiam"))).toBe(false);
+      expect((readManifest(outA) as { docs: Array<{ route: string }> }).docs.map((doc) => doc.route)).toEqual([
+        "/NS-CACHE-A/",
+      ]);
+
+      const wrongCwdClean = runCli(alternateCwd, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultA,
+        "--out",
+        outA,
+      ]);
+      expect(wrongCwdClean.status).not.toBe(0);
+      expect(wrongCwdClean.output).toContain("matching .eiam-output.json");
       expect(fs.existsSync(outA)).toBe(true);
       expect(fs.existsSync(cacheA)).toBe(true);
 

--- a/tests/e2e/mermaid-runtime.spec.ts
+++ b/tests/e2e/mermaid-runtime.spec.ts
@@ -305,6 +305,8 @@ function createFixture(workDir: string, options: MermaidFixtureOptions): { vault
 }
 
 test.describe("Mermaid 런타임 회귀 가드", () => {
+  test.describe.configure({ timeout: 60_000 });
+
   const repoRoot = process.cwd();
   const cliPath = path.join(repoRoot, "src/cli.ts");
 

--- a/tests/e2e/mermaid-runtime.spec.ts
+++ b/tests/e2e/mermaid-runtime.spec.ts
@@ -111,6 +111,7 @@ async function startStaticServer(outDir: string): Promise<{ baseUrl: string; clo
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
       }),
   };
 }
@@ -305,8 +306,6 @@ function createFixture(workDir: string, options: MermaidFixtureOptions): { vault
 }
 
 test.describe("Mermaid 런타임 회귀 가드", () => {
-  test.describe.configure({ timeout: 60_000 });
-
   const repoRoot = process.cwd();
   const cliPath = path.join(repoRoot, "src/cli.ts");
 

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -103,6 +103,31 @@ test.describe("pathBase 정식 지원", () => {
   const cliPath = path.join(repoRoot, "src/cli.ts");
   const vaultPath = path.join(repoRoot, "test-vault");
 
+  test("생성된 404 Home 링크는 root와 정규화된 nested pathBase를 따른다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-404-home-"));
+    const outDir = path.join(workDir, "dist");
+    const configPath = path.join(workDir, "blog.config.mjs");
+
+    try {
+      const rootBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(rootBuild.status, rootBuild.output).toBe(0);
+      const rootNotFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+      expect(rootNotFoundHtml).toContain('<a href="/" class="not-found-link">');
+
+      fs.writeFileSync(
+        configPath,
+        'export default { seo: { siteUrl: "https://example.com", pathBase: " docs/guides/ " } };',
+        "utf8",
+      );
+      const nestedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(nestedBuild.status, nestedBuild.output).toBe(0);
+      const nestedNotFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+      expect(nestedNotFoundHtml).toContain('<a href="/docs/guides/" class="not-found-link">');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("서브패스(/blog)에서 라우팅/내부 링크/본문 fetch가 정상 동작한다", async ({ page }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-path-base-"));
     const outDir = path.join(workDir, "dist");
@@ -126,6 +151,8 @@ test.describe("pathBase 정식 지원", () => {
       "9999",
     ]);
     expect(build.status, build.output).toBe(0);
+    const notFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+    expect(notFoundHtml).toContain('<a href="/blog/" class="not-found-link">');
 
     const server = await startStaticServer(outDir, pathBase);
     try {
@@ -145,6 +172,20 @@ test.describe("pathBase 정식 지원", () => {
       await expect(page).toHaveURL(/\/blog\/BC-VO-02\/$/);
       await expect(page.locator("#viewer-title")).toHaveText("Setup Guide");
       await expect(page.locator("#viewer-nav .nav-link-next")).toHaveAttribute("href", "/blog/BC-XSS-01/");
+
+      const notFoundResponse = await page.goto(`${server.baseUrl}/blog/missing-document/`);
+      expect(notFoundResponse?.status()).toBe(404);
+      await expect(page).toHaveURL(`${server.baseUrl}/blog/missing-document/`);
+      const homeLink = page.locator(".not-found-link");
+      await expect(homeLink).toHaveAttribute("href", "/blog/");
+      const homeRequestPromise = page.waitForRequest(
+        (request) => request.isNavigationRequest() && request.url() === `${server.baseUrl}/blog/`,
+      );
+      await homeLink.click();
+      const homeRequest = await homeRequestPromise;
+      expect(homeRequest.url()).toBe(`${server.baseUrl}/blog/`);
+      await expect(page.locator(".app-root")).toBeVisible();
+      expect(new URL(page.url()).pathname).toMatch(/^\/blog\//);
     } finally {
       await server.close();
       fs.rmSync(workDir, { recursive: true, force: true });

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -104,6 +104,7 @@ test.describe("pathBase 정식 지원", () => {
   const vaultPath = path.join(repoRoot, "test-vault");
 
   test("생성된 404 Home 링크는 root와 정규화된 nested pathBase를 따른다", async () => {
+    test.setTimeout(60_000);
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-404-home-"));
     const outDir = path.join(workDir, "dist");
     const configPath = path.join(workDir, "blog.config.mjs");
@@ -129,6 +130,7 @@ test.describe("pathBase 정식 지원", () => {
   });
 
   test("서브패스(/blog)에서 라우팅/내부 링크/본문 fetch가 정상 동작한다", async ({ page }) => {
+    test.setTimeout(60_000);
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-path-base-"));
     const outDir = path.join(workDir, "dist");
     const configPath = path.join(workDir, "blog.config.mjs");

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -39,10 +39,12 @@ test.describe("런타임 렌더링 XSS 가드", () => {
         __raw_script?: number;
         __raw_event?: number;
         __raw_url?: number;
+        __raw_xmp?: number;
       };
       target.__raw_script = 0;
       target.__raw_event = 0;
       target.__raw_url = 0;
+      target.__raw_xmp = 0;
     });
 
     const assertSanitizedContent = async () => {
@@ -51,16 +53,24 @@ test.describe("런타임 렌더링 XSS 가드", () => {
       await expect(page.locator("#viewer-content iframe")).toHaveCount(0);
       await expect(page.locator("#viewer-content [onerror]")).toHaveCount(0);
       await expect(page.locator("#viewer-content .raw-html-url")).not.toHaveAttribute("href", /javascript:/i);
+      await expect(page.locator("#viewer-content .raw-html-xmp")).toHaveCount(0);
+      await expect(page.locator("#viewer-content")).not.toContainText("XMP_RAW_TEXT_SECRET");
 
       const flags = await page.evaluate(() => {
         const target = window as Window & {
           __raw_script?: number;
           __raw_event?: number;
           __raw_url?: number;
+          __raw_xmp?: number;
         };
-        return [target.__raw_script ?? 0, target.__raw_event ?? 0, target.__raw_url ?? 0];
+        return [
+          target.__raw_script ?? 0,
+          target.__raw_event ?? 0,
+          target.__raw_url ?? 0,
+          target.__raw_xmp ?? 0,
+        ];
       });
-      expect(flags).toEqual([0, 0, 0]);
+      expect(flags).toEqual([0, 0, 0, 0]);
     };
 
     await page.goto("/BC-XSS-01/");

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -32,4 +32,51 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     const xssFlag = await page.evaluate(() => (window as Window & { __xss_title?: number }).__xss_title ?? 0);
     expect(xssFlag).toBe(0);
   });
+
+  test("raw HTML은 직접 route와 client navigation에서 같은 정책으로 sanitize된다", async ({ page }) => {
+    await page.addInitScript(() => {
+      const target = window as Window & {
+        __raw_script?: number;
+        __raw_event?: number;
+        __raw_url?: number;
+      };
+      target.__raw_script = 0;
+      target.__raw_event = 0;
+      target.__raw_url = 0;
+    });
+
+    const assertSanitizedContent = async () => {
+      await expect(page.locator("#viewer-content .raw-html-safe strong")).toHaveText("Allowed raw formatting");
+      await expect(page.locator("#viewer-content script")).toHaveCount(0);
+      await expect(page.locator("#viewer-content iframe")).toHaveCount(0);
+      await expect(page.locator("#viewer-content [onerror]")).toHaveCount(0);
+      await expect(page.locator("#viewer-content .raw-html-url")).not.toHaveAttribute("href", /javascript:/i);
+
+      const flags = await page.evaluate(() => {
+        const target = window as Window & {
+          __raw_script?: number;
+          __raw_event?: number;
+          __raw_url?: number;
+        };
+        return [target.__raw_script ?? 0, target.__raw_event ?? 0, target.__raw_url ?? 0];
+      });
+      expect(flags).toEqual([0, 0, 0]);
+    };
+
+    await page.goto("/BC-XSS-01/");
+    await waitForAppReady(page);
+    await assertSanitizedContent();
+
+    await page.goto("/BC-VO-02/");
+    await waitForAppReady(page);
+    const xssRow = page
+      .locator('#tree-root [data-type="item"][data-item-type="file"]')
+      .filter({ hasText: "Unsafe" })
+      .first();
+    await expect(xssRow).toBeVisible();
+    await xssRow.click();
+    await expect(page).toHaveURL(/\/BC-XSS-01\/$/);
+    await expect(page.locator("#viewer-title")).toContainText("Unsafe");
+    await assertSanitizedContent();
+  });
 });


### PR DESCRIPTION
Closes #14

## Summary

This mother PR integrates the issue #14 safety and correctness program through reviewed, sequential sub PRs.

- Guard build and clean with dedicated output ownership markers and dangerous-path rejection
- Sanitize rendered Markdown HTML by default with an explicit trusted-vault unsafe opt-in
- Exclude unpublished and draft bodies from persistent cache state
- Namespace EIAM cache state by canonical vault/output pairs
- Validate source reuse with SHA-256 fingerprints, including same-size/same-mtime changes
- Reject omitted and flag-shaped CLI option values with precise errors
- Make generated 404 Home links respect normalized deployment pathBase
- Stabilize cold-build pathBase E2E budgets under parallel load without changing assertions

## Integrated sub PRs

- #52 safe output ownership and clean boundaries
- #53 default HTML sanitization
- #54 private/draft cache exclusion
- #55 vault/output cache namespaces
- #56 source content fingerprints
- #57 missing CLI value rejection
- #58 pathBase-aware 404 Home links
- #59 integrated pathBase E2E timeout correction

## Verification

- bun install --frozen-lockfile
- bunx --package typescript tsc --noEmit
- bun run build -- --vault ./test-vault --out ./dist
- bun run test:e2e (43 passed)
- Every sub PR passed current-head CI and had zero unresolved review threads before mother merge

## Residual risk

- bun audit reports one pre-existing moderate advisory through gray-matter -> js-yaml <3.15 (GHSA-h67p-54hq-rp68). Dependency remediation is outside the scoped issue acceptance criteria.