### PR TITLE
perf: minify runtime assets and enforce size budgets

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -30,6 +30,9 @@ jobs:
       - name: Build site
         run: bun run build -- --vault ./test-vault --out ./dist
 
+      - name: Enforce generated asset size budgets
+        run: bun run check:size
+
       - name: Run E2E tests
         run: bun run test:e2e
 

--- a/README.md
+++ b/README.md
@@ -210,9 +210,11 @@ Key points:
 
 - Every published route gets its own `index.html` for direct access.
 - Rendered article bodies are stored separately under `dist/content/`.
-- Runtime assets are content-hashed.
+- Production JavaScript and CSS are minified, then content-hashed from the final emitted bytes.
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
+
+CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS.
 
 ## Config File
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
 		"build": "bun run src/cli.ts build",
 		"dev": "bun run src/cli.ts dev",
 		"clean": "bun run src/cli.ts clean",
+		"check:size": "bun run scripts/check-output-size.ts --out ./dist",
 		"lint:md:publish": "bun run scripts/lint-published-markdown.ts --out-dir dist",
 		"test:e2e": "playwright test",
 		"test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -1,0 +1,77 @@
+import crypto from "node:crypto";
+import fs from "node:fs";
+import path from "node:path";
+import { gzipSync } from "node:zlib";
+
+type AssetKind = "js" | "css";
+
+interface SizeBudget {
+  raw: number;
+  gzip: number;
+}
+
+const BUDGETS: Record<AssetKind, SizeBudget> = {
+  js: { raw: 300_000, gzip: 90_000 },
+  css: { raw: 31_000, gzip: 7_000 },
+};
+
+function parseOutDir(argv: string[]): string {
+  const index = argv.indexOf("--out");
+  if (index === -1) {
+    return path.resolve("dist");
+  }
+
+  const value = argv[index + 1]?.trim();
+  if (!value || value.startsWith("-")) {
+    throw new Error("[size] Missing value for --out");
+  }
+  return path.resolve(value);
+}
+
+function findRuntimeAsset(assetsDir: string, kind: AssetKind): string {
+  const pattern = new RegExp(`^app\\.([a-f0-9]{12})\\.${kind}$`);
+  const matches = fs.readdirSync(assetsDir).filter((entry) => pattern.test(entry));
+  if (matches.length !== 1) {
+    throw new Error(`[size] Expected exactly one app.*.${kind} asset, found ${matches.length}`);
+  }
+  return path.join(assetsDir, matches[0]);
+}
+
+function checkAsset(assetPath: string, kind: AssetKind): string[] {
+  const bytes = fs.readFileSync(assetPath);
+  const rawBytes = bytes.byteLength;
+  const gzipBytes = gzipSync(bytes, { level: 9 }).byteLength;
+  const finalHash = crypto.createHash("sha1").update(bytes).digest("hex").slice(0, 12);
+  const fileName = path.basename(assetPath);
+  const expectedHash = fileName.split(".")[1] ?? "";
+  const budget = BUDGETS[kind];
+  const failures: string[] = [];
+
+  if (finalHash !== expectedHash) {
+    failures.push(`${fileName} hash ${expectedHash} does not match final bytes ${finalHash}`);
+  }
+  if (rawBytes > budget.raw) {
+    failures.push(`${fileName} raw ${rawBytes} exceeds ${budget.raw}`);
+  }
+  if (gzipBytes > budget.gzip) {
+    failures.push(`${fileName} gzip ${gzipBytes} exceeds ${budget.gzip}`);
+  }
+
+  console.log(
+    `[size] ${kind} raw=${rawBytes}/${budget.raw} gzip=${gzipBytes}/${budget.gzip} hash=${finalHash}`,
+  );
+  return failures;
+}
+
+const outDir = parseOutDir(process.argv.slice(2));
+const assetsDir = path.join(outDir, "assets");
+const failures = (["js", "css"] as const).flatMap((kind) =>
+  checkAsset(findRuntimeAsset(assetsDir, kind), kind),
+);
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`[size] ${failure}`);
+  }
+  process.exitCode = 1;
+}

--- a/src/build.ts
+++ b/src/build.ts
@@ -1484,6 +1484,7 @@ async function bundleRuntimeJs(entrypoint: string): Promise<string> {
     format: "esm",
     splitting: false,
     sourcemap: "none",
+    minify: true,
   });
 
   if (!result.success) {
@@ -1499,10 +1500,31 @@ async function bundleRuntimeJs(entrypoint: string): Promise<string> {
   return output.text();
 }
 
+async function bundleRuntimeCss(entrypoint: string): Promise<string> {
+  const result = await Bun.build({
+    entrypoints: [entrypoint],
+    target: "browser",
+    sourcemap: "none",
+    minify: true,
+  });
+
+  if (!result.success) {
+    const details = result.logs.map((log) => String(log)).filter(Boolean).join("\n");
+    throw new Error(`Failed to bundle runtime app.css${details ? `:\n${details}` : ""}`);
+  }
+
+  const output = result.outputs.find((artifact) => artifact.path.endsWith(".css")) ?? result.outputs[0];
+  if (!output) {
+    throw new Error("Failed to bundle runtime app.css: no CSS output was produced");
+  }
+
+  return output.text();
+}
+
 async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeAssets> {
   const runtimeDir = path.join(import.meta.dir, "runtime");
   const runtimeJs = await bundleRuntimeJs(path.join(runtimeDir, "app.js"));
-  const runtimeCss = await Bun.file(path.join(runtimeDir, "app.css")).text();
+  const runtimeCss = await bundleRuntimeCss(path.join(runtimeDir, "app.css"));
 
   const jsRelPath = `assets/app.${makeHash(runtimeJs).slice(0, 12)}.js`;
   const cssRelPath = `assets/app.${makeHash(runtimeCss).slice(0, 12)}.css`;


### PR DESCRIPTION
Part of #22. Implements the detailed acceptance criteria retained in #23.

## Summary

- Minify production JavaScript with Bun's production bundler
- Bundle and minify the runtime CSS before hashing/writing it
- Hash final emitted bytes and verify filename hashes in the budget check
- Enforce raw and gzip budgets in CI
- Document the local budget command and limits

## DnD

- [x] Production JS and CSS are minified
- [x] Content hashes are calculated and checked against final emitted bytes
- [x] CI fails when raw or gzip budgets regress
- [x] Build regression and tree-adapter behavior remain unchanged

## Measurements

| Asset | Before raw/gzip | After raw/gzip |
| --- | ---: | ---: |
| JavaScript | 537,729 / 110,889 B | 286,909 / 83,087 B |
| CSS | 36,068 / 7,152 B | 29,236 / 6,385 B |

## Verification

- `bunx --package typescript tsc --noEmit`
- `bun run build -- --vault ./test-vault --out ./dist`
- `bun run check:size`
- `PLAYWRIGHT_BASE_URL=http://127.0.0.1:9 bunx playwright test tests/e2e/build-regression.spec.ts tests/e2e/tree-adapter.spec.ts` (23 passed)
- Full `bun run test:e2e` is delegated to CI because this sandbox cannot bind the Playwright web server port
