### PR TITLE
perf: normalize manifest document references

### DIFF
--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Key points:
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
-CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command validates manifest schema v2 canonical document references and requires at least 25% raw and 5% gzip reduction versus the former duplicated tree/document projection.
+CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command always validates manifest schema v2 canonical document references; for manifests with at least two documents, it also requires at least 25% raw and 5% gzip reduction versus the former duplicated tree/document projection. Empty and one-document manifests skip only this relative ratio because fixed schema/gzip overhead dominates when there is no meaningful duplication to remove.
 
 ## Config File
 

--- a/README.md
+++ b/README.md
@@ -211,10 +211,11 @@ Key points:
 - Every published route gets its own `index.html` for direct access.
 - Rendered article bodies are stored separately under `dist/content/`.
 - Production JavaScript and CSS are minified, then content-hashed from the final emitted bytes.
+- `manifest.json` uses schema v2: `docIds` preserves order, `docsById` is the canonical metadata index, and tree file nodes carry document references instead of duplicated metadata. The runtime adapter also accepts legacy unversioned/v1 `docs` arrays during migration.
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
-CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS.
+CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command validates manifest schema v2 canonical document references and requires at least 25% raw and 5% gzip reduction versus the former duplicated tree/document projection.
 
 ## Config File
 

--- a/README.md
+++ b/README.md
@@ -215,7 +215,7 @@ Key points:
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
-CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command always validates manifest schema v2 canonical document references; for manifests with at least two documents, it also requires at least 25% raw and 5% gzip reduction versus the former duplicated tree/document projection. Empty and one-document manifests skip only this relative ratio because fixed schema/gzip overhead dominates when there is no meaningful duplication to remove.
+CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command always validates manifest schema v2 canonical document references. Once the reconstructed legacy projection reaches 8,000 bytes, it also requires at least 25% raw and 5% gzip reduction versus that duplicated tree/document projection. Smaller manifests skip only this relative ratio because fixed schema/gzip overhead dominates when there is not yet enough duplicated payload to measure reliably.
 
 ## Config File
 

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -27,7 +27,7 @@ const BUDGETS: Record<AssetKind, SizeBudget> = {
   js: { raw: 300_000, gzip: 90_000 },
   css: { raw: 31_000, gzip: 7_000 },
 };
-const MANIFEST_RATIO_MIN_DOCS = 2;
+const MANIFEST_RATIO_MIN_LEGACY_BYTES = 8_000;
 
 function parseOutDir(argv: string[]): string {
   const index = argv.indexOf("--out");
@@ -182,7 +182,7 @@ function checkManifest(manifestPath: string): string[] {
   const legacyGzipBytes = gzipSync(legacyRaw, { level: 9 }).byteLength;
   const gzipRatio = gzipBytes / legacyGzipBytes;
 
-  if (docIds.length >= MANIFEST_RATIO_MIN_DOCS) {
+  if (legacyRaw.byteLength >= MANIFEST_RATIO_MIN_LEGACY_BYTES) {
     if (rawRatio > 0.75) {
       failures.push(`manifest raw ratio ${(rawRatio * 100).toFixed(1)}% exceeds 75% of the legacy projection`);
     }
@@ -190,7 +190,9 @@ function checkManifest(manifestPath: string): string[] {
       failures.push(`manifest gzip ratio ${(gzipRatio * 100).toFixed(1)}% exceeds 95% of the legacy projection`);
     }
   } else {
-    console.log(`[size] manifest ratio gate skipped for ${docIds.length} doc(s)`);
+    console.log(
+      `[size] manifest ratio gate skipped for legacy projection ${legacyRaw.byteLength}B (<${MANIFEST_RATIO_MIN_LEGACY_BYTES}B)`,
+    );
   }
 
   console.log(

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -27,6 +27,7 @@ const BUDGETS: Record<AssetKind, SizeBudget> = {
   js: { raw: 300_000, gzip: 90_000 },
   css: { raw: 31_000, gzip: 7_000 },
 };
+const MANIFEST_RATIO_MIN_DOCS = 2;
 
 function parseOutDir(argv: string[]): string {
   const index = argv.indexOf("--out");
@@ -181,11 +182,15 @@ function checkManifest(manifestPath: string): string[] {
   const legacyGzipBytes = gzipSync(legacyRaw, { level: 9 }).byteLength;
   const gzipRatio = gzipBytes / legacyGzipBytes;
 
-  if (rawRatio > 0.75) {
-    failures.push(`manifest raw ratio ${(rawRatio * 100).toFixed(1)}% exceeds 75% of the legacy projection`);
-  }
-  if (gzipRatio > 0.95) {
-    failures.push(`manifest gzip ratio ${(gzipRatio * 100).toFixed(1)}% exceeds 95% of the legacy projection`);
+  if (docIds.length >= MANIFEST_RATIO_MIN_DOCS) {
+    if (rawRatio > 0.75) {
+      failures.push(`manifest raw ratio ${(rawRatio * 100).toFixed(1)}% exceeds 75% of the legacy projection`);
+    }
+    if (gzipRatio > 0.95) {
+      failures.push(`manifest gzip ratio ${(gzipRatio * 100).toFixed(1)}% exceeds 95% of the legacy projection`);
+    }
+  } else {
+    console.log(`[size] manifest ratio gate skipped for ${docIds.length} doc(s)`);
   }
 
   console.log(

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -5,6 +5,19 @@ import { gzipSync } from "node:zlib";
 
 type AssetKind = "js" | "css";
 
+interface ManifestDoc {
+  id: string;
+  [key: string]: unknown;
+}
+
+interface ManifestV2 {
+  schemaVersion: number;
+  docIds: string[];
+  docsById: Record<string, ManifestDoc>;
+  tree: unknown[];
+  [key: string]: unknown;
+}
+
 interface SizeBudget {
   raw: number;
   gzip: number;
@@ -63,11 +76,130 @@ function checkAsset(assetPath: string, kind: AssetKind): string[] {
   return failures;
 }
 
+function isRecord(value: unknown): value is Record<string, unknown> {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function toLegacyTree(nodes: unknown[], docsById: Record<string, ManifestDoc>): unknown[] {
+  return nodes.map((node) => {
+    if (!isRecord(node)) {
+      return node;
+    }
+    if (node.type === "folder") {
+      return {
+        ...node,
+        children: toLegacyTree(Array.isArray(node.children) ? node.children : [], docsById),
+      };
+    }
+    if (node.type !== "file" || typeof node.id !== "string") {
+      return node;
+    }
+
+    const doc = docsById[node.id];
+    if (!doc) {
+      return node;
+    }
+    return {
+      ...node,
+      title: doc.title,
+      prefix: doc.prefix,
+      route: doc.route,
+      contentUrl: doc.contentUrl,
+      isNew: doc.isNew,
+      tags: doc.tags,
+      description: doc.description,
+      date: doc.date,
+      updatedDate: doc.updatedDate,
+      branch: doc.branch,
+    };
+  });
+}
+
+function checkManifest(manifestPath: string): string[] {
+  const raw = fs.readFileSync(manifestPath);
+  const parsedValue = JSON.parse(raw.toString("utf8")) as unknown;
+  const failures: string[] = [];
+
+  if (!isRecord(parsedValue)) {
+    return ["manifest.json must contain an object"];
+  }
+  const parsed = parsedValue as ManifestV2;
+  if (parsed.schemaVersion !== 2 || !Array.isArray(parsed.docIds) || !isRecord(parsed.docsById)) {
+    return ["manifest.json must use schemaVersion 2 with docIds and docsById"];
+  }
+  if (!Array.isArray(parsed.tree)) {
+    return ["manifest.json tree must be an array"];
+  }
+
+  const docIds = parsed.docIds.filter((id): id is string => typeof id === "string" && id.length > 0);
+  const uniqueDocIds = new Set(docIds);
+  const docsByIdKeys = Object.keys(parsed.docsById);
+  if (docIds.length !== parsed.docIds.length || uniqueDocIds.size !== docIds.length) {
+    failures.push("manifest.json docIds must contain unique non-empty strings");
+  }
+  if (
+    docsByIdKeys.length !== docIds.length ||
+    docIds.some((id) => !Object.hasOwn(parsed.docsById, id) || parsed.docsById[id]?.id !== id)
+  ) {
+    failures.push("manifest.json docsById must exactly match docIds");
+  }
+
+  const inspectTree = (nodes: unknown[]) => {
+    for (const node of nodes) {
+      if (!isRecord(node)) {
+        failures.push("manifest.json tree nodes must be objects");
+        continue;
+      }
+      if (node.type === "folder") {
+        inspectTree(Array.isArray(node.children) ? node.children : []);
+        continue;
+      }
+      if (node.type !== "file") {
+        failures.push("manifest.json tree nodes must be file or folder nodes");
+        continue;
+      }
+      const keys = Object.keys(node).sort();
+      if (keys.join(",") !== "id,name,type") {
+        failures.push(`manifest file node ${String(node.id ?? "<unknown>")} duplicates document metadata`);
+      }
+      if (typeof node.id !== "string" || !Object.hasOwn(parsed.docsById, node.id)) {
+        failures.push(`manifest file node ${String(node.id ?? "<unknown>")} has a dangling document reference`);
+      }
+    }
+  };
+  inspectTree(parsed.tree);
+
+  const { schemaVersion: _schemaVersion, docIds: _docIds, docsById: _docsById, ...rest } = parsed;
+  const legacyProjection = {
+    ...rest,
+    tree: toLegacyTree(parsed.tree, parsed.docsById),
+    docs: docIds.map((id) => parsed.docsById[id]),
+  };
+  const legacyRaw = Buffer.from(`${JSON.stringify(legacyProjection, null, 2)}\n`);
+  const rawRatio = raw.byteLength / legacyRaw.byteLength;
+  const gzipBytes = gzipSync(raw, { level: 9 }).byteLength;
+  const legacyGzipBytes = gzipSync(legacyRaw, { level: 9 }).byteLength;
+  const gzipRatio = gzipBytes / legacyGzipBytes;
+
+  if (rawRatio > 0.75) {
+    failures.push(`manifest raw ratio ${(rawRatio * 100).toFixed(1)}% exceeds 75% of the legacy projection`);
+  }
+  if (gzipRatio > 0.95) {
+    failures.push(`manifest gzip ratio ${(gzipRatio * 100).toFixed(1)}% exceeds 95% of the legacy projection`);
+  }
+
+  console.log(
+    `[size] manifest raw=${raw.byteLength}/${legacyRaw.byteLength} (${(rawRatio * 100).toFixed(1)}%) gzip=${gzipBytes}/${legacyGzipBytes} (${(gzipRatio * 100).toFixed(1)}%)`,
+  );
+  return failures;
+}
+
 const outDir = parseOutDir(process.argv.slice(2));
 const assetsDir = path.join(outDir, "assets");
 const failures = (["js", "css"] as const).flatMap((kind) =>
   checkAsset(findRuntimeAsset(assetsDir, kind), kind),
 );
+failures.push(...checkManifest(path.join(outDir, "manifest.json")));
 
 if (failures.length > 0) {
   for (const failure of failures) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -2,7 +2,17 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import matter from "gray-matter";
-import type { BuildCache, BuildOptions, DocRecord, FileNode, FolderNode, Manifest, TreeNode, WikiResolver } from "./types";
+import type {
+  BuildCache,
+  BuildOptions,
+  DocRecord,
+  FileNode,
+  FolderNode,
+  Manifest,
+  ManifestDoc,
+  TreeNode,
+  WikiResolver,
+} from "./types";
 import { createMarkdownRenderer } from "./markdown";
 import { buildCanonicalUrl, escapeHtmlAttribute } from "./seo";
 import { render404Html, renderAppShellHtml } from "./template";
@@ -1020,16 +1030,6 @@ function fileNodeFromDoc(doc: DocRecord): FileNode {
     type: "file",
     name: doc.fileName,
     id: doc.id,
-    title: doc.title,
-    prefix: doc.prefix,
-    route: doc.route,
-    contentUrl: doc.contentUrl,
-    isNew: doc.isNew,
-    tags: doc.tags,
-    description: doc.description,
-    date: doc.date,
-    updatedDate: doc.updatedDate,
-    branch: doc.branch,
   };
 }
 
@@ -1200,22 +1200,27 @@ function buildManifest(docs: DocRecord[], tree: TreeNode[], options: BuildOption
   const wikiLookup = createWikiLookup(docs);
   const backlinksByDocId = buildBacklinksByDocId(docs, wikiLookup);
 
-  const docsForManifest = docs.map((doc) => ({
-    id: doc.id,
-    route: doc.route,
-    title: doc.title,
-    prefix: doc.prefix,
-    categoryPath: doc.categoryPath,
-    date: doc.date,
-    updatedDate: doc.updatedDate,
-    tags: doc.tags,
-    description: doc.description,
-    isNew: doc.isNew,
-    contentUrl: doc.contentUrl,
-    branch: doc.branch,
-    wikiTargets: doc.wikiTargets,
-    backlinks: backlinksByDocId.get(doc.id) ?? [],
-  }));
+  const docsById = Object.fromEntries(
+    docs.map((doc) => [
+      doc.id,
+      {
+        id: doc.id,
+        route: doc.route,
+        title: doc.title,
+        prefix: doc.prefix,
+        categoryPath: doc.categoryPath,
+        date: doc.date,
+        updatedDate: doc.updatedDate,
+        tags: doc.tags,
+        description: doc.description,
+        isNew: doc.isNew,
+        contentUrl: doc.contentUrl,
+        branch: doc.branch,
+        wikiTargets: doc.wikiTargets,
+        backlinks: backlinksByDocId.get(doc.id) ?? [],
+      },
+    ]),
+  );
 
   const branchSet = new Set<string>([DEFAULT_BRANCH]);
   for (const doc of docs) {
@@ -1235,6 +1240,7 @@ function buildManifest(docs: DocRecord[], tree: TreeNode[], options: BuildOption
   });
 
   return {
+    schemaVersion: 2,
     generatedAt: new Date().toISOString(),
     siteTitle: resolveSiteTitle(options),
     pathBase: options.seo?.pathBase ?? "",
@@ -1247,7 +1253,8 @@ function buildManifest(docs: DocRecord[], tree: TreeNode[], options: BuildOption
     },
     tree,
     routeMap,
-    docs: docsForManifest,
+    docIds: docs.map((doc) => doc.id),
+    docsById,
   };
 }
 
@@ -1679,7 +1686,7 @@ function renderInitialNav(docs: DocRecord[], currentId: string, pathBase: string
   return html;
 }
 
-function renderInitialBacklinks(backlinks: Manifest["docs"][number]["backlinks"], pathBase: string): string {
+function renderInitialBacklinks(backlinks: ManifestDoc["backlinks"], pathBase: string): string {
   if (backlinks.length === 0) {
     return "";
   }
@@ -1699,7 +1706,7 @@ function buildInitialView(
   doc: DocRecord,
   docs: DocRecord[],
   contentHtml: string,
-  manifestDocById: Map<string, Manifest["docs"][number]>,
+  manifestDocById: Map<string, Manifest["docsById"][string]>,
   pathBase: string,
 ): AppShellInitialView {
   const manifestDoc = manifestDocById.get(doc.id);
@@ -1723,7 +1730,7 @@ async function writeShellPages(
   runtimeAssets: RuntimeAssets,
   contentByDocId: Map<string, string>,
 ): Promise<void> {
-  const manifestDocById = new Map(manifest.docs.map((doc) => [doc.id, doc]));
+  const manifestDocById = new Map(Object.entries(manifest.docsById));
   const pathBase = options.seo?.pathBase ?? "";
   const indexDoc = pickHomeDoc(docs);
   const indexOutputPath = "index.html";
@@ -1878,8 +1885,8 @@ function buildWikiResolutionSignature(doc: DocRecord, lookup: WikiLookup): strin
 function buildBacklinksByDocId(
   docs: DocRecord[],
   lookup: WikiLookup,
-): Map<string, Manifest["docs"][number]["backlinks"]> {
-  const buckets = new Map<string, Map<string, Manifest["docs"][number]["backlinks"][number]>>();
+): Map<string, ManifestDoc["backlinks"]> {
+  const buckets = new Map<string, Map<string, ManifestDoc["backlinks"][number]>>();
 
   for (const doc of docs) {
     for (const target of doc.wikiTargets) {
@@ -1888,7 +1895,7 @@ function buildBacklinksByDocId(
         continue;
       }
 
-      const bucket = buckets.get(targetDoc.id) ?? new Map<string, Manifest["docs"][number]["backlinks"][number]>();
+      const bucket = buckets.get(targetDoc.id) ?? new Map<string, ManifestDoc["backlinks"][number]>();
       bucket.set(doc.id, {
         id: doc.id,
         route: doc.route,
@@ -1899,9 +1906,9 @@ function buildBacklinksByDocId(
     }
   }
 
-  const backlinksByDocId = new Map<string, Manifest["docs"][number]["backlinks"]>();
+  const backlinksByDocId = new Map<string, ManifestDoc["backlinks"]>();
   for (const doc of docs) {
-    const source = buckets.get(doc.id) ?? new Map<string, Manifest["docs"][number]["backlinks"][number]>();
+    const source = buckets.get(doc.id) ?? new Map<string, ManifestDoc["backlinks"][number]>();
     const backlinks = Array.from(source.values()).sort((left, right) =>
       left.route.localeCompare(right.route, "ko-KR"),
     );

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,4 +1,5 @@
 import { FileTree, prepareFileTreeInput } from "@pierre/trees";
+import { getManifestDocs, normalizeManifestPayload } from "./manifest-adapter.js";
 import { buildTreesAdapterInput } from "./tree-adapter.js";
 
 const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
@@ -675,19 +676,7 @@ function loadInitialManifestData() {
 
   try {
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-
-    if (!Array.isArray(parsed.docs) || !Array.isArray(parsed.tree)) {
-      return null;
-    }
-
-    if (!parsed.routeMap || typeof parsed.routeMap !== "object") {
-      return null;
-    }
-
-    return parsed;
+    return normalizeManifestPayload(parsed);
   } catch {
     return null;
   }
@@ -813,7 +802,7 @@ function cloneFilteredTree(nodes, visibleDocIds) {
 }
 
 function buildBranchView(manifest, branch, defaultBranch) {
-  const docs = manifest.docs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
+  const docs = getManifestDocs(manifest).filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
   const visibleDocIds = new Set(docs.map((doc) => doc.id));
   const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
   const trees = buildTreesAdapterInput(tree, docs);
@@ -1580,14 +1569,18 @@ async function start() {
     if (!manifestRes.ok) {
       throw new Error(`Failed to load manifest: ${manifestRes.status}`);
     }
-    manifest = await manifestRes.json();
+    manifest = normalizeManifestPayload(await manifestRes.json());
+    if (!manifest) {
+      throw new Error("Failed to load a supported manifest schema");
+    }
   }
   const mermaidConfig = resolveMermaidConfig(manifest);
   const pathBase = normalizePathBase(manifest.pathBase);
   const siteTitle = resolveSiteTitle(manifest);
   const defaultBranch = normalizeBranch(manifest.defaultBranch) || DEFAULT_BRANCH;
   const availableBranchSet = new Set([defaultBranch]);
-  for (const doc of manifest.docs) {
+  const manifestDocs = getManifestDocs(manifest);
+  for (const doc of manifestDocs) {
     const docBranch = normalizeBranch(doc.branch);
     if (docBranch) {
       availableBranchSet.add(docBranch);
@@ -1646,7 +1639,7 @@ async function start() {
   };
   let view = getBranchView(activeBranch);
 
-  const docsById = new Map(manifest.docs.map((doc) => [doc.id, doc]));
+  const docsById = new Map(manifestDocs.map((doc) => [doc.id, doc]));
 
   const updateBranchInfo = () => {
     if (sidebarBranchInfo instanceof HTMLElement) {

--- a/src/runtime/manifest-adapter.js
+++ b/src/runtime/manifest-adapter.js
@@ -1,0 +1,92 @@
+const CURRENT_SCHEMA_VERSION = 2;
+
+function isRecord(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+function hasManifestEnvelope(value) {
+  return isRecord(value) && Array.isArray(value.tree) && isRecord(value.routeMap);
+}
+
+function collectLegacyDocs(docs) {
+  if (!Array.isArray(docs)) {
+    return null;
+  }
+
+  const docIds = [];
+  const docsById = Object.create(null);
+  for (const doc of docs) {
+    if (!isRecord(doc) || typeof doc.id !== "string" || !doc.id || Object.hasOwn(docsById, doc.id)) {
+      return null;
+    }
+    docIds.push(doc.id);
+    docsById[doc.id] = doc;
+  }
+
+  return { docIds, docsById };
+}
+
+function collectCurrentDocs(docIdsInput, docsByIdInput) {
+  if (!Array.isArray(docIdsInput) || !isRecord(docsByIdInput)) {
+    return null;
+  }
+
+  const docIds = [];
+  const docsById = Object.create(null);
+  for (const id of docIdsInput) {
+    if (
+      typeof id !== "string" ||
+      !id ||
+      Object.hasOwn(docsById, id) ||
+      !Object.hasOwn(docsByIdInput, id)
+    ) {
+      return null;
+    }
+
+    const doc = docsByIdInput[id];
+    if (!isRecord(doc) || doc.id !== id) {
+      return null;
+    }
+    docIds.push(id);
+    docsById[id] = doc;
+  }
+
+  if (Object.keys(docsByIdInput).length !== docIds.length) {
+    return null;
+  }
+
+  return { docIds, docsById };
+}
+
+export function normalizeManifestPayload(value) {
+  if (!hasManifestEnvelope(value)) {
+    return null;
+  }
+
+  let normalizedDocs;
+  if (value.schemaVersion === CURRENT_SCHEMA_VERSION) {
+    normalizedDocs = collectCurrentDocs(value.docIds, value.docsById);
+  } else if (value.schemaVersion == null || value.schemaVersion === 1) {
+    normalizedDocs = collectLegacyDocs(value.docs);
+  } else {
+    return null;
+  }
+
+  if (!normalizedDocs) {
+    return null;
+  }
+
+  const { docs: _legacyDocs, ...manifest } = value;
+  return {
+    ...manifest,
+    schemaVersion: CURRENT_SCHEMA_VERSION,
+    ...normalizedDocs,
+  };
+}
+
+export function getManifestDocs(manifest) {
+  if (!manifest || !Array.isArray(manifest.docIds) || !isRecord(manifest.docsById)) {
+    return [];
+  }
+  return manifest.docIds.map((id) => manifest.docsById[id]).filter(Boolean);
+}

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -138,7 +138,7 @@ export function buildTreesAdapterInput(treeNodes, docs = []) {
       const treePath = registerPath(joinTreePath(parentPath, formatTreesFileBasename(node, doc), false), {
         branch: node.branch ?? doc?.branch ?? null,
         docId: node.id,
-        isNew: node.isNew === true,
+        isNew: (node.isNew ?? doc?.isNew) === true,
         kind: "file",
         prefix: node.prefix ?? doc?.prefix ?? "",
         route: node.route ?? doc?.route ?? "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -117,16 +117,6 @@ export interface FileNode {
   type: "file";
   name: string;
   id: string;
-  title: string;
-  prefix?: string;
-  route: string;
-  contentUrl: string;
-  isNew: boolean;
-  tags: string[];
-  description?: string;
-  date?: string;
-  updatedDate?: string;
-  branch: string | null;
 }
 
 export interface FolderNode {
@@ -139,7 +129,30 @@ export interface FolderNode {
 
 export type TreeNode = FolderNode | FileNode;
 
+export interface ManifestDoc {
+  id: string;
+  route: string;
+  title: string;
+  prefix?: string;
+  categoryPath: string;
+  contentUrl: string;
+  date?: string;
+  updatedDate?: string;
+  tags: string[];
+  description?: string;
+  isNew: boolean;
+  branch: string | null;
+  wikiTargets: string[];
+  backlinks: Array<{
+    id: string;
+    route: string;
+    title: string;
+    prefix?: string;
+  }>;
+}
+
 export interface Manifest {
+  schemaVersion: 2;
   generatedAt: string;
   siteTitle: string;
   pathBase: string;
@@ -156,27 +169,8 @@ export interface Manifest {
   };
   tree: TreeNode[];
   routeMap: Record<string, string>;
-  docs: Array<{
-    id: string;
-    route: string;
-    title: string;
-    prefix?: string;
-    categoryPath: string;
-    contentUrl: string;
-    date?: string;
-    updatedDate?: string;
-    tags: string[];
-    description?: string;
-    isNew: boolean;
-    branch: string | null;
-    wikiTargets: string[];
-    backlinks: Array<{
-      id: string;
-      route: string;
-      title: string;
-      prefix?: string;
-    }>;
-  }>;
+  docIds: string[];
+  docsById: Record<string, ManifestDoc>;
 }
 
 export interface BuildCache {

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -117,7 +117,41 @@ function findFolderNodeByPath(
 test.describe("빌드 회귀 가드", () => {
   const repoRoot = process.cwd();
   const cliPath = path.join(repoRoot, "src/cli.ts");
+  const sizeCheckPath = path.join(repoRoot, "scripts/check-output-size.ts");
   const vaultPath = path.join(repoRoot, "test-vault");
+
+  test("manifest size gate는 empty/one-doc vault의 고정 overhead를 허용한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-small-manifest-size-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+
+    try {
+      fs.mkdirSync(vaultDir, { recursive: true });
+      const emptyBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(emptyBuild.status, emptyBuild.output).toBe(0);
+      const emptyCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
+      expect(emptyCheck.status, emptyCheck.output).toBe(0);
+      expect(emptyCheck.output).toContain("manifest ratio gate skipped for 0 doc(s)");
+
+      writeText(
+        path.join(vaultDir, "only.md"),
+        `---
+publish: true
+prefix: SMALL-01
+category_path: small
+title: Only document
+---
+`,
+      );
+      const oneDocBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(oneDocBuild.status, oneDocBuild.output).toBe(0);
+      const oneDocCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
+      expect(oneDocCheck.status, oneDocCheck.output).toBe(0);
+      expect(oneDocCheck.output).toContain("manifest ratio gate skipped for 1 doc(s)");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
 
   test("증분 빌드에서 누락된 content 파일을 복구한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-build-regression-"));

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -120,7 +120,7 @@ test.describe("빌드 회귀 가드", () => {
   const sizeCheckPath = path.join(repoRoot, "scripts/check-output-size.ts");
   const vaultPath = path.join(repoRoot, "test-vault");
 
-  test("manifest size gate는 empty/one-doc vault의 고정 overhead를 허용한다", async () => {
+  test("manifest size gate는 tiny vault의 고정 overhead를 허용한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-small-manifest-size-"));
     const vaultDir = path.join(workDir, "vault");
     const outDir = path.join(workDir, "dist");
@@ -131,7 +131,7 @@ test.describe("빌드 회귀 가드", () => {
       expect(emptyBuild.status, emptyBuild.output).toBe(0);
       const emptyCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
       expect(emptyCheck.status, emptyCheck.output).toBe(0);
-      expect(emptyCheck.output).toContain("manifest ratio gate skipped for 0 doc(s)");
+      expect(emptyCheck.output).toContain("manifest ratio gate skipped for legacy projection");
 
       writeText(
         path.join(vaultDir, "only.md"),
@@ -147,7 +147,25 @@ title: Only document
       expect(oneDocBuild.status, oneDocBuild.output).toBe(0);
       const oneDocCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
       expect(oneDocCheck.status, oneDocCheck.output).toBe(0);
-      expect(oneDocCheck.output).toContain("manifest ratio gate skipped for 1 doc(s)");
+      expect(oneDocCheck.output).toContain("manifest ratio gate skipped for legacy projection");
+
+      for (let index = 2; index <= 3; index += 1) {
+        writeText(
+          path.join(vaultDir, `doc-${index}.md`),
+          `---
+publish: true
+prefix: SMALL-0${index}
+category_path: small
+title: Document ${index}
+---
+`,
+        );
+        const tinyBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+        expect(tinyBuild.status, tinyBuild.output).toBe(0);
+        const tinyCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
+        expect(tinyCheck.status, tinyCheck.output).toBe(0);
+        expect(tinyCheck.output).toContain("manifest ratio gate skipped for legacy projection");
+      }
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -9,6 +9,31 @@ interface CliResult {
   output: string;
 }
 
+interface ManifestDocIndex<T> {
+  schemaVersion: number;
+  docIds: string[];
+  docsById: Record<string, T>;
+}
+
+interface TestTreeNode {
+  type: string;
+  id?: string;
+  name?: string;
+  path?: string;
+  children?: TestTreeNode[];
+}
+
+function getManifestDocs<T>(manifest: ManifestDocIndex<T>): T[] {
+  return manifest.docIds.map((id) => manifest.docsById[id]).filter((doc): doc is T => doc !== undefined);
+}
+
+function getTreeDocTitles(
+  nodes: TestTreeNode[] | undefined,
+  docsById: Record<string, { title: string }>,
+): Array<string | undefined> {
+  return (nodes ?? []).map((node) => (node.id ? docsById[node.id]?.title : undefined));
+}
+
 function writeText(filePath: string, content: string): void {
   fs.mkdirSync(path.dirname(filePath), { recursive: true });
   fs.writeFileSync(filePath, content, "utf8");
@@ -37,10 +62,8 @@ function runCli(cwd: string, args: string[], timeout?: number): CliResult {
 }
 
 function readDocContentHtml(outDir: string, route: string): string {
-  const manifest = readManifest(outDir) as {
-    docs: Array<{ route: string; contentUrl: string }>;
-  };
-  const doc = manifest.docs.find((entry) => entry.route === route);
+  const manifest = readManifest(outDir) as ManifestDocIndex<{ route: string; contentUrl: string }>;
+  const doc = getManifestDocs(manifest).find((entry) => entry.route === route);
   if (!doc) {
     throw new Error(`route ${route} 문서를 manifest에서 찾지 못했습니다.`);
   }
@@ -73,18 +96,15 @@ function findOnlyCacheIndexPath(workDir: string): string {
 }
 
 function findFolderNodeByPath(
-  nodes: Array<{ type: string; path?: string; children?: Array<{ type: string; path?: string; children?: unknown[] }> }>,
+  nodes: TestTreeNode[],
   targetPath: string,
-): { type: string; path?: string; children?: Array<{ type: string; path?: string; children?: unknown[] }> } | null {
+): TestTreeNode | null {
   for (const node of nodes) {
     if (node.type === "folder" && node.path === targetPath) {
       return node;
     }
     if (node.type === "folder" && Array.isArray(node.children)) {
-      const found = findFolderNodeByPath(
-        node.children as Array<{ type: string; path?: string; children?: Array<{ type: string; path?: string; children?: unknown[] }> }>,
-        targetPath,
-      );
+      const found = findFolderNodeByPath(node.children, targetPath);
       if (found) {
         return found;
       }
@@ -612,8 +632,8 @@ VAULT_B_BODY
       expect(wrongVaultBuild.status).not.toBe(0);
       expect(wrongVaultBuild.output).toContain("matching .eiam-output.json");
       expect(fs.readFileSync(markerAPath, "utf8")).toBe(markerABefore);
-      const manifestAfterWrongBuild = readManifest(outA) as { docs: Array<{ route: string }> };
-      expect(manifestAfterWrongBuild.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
+      const manifestAfterWrongBuild = readManifest(outA) as ManifestDocIndex<{ route: string }>;
+      expect(getManifestDocs(manifestAfterWrongBuild).map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
 
       const wrongVaultClean = runCli(workDir, [cliPath, "clean", "--vault", vaultB, "--out", outA]);
       expect(wrongVaultClean.status).not.toBe(0);
@@ -633,9 +653,9 @@ VAULT_B_BODY
       expect(wrongCwdBuild.output).toContain("matching .eiam-output.json");
       expect(fs.readFileSync(markerAPath, "utf8")).toBe(markerABefore);
       expect(fs.existsSync(path.join(alternateCwd, ".cache", "eiam"))).toBe(false);
-      expect((readManifest(outA) as { docs: Array<{ route: string }> }).docs.map((doc) => doc.route)).toEqual([
-        "/NS-CACHE-A/",
-      ]);
+      expect(
+        getManifestDocs(readManifest(outA) as ManifestDocIndex<{ route: string }>).map((doc) => doc.route),
+      ).toEqual(["/NS-CACHE-A/"]);
 
       const wrongCwdClean = runCli(alternateCwd, [
         cliPath,
@@ -657,8 +677,8 @@ VAULT_B_BODY
       const cacheB = afterBuildB.find((cachePath) => cachePath !== cacheA);
       expect(cacheB).toBeDefined();
       expect(fs.readFileSync(cacheB!, "utf8")).toContain("VAULT_B_BODY");
-      const manifestB = readManifest(outB) as { docs: Array<{ route: string }> };
-      expect(manifestB.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-B/"]);
+      const manifestB = readManifest(outB) as ManifestDocIndex<{ route: string }>;
+      expect(getManifestDocs(manifestB).map((doc) => doc.route)).toEqual(["/NS-CACHE-B/"]);
 
       const alternateBuild = runCli(workDir, [
         cliPath,
@@ -679,8 +699,8 @@ VAULT_B_BODY
       const rebuildA = runCli(workDir, [cliPath, "build", "--vault", vaultA, "--out", outA]);
       expect(rebuildA.status, rebuildA.output).toBe(0);
       expect(rebuildA.output).toContain("total=1 rendered=0 skipped=1");
-      const manifestA = readManifest(outA) as { docs: Array<{ route: string }> };
-      expect(manifestA.docs.map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
+      const manifestA = readManifest(outA) as ManifestDocIndex<{ route: string }>;
+      expect(getManifestDocs(manifestA).map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
 
       const unrelatedCacheFile = path.join(workDir, ".cache", "keep.txt");
       writeText(unrelatedCacheFile, "unrelated cache data");
@@ -810,11 +830,13 @@ TARGET_B_BODY
       expect(fs.existsSync(path.join(outDir, "FP-ROUTE-A", "index.html"))).toBe(false);
       expect(fs.existsSync(path.join(outDir, "FP-ROUTE-B", "index.html"))).toBe(true);
 
-      const manifest = readManifest(outDir) as {
-        docs: Array<{ route: string; backlinks: Array<{ route: string }> }>;
-      };
-      const targetA = manifest.docs.find((doc) => doc.route === "/FP-TARGET-A/");
-      const targetB = manifest.docs.find((doc) => doc.route === "/FP-TARGET-B/");
+      const manifest = readManifest(outDir) as ManifestDocIndex<{
+        route: string;
+        backlinks: Array<{ route: string }>;
+      }>;
+      const docs = getManifestDocs(manifest);
+      const targetA = docs.find((doc) => doc.route === "/FP-TARGET-A/");
+      const targetB = docs.find((doc) => doc.route === "/FP-TARGET-B/");
       expect(targetA?.backlinks).toEqual([]);
       expect(targetB?.backlinks.map((backlink) => backlink.route)).toEqual(["/FP-LINKER/"]);
     } finally {
@@ -1055,8 +1077,11 @@ DRAFT_CACHE_SECRET
 
       const stateBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(stateBuild.status, stateBuild.output).toBe(0);
-      const manifest = readManifest(outDir) as { docs: Array<{ route: string }> };
-      expect(manifest.docs.map((doc) => doc.route).sort()).toEqual(["/CACHE-DRAFT/", "/CACHE-PRIVATE/"]);
+      const manifest = readManifest(outDir) as ManifestDocIndex<{ route: string }>;
+      expect(getManifestDocs(manifest).map((doc) => doc.route).sort()).toEqual([
+        "/CACHE-DRAFT/",
+        "/CACHE-PRIVATE/",
+      ]);
 
       const nextCache = fs.readFileSync(cachePath, "utf8");
       expect(nextCache).not.toContain("PUBLIC_CACHE_BODY");
@@ -1277,34 +1302,31 @@ title: API Detail
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
 
-      const manifest = readManifest(outDir) as {
-        tree: Array<{
-          type: string;
-          path?: string;
-          name?: string;
-          children?: Array<{ type: string; title?: string; path?: string; children?: unknown[] }>;
-        }>;
-        docs: Array<{ route: string; categoryPath: string }>;
-      };
+      const manifest = readManifest(outDir) as ManifestDocIndex<{
+        route: string;
+        categoryPath: string;
+        title: string;
+      }> & { tree: TestTreeNode[] };
+      const docs = getManifestDocs(manifest);
 
       const pinnedFolder = manifest.tree[0];
       expect(pinnedFolder.type).toBe("folder");
       expect(pinnedFolder.path).toBe("__virtual__/pinned/category/engineering/guides");
-      expect(pinnedFolder.children?.map((node) => node.title)).toEqual(["Guide Overview", "API Detail"]);
+      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual(["Guide Overview", "API Detail"]);
 
       const engineeringFolder = findFolderNodeByPath(manifest.tree, "engineering");
       expect(engineeringFolder).not.toBeNull();
       const guidesFolder = findFolderNodeByPath(manifest.tree, "engineering/guides");
       expect(guidesFolder).not.toBeNull();
-      expect(guidesFolder?.children?.some((node) => node.title === "Guide Overview")).toBe(true);
+      expect(getTreeDocTitles(guidesFolder?.children, manifest.docsById)).toContain("Guide Overview");
       expect(findFolderNodeByPath(manifest.tree, "misc")).toBeNull();
 
       const apiFolder = findFolderNodeByPath(manifest.tree, "engineering/guides/api");
       expect(apiFolder).not.toBeNull();
-      expect(apiFolder?.children?.some((node) => node.title === "API Detail")).toBe(true);
+      expect(getTreeDocTitles(apiFolder?.children, manifest.docsById)).toContain("API Detail");
 
-      expect(manifest.docs.find((doc) => doc.route === "/CAT-02/")?.categoryPath).toBe("engineering/guides");
-      expect(manifest.docs.find((doc) => doc.route === "/CAT-03/")?.categoryPath).toBe("engineering/guides/api");
+      expect(docs.find((doc) => doc.route === "/CAT-02/")?.categoryPath).toBe("engineering/guides");
+      expect(docs.find((doc) => doc.route === "/CAT-03/")?.categoryPath).toBe("engineering/guides/api");
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -1330,8 +1352,8 @@ title: Missing Category
       expect(build.status, build.output).toBe(0);
       expect(build.output).toContain("[publish] Skipped published doc without category_path: notes/missing-category.md");
 
-      const manifest = readManifest(outDir) as { docs: Array<{ route: string }> };
-      expect(manifest.docs).toEqual([]);
+      const manifest = readManifest(outDir) as ManifestDocIndex<{ route: string }>;
+      expect(getManifestDocs(manifest)).toEqual([]);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -1388,18 +1410,15 @@ title: Should Not Pin
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
 
-      const manifest = readManifest(outDir) as {
-        tree: Array<{
-          type: string;
-          path?: string;
-          children?: Array<{ title?: string }>;
-        }>;
-      };
+      const manifest = readManifest(outDir) as ManifestDocIndex<{ title: string }> & { tree: TestTreeNode[] };
 
       const pinnedFolder = manifest.tree[0];
       expect(pinnedFolder.type).toBe("folder");
       expect(pinnedFolder.path).toBe("__virtual__/pinned/source/legacy-notice");
-      expect(pinnedFolder.children?.map((node) => node.title)).toEqual(["Legacy Notice One", "Legacy Notice Two"]);
+      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual([
+        "Legacy Notice One",
+        "Legacy Notice Two",
+      ]);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -1446,25 +1465,23 @@ title: Normalized API Reference
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
 
-      const manifest = readManifest(outDir) as {
-        tree: Array<{
-          type: string;
-          path?: string;
-          children?: Array<{ title?: string; path?: string; children?: unknown[] }>;
-        }>;
-        docs: Array<{ route: string; categoryPath: string }>;
-      };
+      const manifest = readManifest(outDir) as ManifestDocIndex<{
+        route: string;
+        categoryPath: string;
+        title: string;
+      }> & { tree: TestTreeNode[] };
+      const docs = getManifestDocs(manifest);
 
       expect(manifest.tree[0]?.path).toBe("__virtual__/pinned/category/engineering/guides/api");
-      expect(manifest.tree[0]?.children?.map((node) => node.title)).toEqual([
+      expect(getTreeDocTitles(manifest.tree[0]?.children, manifest.docsById)).toEqual([
         "Normalized API Guide",
         "Normalized API Reference",
       ]);
 
       expect(findFolderNodeByPath(manifest.tree, "engineering/guides/api")).not.toBeNull();
       expect(findFolderNodeByPath(manifest.tree, "engineering/guides/api/reference")).not.toBeNull();
-      expect(manifest.docs.find((doc) => doc.route === "/NORM-01/")?.categoryPath).toBe("engineering/guides/api");
-      expect(manifest.docs.find((doc) => doc.route === "/NORM-02/")?.categoryPath).toBe(
+      expect(docs.find((doc) => doc.route === "/NORM-01/")?.categoryPath).toBe("engineering/guides/api");
+      expect(docs.find((doc) => doc.route === "/NORM-02/")?.categoryPath).toBe(
         "engineering/guides/api/reference",
       );
     } finally {
@@ -1535,19 +1552,12 @@ title: Menu Config Guide
       ]);
       expect(build.status, build.output).toBe(0);
 
-      const manifest = readManifest(outDir) as {
-        tree: Array<{
-          type: string;
-          path?: string;
-          name?: string;
-          children?: Array<{ title?: string }>;
-        }>;
-      };
+      const manifest = readManifest(outDir) as ManifestDocIndex<{ title: string }> & { tree: TestTreeNode[] };
 
       const pinnedFolder = manifest.tree[0];
       expect(pinnedFolder.name).toBe("GUIDES");
       expect(pinnedFolder.path).toBe("__virtual__/pinned/category/engineering/guides");
-      expect(pinnedFolder.children?.map((node) => node.title)).toEqual(["Menu Config Guide"]);
+      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual(["Menu Config Guide"]);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/manifest-adapter.spec.ts
+++ b/tests/e2e/manifest-adapter.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { getManifestDocs, normalizeManifestPayload } from "../../src/runtime/manifest-adapter.js";
+
+const envelope = {
+  tree: [],
+  routeMap: {},
+  defaultBranch: "dev",
+};
+
+test.describe("manifest schema adapter", () => {
+  test("schema v2의 canonical doc 순서를 유지한다", () => {
+    const normalized = normalizeManifestPayload({
+      ...envelope,
+      schemaVersion: 2,
+      docIds: ["doc-b", "doc-a"],
+      docsById: {
+        "doc-a": { id: "doc-a", route: "/A/" },
+        "doc-b": { id: "doc-b", route: "/B/" },
+      },
+    });
+
+    expect(normalized).not.toBeNull();
+    expect(getManifestDocs(normalized).map((doc) => doc.route)).toEqual(["/B/", "/A/"]);
+  });
+
+  test("legacy docs array payload를 schema v2 index로 migration한다", () => {
+    const legacy = {
+      ...envelope,
+      schemaVersion: 1,
+      docs: [
+        { id: "doc-a", route: "/A/" },
+        { id: "doc-b", route: "/B/" },
+      ],
+    };
+
+    const normalized = normalizeManifestPayload(legacy);
+
+    expect(normalized).toMatchObject({
+      schemaVersion: 2,
+      docIds: ["doc-a", "doc-b"],
+      docsById: {
+        "doc-a": { id: "doc-a", route: "/A/" },
+        "doc-b": { id: "doc-b", route: "/B/" },
+      },
+    });
+    expect(normalized).not.toHaveProperty("docs");
+  });
+
+  test("unsupported version과 dangling doc reference를 거부한다", () => {
+    expect(
+      normalizeManifestPayload({
+        ...envelope,
+        schemaVersion: 3,
+        docIds: [],
+        docsById: {},
+      }),
+    ).toBeNull();
+
+    expect(
+      normalizeManifestPayload({
+        ...envelope,
+        schemaVersion: 2,
+        docIds: ["missing"],
+        docsById: {},
+      }),
+    ).toBeNull();
+  });
+});

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -6,6 +6,7 @@ test.describe("Trees sidebar adapter", () => {
     const docs = [
       {
         id: "doc-a",
+        isNew: true,
         prefix: "BC-VO-02",
         route: "/BC-VO-02/",
         title: "Setup Guide",
@@ -13,6 +14,7 @@ test.describe("Trees sidebar adapter", () => {
       },
       {
         id: "doc-b",
+        isNew: false,
         prefix: "BC-XSS-01",
         route: "/BC-XSS-01/",
         title: "Unsafe <img src=x onerror=alert(1)>",
@@ -30,11 +32,6 @@ test.describe("Trees sidebar adapter", () => {
             type: "file",
             id: "doc-a",
             name: "setup-guide.md",
-            prefix: "BC-VO-02",
-            route: "/BC-VO-02/",
-            title: "Setup Guide",
-            isNew: true,
-            branch: null,
           },
         ],
       },
@@ -48,21 +45,11 @@ test.describe("Trees sidebar adapter", () => {
             type: "file",
             id: "doc-a",
             name: "setup-guide.md",
-            prefix: "BC-VO-02",
-            route: "/BC-VO-02/",
-            title: "Setup Guide",
-            isNew: true,
-            branch: null,
           },
           {
             type: "file",
             id: "doc-b",
             name: "unsafe.md",
-            prefix: "BC-XSS-01",
-            route: "/BC-XSS-01/",
-            title: "Unsafe <img src=x onerror=alert(1)>",
-            isNew: false,
-            branch: null,
           },
         ],
       },
@@ -80,11 +67,6 @@ test.describe("Trees sidebar adapter", () => {
                 type: "file",
                 id: "doc-a",
                 name: "setup-guide.md",
-                prefix: "BC-VO-02",
-                route: "/BC-VO-02/",
-                title: "Setup Guide",
-                isNew: true,
-                branch: null,
               },
             ],
           },
@@ -112,6 +94,7 @@ test.describe("Trees sidebar adapter", () => {
       "engineering/guides/BC-VO-02 Setup Guide",
     ]);
     expect(adapter.docIdToPrimaryTreePath.get("doc-a")).toBe("PINNED/BC-VO-02 Setup Guide");
+    expect(adapter.metadataByTreePath.get("Recent/BC-VO-02 Setup Guide")?.isNew).toBe(true);
   });
 
   test("file basenames use prefix plus title and avoid path separator leaks", () => {

--- a/tests/e2e/utils/manifest.ts
+++ b/tests/e2e/utils/manifest.ts
@@ -44,17 +44,35 @@ export async function getInitialManifest(page: Page): Promise<ManifestShape> {
     }
   });
 
-  if (!manifest || typeof manifest !== "object" || !Array.isArray((manifest as { docs?: unknown[] }).docs)) {
+  if (!manifest || typeof manifest !== "object") {
     throw new Error("초기 manifest 데이터를 읽지 못했습니다.");
   }
 
-  const defaultBranchRaw = (manifest as { defaultBranch?: unknown }).defaultBranch;
+  const manifestRecord = manifest as {
+    schemaVersion?: unknown;
+    defaultBranch?: unknown;
+    docIds?: unknown;
+    docsById?: unknown;
+  };
+  if (
+    manifestRecord.schemaVersion !== 2 ||
+    !Array.isArray(manifestRecord.docIds) ||
+    !manifestRecord.docsById ||
+    typeof manifestRecord.docsById !== "object"
+  ) {
+    throw new Error("초기 manifest schema v2 데이터를 읽지 못했습니다.");
+  }
+
+  const defaultBranchRaw = manifestRecord.defaultBranch;
   const defaultBranch = normalizeBranch(defaultBranchRaw);
   if (!defaultBranch) {
     throw new Error("manifest.defaultBranch 값이 유효하지 않습니다.");
   }
 
-  const docs = (manifest as { docs: Array<{ route?: unknown; branch?: unknown }> }).docs
+  const docsById = manifestRecord.docsById as Record<string, { route?: unknown; branch?: unknown }>;
+  const docs = manifestRecord.docIds
+    .map((id) => (typeof id === "string" ? docsById[id] : undefined))
+    .filter((doc): doc is { route?: unknown; branch?: unknown } => !!doc)
     .filter((doc) => typeof doc.route === "string" && doc.route.length > 0)
     .map((doc) => ({
       route: String(doc.route),


### PR DESCRIPTION
Part of #22. Implements the detailed acceptance criteria retained in #25.

## Summary

- Publish manifest schema v2 with ordered `docIds` and canonical `docsById`
- Reduce every real/recent/pinned tree file node to an `id`/`name` document reference
- Resolve tree labels, routes, branch metadata, and new-state from the canonical document index
- Add a runtime migration adapter for legacy unversioned/v1 `docs` arrays
- Enforce schema integrity, dangling-reference checks, and manifest size regression ratios in CI

## DnD

- [x] Shared document metadata has one canonical `docsById` representation
- [x] Real, Recent, and pinned tree nodes reference canonical document IDs
- [x] Runtime consumers resolve metadata through the schema adapter without behavior loss
- [x] Schema v2 is explicit and legacy unversioned/v1 payloads migrate safely
- [x] Manifest raw/gzip regression is measured and enforced

## Measurements

`test-vault` production manifest:

| Asset | Before raw/gzip | After raw/gzip | Change |
| --- | ---: | ---: | ---: |
| `manifest.json` | 10,047 / 1,676 B | 6,333 / 1,460 B | -37.0% / -12.9% |

The CI gate also reconstructs the former duplicated projection from the same payload and requires schema v2 to remain at or below 75% raw and 95% gzip.

## Verification

- `bunx --package typescript tsc --noEmit`
- `bun run build -- --vault ./test-vault --out ./dist`
- `bun run check:size`
- focused build/schema/tree regression: 26 passed
- `bun run test:e2e`: 48 passed
