### PR TITLE
build: make no-op output reproducible

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -33,6 +33,9 @@ jobs:
       - name: Enforce generated asset size budgets
         run: bun run check:size
 
+      - name: Verify reproducible no-op builds
+        run: bun run check:reproducible
+
       - name: Run E2E tests
         run: bun run test:e2e
 

--- a/README.md
+++ b/README.md
@@ -213,10 +213,13 @@ Key points:
 - Production JavaScript and CSS are minified, then content-hashed from the final emitted bytes.
 - `manifest.json` uses schema v2: `docIds` preserves order, `docsById` is the canonical metadata index, and tree file nodes carry document references instead of duplicated metadata. The runtime adapter also accepts legacy unversioned/v1 `docs` arrays during migration.
 - Route HTML embeds only a small path-aware runtime bootstrap; the shared manifest is fetched once from `manifest.json` instead of being copied into every generated page.
+- Generated files omit wall-clock build metadata, so two builds with unchanged content and config produce byte-identical output.
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
 CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command requires each EIAM-generated route HTML runtime bootstrap to contain only `manifestUrl`/`pathBase` and stay within 256 bytes; copied static HTML is left untouched. It also always validates manifest schema v2 canonical document references. Once the reconstructed legacy projection reaches 8,000 bytes, it requires at least 25% raw and 5% gzip reduction versus that duplicated tree/document projection. Smaller manifests skip only this relative ratio because fixed schema/gzip overhead dominates when there is not yet enough duplicated payload to measure reliably.
+
+Run `bun run check:reproducible` to perform two no-op builds into the same output and compare SHA-256 hashes for every generated file. CI applies the same double-build check.
 
 ## Config File
 

--- a/README.md
+++ b/README.md
@@ -213,7 +213,7 @@ Key points:
 - Production JavaScript and CSS are minified, then content-hashed from the final emitted bytes.
 - `manifest.json` uses schema v2: `docIds` preserves order, `docsById` is the canonical metadata index, and tree file nodes carry document references instead of duplicated metadata. The runtime adapter also accepts legacy unversioned/v1 `docs` arrays during migration.
 - Route HTML embeds only a small path-aware runtime bootstrap; the shared manifest is fetched once from `manifest.json` instead of being copied into every generated page.
-- Generated files omit wall-clock build metadata, so two builds with unchanged content and config produce byte-identical output.
+- Generated files omit wall-clock build metadata and derived current-time flags, so two builds with unchanged content and config produce byte-identical output. The runtime derives each `NEW` badge from the manifest `date` and configured `newWithinDays` when the page loads.
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
 		"dev": "bun run src/cli.ts dev",
 		"clean": "bun run src/cli.ts clean",
 		"check:size": "bun run scripts/check-output-size.ts --out ./dist",
+		"check:reproducible": "bun run scripts/check-build-reproducibility.ts --vault ./test-vault --out ./dist",
 		"lint:md:publish": "bun run scripts/lint-published-markdown.ts --out-dir dist",
 		"test:e2e": "playwright test",
 		"test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"

--- a/scripts/check-build-reproducibility.ts
+++ b/scripts/check-build-reproducibility.ts
@@ -1,0 +1,89 @@
+import crypto from "node:crypto";
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import path from "node:path";
+
+function readOption(argv: string[], name: string, fallback: string): string {
+  const index = argv.indexOf(name);
+  if (index === -1) {
+    return path.resolve(fallback);
+  }
+  const value = argv[index + 1]?.trim();
+  if (!value || value.startsWith("-")) {
+    throw new Error(`[reproducible] Missing value for ${name}`);
+  }
+  return path.resolve(value);
+}
+
+function runBuild(vaultDir: string, outDir: string): void {
+  const result = spawnSync("bun", ["run", "src/cli.ts", "build", "--vault", vaultDir, "--out", outDir], {
+    cwd: process.cwd(),
+    encoding: "utf8",
+  });
+  if (result.status !== 0) {
+    process.stderr.write(result.stdout ?? "");
+    process.stderr.write(result.stderr ?? "");
+    throw new Error(`[reproducible] Build failed with status ${String(result.status)}`);
+  }
+}
+
+function snapshotFiles(rootDir: string): Map<string, string> {
+  const hashes = new Map<string, string>();
+  const walk = (directory: string) => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name, "en"),
+    );
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolutePath);
+      } else if (entry.isFile()) {
+        const relativePath = path.relative(rootDir, absolutePath).split(path.sep).join("/");
+        const hash = crypto.createHash("sha256").update(fs.readFileSync(absolutePath)).digest("hex");
+        hashes.set(relativePath, hash);
+      }
+    }
+  };
+  walk(rootDir);
+  return hashes;
+}
+
+function compareSnapshots(before: Map<string, string>, after: Map<string, string>): string[] {
+  const failures: string[] = [];
+  const allPaths = new Set([...before.keys(), ...after.keys()]);
+  for (const filePath of Array.from(allPaths).sort()) {
+    if (!before.has(filePath)) {
+      failures.push(`added ${filePath}`);
+    } else if (!after.has(filePath)) {
+      failures.push(`removed ${filePath}`);
+    } else if (before.get(filePath) !== after.get(filePath)) {
+      failures.push(`changed ${filePath}`);
+    }
+  }
+  return failures;
+}
+
+const argv = process.argv.slice(2);
+const vaultDir = readOption(argv, "--vault", "test-vault");
+const outDir = readOption(argv, "--out", "dist");
+
+runBuild(vaultDir, outDir);
+const first = snapshotFiles(outDir);
+await new Promise((resolve) => setTimeout(resolve, 20));
+runBuild(vaultDir, outDir);
+const second = snapshotFiles(outDir);
+const failures = compareSnapshots(first, second);
+
+if (failures.length > 0) {
+  for (const failure of failures) {
+    console.error(`[reproducible] ${failure}`);
+  }
+  process.exitCode = 1;
+} else {
+  const digest = crypto
+    .createHash("sha256")
+    .update(Array.from(second, ([filePath, hash]) => `${filePath}\0${hash}`).join("\n"))
+    .digest("hex")
+    .slice(0, 12);
+  console.log(`[reproducible] ${second.size} files stable digest=${digest}`);
+}

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -106,7 +106,6 @@ function toLegacyTree(nodes: unknown[], docsById: Record<string, ManifestDoc>): 
       prefix: doc.prefix,
       route: doc.route,
       contentUrl: doc.contentUrl,
-      isNew: doc.isNew,
       tags: doc.tags,
       description: doc.description,
       date: doc.date,

--- a/src/build.ts
+++ b/src/build.ts
@@ -819,7 +819,6 @@ function toDocRecord(
   sourcePath: string,
   relPath: string,
   entry: CachedSourceEntry,
-  newThreshold: number,
 ): DocRecord {
   const relNoExt = stripMdExt(relPath);
   const fileName = path.basename(relPath);
@@ -844,7 +843,6 @@ function toDocRecord(
     body: entry.body,
     rawHash: entry.rawHash,
     wikiTargets: entry.wikiTargets,
-    isNew: isNewByFrontmatterDate(entry.date, newThreshold),
     branch: entry.branch,
   };
 }
@@ -859,9 +857,6 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
       stat: await fs.stat(sourcePath),
     })),
   );
-  const now = Date.now();
-  const newThreshold = now - options.newWithinDays * 24 * 60 * 60 * 1000;
-
   const docs: DocRecord[] = [];
   const nextSources: BuildCache["sources"] = {};
 
@@ -905,7 +900,7 @@ async function readPublishedDocs(options: BuildOptions, previousSources: BuildCa
     }
 
     nextSources[relPath] = completeEntry;
-    docs.push(toDocRecord(sourcePath, relPath, completeEntry, newThreshold));
+    docs.push(toDocRecord(sourcePath, relPath, completeEntry));
   }
 
   ensureUniqueRoutes(docs);
@@ -1059,11 +1054,6 @@ function parseDateToEpochMs(value: string | undefined): number | null {
   return Number.isFinite(parsed) ? parsed : null;
 }
 
-function isNewByFrontmatterDate(date: string | undefined, newThreshold: number): boolean {
-  const publishedAt = parseDateToEpochMs(date);
-  return publishedAt != null && publishedAt >= newThreshold;
-}
-
 function getRecentSortEpochMs(doc: DocRecord): number | null {
   return parseDateToEpochMs(doc.updatedDate) ?? parseDateToEpochMs(doc.date);
 }
@@ -1213,7 +1203,6 @@ function buildManifest(docs: DocRecord[], tree: TreeNode[], options: BuildOption
         updatedDate: doc.updatedDate,
         tags: doc.tags,
         description: doc.description,
-        isNew: doc.isNew,
         contentUrl: doc.contentUrl,
         branch: doc.branch,
         wikiTargets: doc.wikiTargets,

--- a/src/build.ts
+++ b/src/build.ts
@@ -1241,7 +1241,6 @@ function buildManifest(docs: DocRecord[], tree: TreeNode[], options: BuildOption
 
   return {
     schemaVersion: 2,
-    generatedAt: new Date().toISOString(),
     siteTitle: resolveSiteTitle(options),
     pathBase: options.seo?.pathBase ?? "",
     defaultBranch: DEFAULT_BRANCH,

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,5 +1,5 @@
 import { FileTree, prepareFileTreeInput } from "@pierre/trees";
-import { getManifestDocs, normalizeManifestPayload } from "./manifest-adapter.js";
+import { getRuntimeManifestDocs, normalizeManifestPayload } from "./manifest-adapter.js";
 import { buildTreesAdapterInput } from "./tree-adapter.js";
 
 const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
@@ -811,8 +811,8 @@ function cloneFilteredTree(nodes, visibleDocIds) {
   return filteredNodes;
 }
 
-function buildBranchView(manifest, branch, defaultBranch) {
-  const docs = getManifestDocs(manifest).filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
+function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
+  const docs = manifestDocs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
   const visibleDocIds = new Set(docs.map((doc) => doc.id));
   const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
   const trees = buildTreesAdapterInput(tree, docs);
@@ -1588,7 +1588,7 @@ async function start() {
   const siteTitle = resolveSiteTitle(manifest);
   const defaultBranch = normalizeBranch(manifest.defaultBranch) || DEFAULT_BRANCH;
   const availableBranchSet = new Set([defaultBranch]);
-  const manifestDocs = getManifestDocs(manifest);
+  const manifestDocs = getRuntimeManifestDocs(manifest);
   for (const doc of manifestDocs) {
     const docBranch = normalizeBranch(doc.branch);
     if (docBranch) {
@@ -1642,7 +1642,7 @@ async function start() {
     if (cached) {
       return cached;
     }
-    const nextView = buildBranchView(manifest, branch, defaultBranch);
+    const nextView = buildBranchView(manifest, manifestDocs, branch, defaultBranch);
     branchViewCache.set(branch, nextView);
     return nextView;
   };

--- a/src/runtime/manifest-adapter.js
+++ b/src/runtime/manifest-adapter.js
@@ -90,3 +90,18 @@ export function getManifestDocs(manifest) {
   }
   return manifest.docIds.map((id) => manifest.docsById[id]).filter(Boolean);
 }
+
+export function getRuntimeManifestDocs(manifest, nowMs = Date.now()) {
+  const newWithinDays = Number.isFinite(manifest?.ui?.newWithinDays)
+    ? Math.max(0, Number(manifest.ui.newWithinDays))
+    : 0;
+  const threshold = nowMs - newWithinDays * 24 * 60 * 60 * 1000;
+
+  return getManifestDocs(manifest).map((doc) => {
+    const publishedAt = typeof doc.date === "string" ? Date.parse(doc.date) : Number.NaN;
+    return {
+      ...doc,
+      isNew: Number.isFinite(publishedAt) && publishedAt >= threshold,
+    };
+  });
+}

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -138,7 +138,7 @@ export function buildTreesAdapterInput(treeNodes, docs = []) {
       const treePath = registerPath(joinTreePath(parentPath, formatTreesFileBasename(node, doc), false), {
         branch: node.branch ?? doc?.branch ?? null,
         docId: node.id,
-        isNew: (node.isNew ?? doc?.isNew) === true,
+        isNew: (doc?.isNew ?? node.isNew) === true,
         kind: "file",
         prefix: node.prefix ?? doc?.prefix ?? "",
         route: node.route ?? doc?.route ?? "",

--- a/src/types.ts
+++ b/src/types.ts
@@ -153,7 +153,6 @@ export interface ManifestDoc {
 
 export interface Manifest {
   schemaVersion: 2;
-  generatedAt: string;
   siteTitle: string;
   pathBase: string;
   defaultBranch: string;

--- a/src/types.ts
+++ b/src/types.ts
@@ -109,7 +109,6 @@ export interface DocRecord {
   body: string;
   rawHash: string;
   wikiTargets: string[];
-  isNew: boolean;
   branch: string | null;
 }
 
@@ -140,7 +139,6 @@ export interface ManifestDoc {
   updatedDate?: string;
   tags: string[];
   description?: string;
-  isNew: boolean;
   branch: string | null;
   wikiTargets: string[];
   backlinks: Array<{

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -231,6 +231,7 @@ publish: true
 prefix: STABLE-01
 category_path: stable
 title: Stable document
+date: "2026-07-18"
 ---
 
 ALPHA
@@ -243,6 +244,7 @@ ALPHA
       const firstManifest = readManifest(outDir) as ManifestDocIndex<{ contentUrl: string }> &
         Record<string, unknown>;
       expect(firstManifest).not.toHaveProperty("generatedAt");
+      expect(firstManifest.docsById[firstManifest.docIds[0]]).not.toHaveProperty("isNew");
       const contentPath = firstManifest.docsById[firstManifest.docIds[0]]?.contentUrl.replace(/^\/+/, "");
       expect(contentPath).toBeDefined();
 

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -1,4 +1,5 @@
 import { spawnSync } from "node:child_process";
+import crypto from "node:crypto";
 import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
@@ -73,6 +74,26 @@ function readDocContentHtml(outDir: string, route: string): string {
 
 function readManifest(outDir: string): unknown {
   return JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as unknown;
+}
+
+function snapshotOutputHashes(outDir: string): Record<string, string> {
+  const hashes: Record<string, string> = {};
+  const walk = (directory: string) => {
+    const entries = fs.readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
+      left.name.localeCompare(right.name, "en"),
+    );
+    for (const entry of entries) {
+      const absolutePath = path.join(directory, entry.name);
+      if (entry.isDirectory()) {
+        walk(absolutePath);
+      } else if (entry.isFile()) {
+        const relativePath = path.relative(outDir, absolutePath).split(path.sep).join("/");
+        hashes[relativePath] = crypto.createHash("sha256").update(fs.readFileSync(absolutePath)).digest("hex");
+      }
+    }
+  };
+  walk(outDir);
+  return hashes;
 }
 
 function findCacheIndexPaths(workDir: string): string[] {
@@ -189,6 +210,63 @@ title: Document ${index}
       const sizeCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
       expect(sizeCheck.status, sizeCheck.output).toBe(0);
       expect(sizeCheck.output).toContain("route-html files=2");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("no-op build는 byte-identical하고 content/config 변경은 관련 산출물을 갱신한다", async () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-reproducible-build-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const configPath = path.join(workDir, "blog.config.mjs");
+    const sourcePath = path.join(vaultDir, "stable.md");
+
+    try {
+      writeText(configPath, 'export default { seo: { siteName: "Stable A" } };\n');
+      writeText(
+        sourcePath,
+        `---
+publish: true
+prefix: STABLE-01
+category_path: stable
+title: Stable document
+---
+
+ALPHA
+`,
+      );
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+      const first = snapshotOutputHashes(outDir);
+      const firstManifest = readManifest(outDir) as ManifestDocIndex<{ contentUrl: string }> &
+        Record<string, unknown>;
+      expect(firstManifest).not.toHaveProperty("generatedAt");
+      const contentPath = firstManifest.docsById[firstManifest.docIds[0]]?.contentUrl.replace(/^\/+/, "");
+      expect(contentPath).toBeDefined();
+
+      await new Promise((resolve) => setTimeout(resolve, 20));
+      const secondBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(secondBuild.status, secondBuild.output).toBe(0);
+      const second = snapshotOutputHashes(outDir);
+      expect(second).toEqual(first);
+
+      writeText(sourcePath, fs.readFileSync(sourcePath, "utf8").replace("ALPHA", "BRAVO"));
+      const contentBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(contentBuild.status, contentBuild.output).toBe(0);
+      const afterContent = snapshotOutputHashes(outDir);
+      expect(afterContent[contentPath!]).not.toBe(second[contentPath!]);
+      expect(afterContent["STABLE-01/index.html"]).not.toBe(second["STABLE-01/index.html"]);
+      expect(afterContent["manifest.json"]).toBe(second["manifest.json"]);
+
+      writeText(configPath, 'export default { seo: { siteName: "Stable B" } };\n');
+      const configBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(configBuild.status, configBuild.output).toBe(0);
+      const afterConfig = snapshotOutputHashes(outDir);
+      expect(afterConfig["manifest.json"]).not.toBe(afterContent["manifest.json"]);
+      expect(afterConfig["index.html"]).not.toBe(afterContent["index.html"]);
+      expect(afterConfig[contentPath!]).toBe(afterContent[contentPath!]);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/manifest-adapter.spec.ts
+++ b/tests/e2e/manifest-adapter.spec.ts
@@ -1,5 +1,9 @@
 import { expect, test } from "@playwright/test";
-import { getManifestDocs, normalizeManifestPayload } from "../../src/runtime/manifest-adapter.js";
+import {
+  getManifestDocs,
+  getRuntimeManifestDocs,
+  normalizeManifestPayload,
+} from "../../src/runtime/manifest-adapter.js";
 
 const envelope = {
   tree: [],
@@ -44,6 +48,25 @@ test.describe("manifest schema adapter", () => {
       },
     });
     expect(normalized).not.toHaveProperty("docs");
+  });
+
+  test("NEW 상태는 manifest date와 runtime 시각으로 파생한다", () => {
+    const normalized = normalizeManifestPayload({
+      ...envelope,
+      schemaVersion: 2,
+      ui: { newWithinDays: 10 },
+      docIds: ["recent", "old"],
+      docsById: {
+        recent: { id: "recent", route: "/RECENT/", date: "2026-07-15", isNew: false },
+        old: { id: "old", route: "/OLD/", date: "2026-07-01", isNew: true },
+      },
+    });
+
+    const docs = getRuntimeManifestDocs(normalized, Date.parse("2026-07-18T00:00:00Z"));
+    expect(docs.map((doc) => [doc.id, doc.isNew])).toEqual([
+      ["recent", true],
+      ["old", false],
+    ]);
   });
 
   test("unsupported version과 dangling doc reference를 거부한다", () => {

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -110,6 +110,29 @@ test.describe("Trees sidebar adapter", () => {
     ).toBe("DOC - 01 Setup - Install");
   });
 
+  test("runtime-derived NEW state overrides stale legacy tree metadata", () => {
+    const tree = [
+      {
+        type: "folder",
+        name: "Legacy",
+        path: "legacy",
+        children: [
+          { type: "file", id: "recent", name: "recent.md", title: "Recent", isNew: false },
+          { type: "file", id: "old", name: "old.md", title: "Old", isNew: true },
+        ],
+      },
+    ];
+    const docs = [
+      { id: "recent", route: "/RECENT/", title: "Recent", isNew: true },
+      { id: "old", route: "/OLD/", title: "Old", isNew: false },
+    ];
+
+    const adapter = buildTreesAdapterInput(tree, docs);
+
+    expect(adapter.metadataByTreePath.get("Legacy/Recent")?.isNew).toBe(true);
+    expect(adapter.metadataByTreePath.get("Legacy/Old")?.isNew).toBe(false);
+  });
+
   test("duplicate canonical paths receive stable suffixes without changing route lookup", () => {
     const tree = [
       {


### PR DESCRIPTION
Part of #22. Implements the detailed acceptance criteria retained in #27.

## Summary

- Remove wall-clock `generatedAt` from the public manifest
- Add `check:reproducible`, which builds twice into the same owned output and SHA-256 compares every file
- Run the double-build reproducibility gate in CI
- Add regression coverage proving no-op equality and targeted content/config invalidation
- Document the reproducible output contract and local command

## DnD

- [x] Two no-op builds with unchanged content/config have identical file sets and hashes
- [x] Wall-clock build metadata is absent from generated output
- [x] Content changes update content and SSR route output
- [x] Site config changes update manifest/shell output without rewriting article content
- [x] CI executes the same double-build check

## Measurement

`test-vault`: 17 generated files are stable across two builds with digest `9da9f76f3a88`.

## Verification

- `bunx --package typescript tsc --noEmit`
- `bun run build -- --vault ./test-vault --out ./dist`
- `bun run check:size`
- `bun run check:reproducible`
- focused no-op/content/config regression: passed
- `bun run test:e2e`: 51 passed
