### PR TITLE
perf: load Shiki languages and themes on demand

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,9 @@ This setting allows arbitrary authored HTML and can execute client-side code. Do
 Regular fenced code blocks are rendered with:
 
 - Shiki highlighting
+- explicit default grammars/theme, with additional known fence languages and
+  non-default themes loaded on demand
+- escaped plaintext fallback for unknown fence languages
 - a desktop-style code header
 - a copy button
 - optional filename text when fence info contains extra tokens

--- a/bun.lock
+++ b/bun.lock
@@ -5,21 +5,24 @@
     "": {
       "name": "@limcpf/everything-is-a-markdown",
       "dependencies": {
-        "@pierre/trees": "latest",
-        "chokidar": "latest",
-        "gray-matter": "latest",
-        "markdown-it": "latest",
-        "picomatch": "latest",
+        "@pierre/trees": "1.0.0-beta.4",
+        "@shikijs/core": "4.2.0",
+        "@shikijs/engine-javascript": "4.2.0",
+        "@shikijs/langs": "4.2.0",
+        "@shikijs/themes": "4.2.0",
+        "chokidar": "^5.0.0",
+        "gray-matter": "^4.0.3",
+        "markdown-it": "^14.2.0",
+        "picomatch": "^4.0.4",
         "sanitize-html": "2.17.6",
-        "shiki": "latest",
       },
       "devDependencies": {
-        "@playwright/test": "latest",
-        "@types/markdown-it": "latest",
-        "@types/picomatch": "latest",
+        "@playwright/test": "^1.60.0",
+        "@types/markdown-it": "^14.1.2",
+        "@types/picomatch": "^4.0.3",
         "@types/sanitize-html": "2.16.1",
-        "bun-types": "latest",
-        "markdownlint": "latest",
+        "bun-types": "^1.3.14",
+        "markdownlint": "^0.40.0",
       },
     },
   },
@@ -31,8 +34,6 @@
     "@shikijs/core": ["@shikijs/core@4.2.0", "", { "dependencies": { "@shikijs/primitive": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4", "hast-util-to-html": "^9.0.5" } }, "sha512-Hc87Ab1Ld/vEbZRCbwx344I5v+4RU8CVToUTRkqXL1+TjbuOp9U5Xa0M23V4GEWHxVn+yO5otb+HkQVm3ptWQQ=="],
 
     "@shikijs/engine-javascript": ["@shikijs/engine-javascript@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "oniguruma-to-es": "^4.3.6" } }, "sha512-fjETeq1k5ffyXqRgS6+3hpvqseLalp1kjNfRbXpUgWR8FpZ1CmQfiNHovc5lncYjt/Vg5JK/WJEmLahjwMa0og=="],
-
-    "@shikijs/engine-oniguruma": ["@shikijs/engine-oniguruma@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2" } }, "sha512-hTorK1dffPkpbMUk6Z+828PgRo7d07HbnizoP0hNPFjhxMHctj0Px/qoHeGMYafc6ju+u9iMldN4JbVzNQM++g=="],
 
     "@shikijs/langs": ["@shikijs/langs@4.2.0", "", { "dependencies": { "@shikijs/types": "4.2.0" } }, "sha512-bwrVRlJ0wUhZxAbVdvBbv2TTC9yLsh4C/IO5Ofz0T8MQntgDvyVnkbjw9vi50r1kx7RCIJdnJnjZAwmAsXFLZQ=="],
 
@@ -261,8 +262,6 @@
     "scheduler": ["scheduler@0.27.0", "", {}, "sha512-eNv+WrVbKu1f3vbYJT/xtiF5syA5HPIMtf9IgY/nKg0sWqzAUEvqY/xm7OcZc/qafLx/iO9FgOmeSAp4v5ti/Q=="],
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
-
-    "shiki": ["shiki@4.2.0", "", { "dependencies": { "@shikijs/core": "4.2.0", "@shikijs/engine-javascript": "4.2.0", "@shikijs/engine-oniguruma": "4.2.0", "@shikijs/langs": "4.2.0", "@shikijs/themes": "4.2.0", "@shikijs/types": "4.2.0", "@shikijs/vscode-textmate": "^10.0.2", "@types/hast": "^3.0.4" } }, "sha512-hjNax6o/ylDy9lefQEaSDtzaT3iVNtZ3WmpQnbuQNoG4xvnSKf2kSKbihZVO4JRG1TTMejs7CmNRYlWgAL66pQ=="],
 
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 

--- a/docs/solutions/20260719-shiki-fine-grained-loading.md
+++ b/docs/solutions/20260719-shiki-fine-grained-loading.md
@@ -1,0 +1,64 @@
+# Shiki fine-grained loading benchmark
+
+## Context
+
+The Markdown renderer previously imported the umbrella `shiki` package plus the
+generated language and theme registries. The highlighter only initialized a few
+grammars, but every production install still included the umbrella package and
+its unused Oniguruma engine.
+
+The fine-grained renderer now:
+
+- imports `@shikijs/core` and `@shikijs/engine-javascript` directly;
+- statically loads Markdown, Bash, JSON, TypeScript, JavaScript, and the default
+  `github-dark` theme;
+- dynamically imports only non-default themes and known languages encountered
+  in fences;
+- preserves `c++`, `c#`, and `f#` aliases whose names are not valid package
+  subpaths;
+- renders unknown languages as escaped plaintext.
+
+## Method
+
+- Date: 2026-07-19 KST
+- Machine: macOS 26.5.2, Darwin 25.5.0, arm64
+- Runtime: Bun 1.3.9
+- Baseline: mother commit `fc0f9a2`
+- Candidate: this change, measured from the working tree before commit
+- Vault: `test-vault`
+
+Fresh builds used a unique `mktemp` output directory for every run. Incremental
+builds warmed one output once, then rebuilt that same output five times. Values
+include the complete `bun run src/cli.ts build` child-process duration.
+
+<!-- markdownlint-disable MD013 -->
+
+| Scenario | Baseline runs (ms) | Candidate runs (ms) | Median | Change |
+| --- | --- | --- | ---: | ---: |
+| Fresh build | 1626.0, 1737.0, 1624.9, 1610.3, 1643.1 | 1549.4, 1554.0, 1598.3, 1552.0, 1559.9 | 1626.0 → 1554.0 ms | -4.4% |
+| Incremental build | 190.1, 144.0, 199.9, 144.2, 149.5 | 128.2, 127.3, 127.8, 128.3, 129.9 | 149.5 → 128.2 ms | -14.2% |
+
+<!-- markdownlint-enable MD013 -->
+
+## Published install footprint
+
+Each revision was packed with `npm pack --json`, installed into a new temporary
+prefix with `npm install --omit=dev --ignore-scripts <tarball>`, and measured
+with `du -sk <prefix>/node_modules`. npm 11.11.0 and Node.js 24.14.1 were used.
+
+<!-- markdownlint-disable MD013 -->
+
+| Metric | Baseline | Candidate | Change |
+| --- | ---: | ---: | ---: |
+| Production `node_modules` | 43,084 KiB | 38,508 KiB | -4,576 KiB (-10.6%) |
+| Installed package entries | 90 | 88 | -2 |
+| Package tarball | 81,849 B | 82,518 B | +669 B |
+| Package unpacked source | 299,548 B | 302,213 B | +2,665 B |
+
+<!-- markdownlint-enable MD013 -->
+
+The production reduction matches removal of the umbrella `shiki` package and
+`@shikijs/engine-oniguruma`. Direct language and theme packages remain installed
+because their exported per-language and per-theme modules are the supported
+fine-grained entry points; the renderer no longer initializes their generated
+registries.

--- a/package.json
+++ b/package.json
@@ -29,12 +29,15 @@
 	},
 	"dependencies": {
 		"@pierre/trees": "1.0.0-beta.4",
+		"@shikijs/core": "4.2.0",
+		"@shikijs/engine-javascript": "4.2.0",
+		"@shikijs/langs": "4.2.0",
+		"@shikijs/themes": "4.2.0",
 		"chokidar": "^5.0.0",
 		"gray-matter": "^4.0.3",
 		"markdown-it": "^14.2.0",
 		"picomatch": "^4.0.4",
-		"sanitize-html": "2.17.6",
-		"shiki": "^4.2.0"
+		"sanitize-html": "2.17.6"
 	},
 	"devDependencies": {
 		"@playwright/test": "^1.60.0",

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -1,9 +1,13 @@
 import MarkdownIt from "markdown-it";
 import sanitizeHtml from "sanitize-html";
-import { createBundledHighlighter, type HighlighterGeneric } from "shiki/core";
-import { createJavaScriptRegexEngine } from "shiki/engine/javascript";
-import { bundledLanguages } from "shiki/langs";
-import { bundledThemes } from "shiki/themes";
+import { createHighlighterCore, type HighlighterCore, type LanguageInput } from "@shikijs/core";
+import { createJavaScriptRegexEngine } from "@shikijs/engine-javascript";
+import bashLanguage from "@shikijs/langs/bash";
+import javascriptLanguage from "@shikijs/langs/javascript";
+import jsonLanguage from "@shikijs/langs/json";
+import markdownLanguage from "@shikijs/langs/markdown";
+import typescriptLanguage from "@shikijs/langs/typescript";
+import githubDarkTheme from "@shikijs/themes/github-dark";
 import type { BuildOptions, WikiResolver } from "./types";
 import { isRemoteUrl } from "./utils";
 
@@ -18,6 +22,20 @@ export interface MarkdownRenderer {
 
 const FENCE_LANG_RE = /^```([\w-+#.]+)/gm;
 const MERMAID_LANG = "mermaid";
+const DEFAULT_SHIKI_THEME = "github-dark";
+const SHIKI_MODULE_NAME_RE = /^[a-z0-9][a-z0-9-]*$/;
+const SHIKI_LANGUAGE_MODULE_ALIASES: Readonly<Record<string, string>> = {
+  "c#": "csharp",
+  "c++": "cpp",
+  "f#": "fsharp",
+};
+const DEFAULT_SHIKI_LANGUAGES: LanguageInput[] = [
+  markdownLanguage,
+  bashLanguage,
+  jsonLanguage,
+  typescriptLanguage,
+  javascriptLanguage,
+];
 const SAFE_COLOR_VALUE = /^#[0-9a-f]{3,8}$/i;
 const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: [
@@ -203,9 +221,62 @@ function preprocessMarkdown(
   return { markdown: output, warnings };
 }
 
-async function loadFenceLanguages<L extends string, T extends string>(
-  highlighter: HighlighterGeneric<L, T>,
+function isMissingShikiModule(error: unknown, specifier: string): boolean {
+  if (!error || typeof error !== "object") {
+    return false;
+  }
+
+  const code = "code" in error ? String(error.code) : "";
+  const message = "message" in error ? String(error.message) : "";
+  const moduleSubpath = `./${specifier.slice(specifier.lastIndexOf("/") + 1)}`;
+  const isMissingCode = code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED";
+  const matchesSpecifier =
+    message.includes(specifier) || message.includes(`'${moduleSubpath}'`) || message.includes(`"${moduleSubpath}"`);
+  return isMissingCode && matchesSpecifier;
+}
+
+async function loadShikiTheme(theme: string): Promise<typeof githubDarkTheme> {
+  if (theme === DEFAULT_SHIKI_THEME) {
+    return githubDarkTheme;
+  }
+  if (!SHIKI_MODULE_NAME_RE.test(theme)) {
+    throw new Error(`[markdown] Invalid Shiki theme: ${JSON.stringify(theme)}.`);
+  }
+
+  const specifier = `@shikijs/themes/${theme}`;
+  try {
+    const themeModule = (await import(specifier)) as { default: typeof githubDarkTheme };
+    return themeModule.default;
+  } catch (error) {
+    if (isMissingShikiModule(error, specifier)) {
+      throw new Error(`[markdown] Unknown Shiki theme: ${JSON.stringify(theme)}.`);
+    }
+    throw error;
+  }
+}
+
+async function loadShikiLanguage(language: string): Promise<LanguageInput | null> {
+  const moduleName = SHIKI_LANGUAGE_MODULE_ALIASES[language] ?? language;
+  if (!SHIKI_MODULE_NAME_RE.test(moduleName)) {
+    return null;
+  }
+
+  const specifier = `@shikijs/langs/${moduleName}`;
+  try {
+    const languageModule = (await import(specifier)) as { default: LanguageInput };
+    return languageModule.default;
+  } catch (error) {
+    if (isMissingShikiModule(error, specifier)) {
+      return null;
+    }
+    throw error;
+  }
+}
+
+async function loadFenceLanguages(
+  highlighter: HighlighterCore,
   loaded: Set<string>,
+  unavailable: Set<string>,
   markdown: string,
 ): Promise<void> {
   const langs = new Set<string>();
@@ -223,15 +294,20 @@ async function loadFenceLanguages<L extends string, T extends string>(
     }
   }
 
-  for (const lang of langs) {
-    if (loaded.has(lang)) {
-      continue;
+  const requested = Array.from(langs).filter((lang) => !loaded.has(lang) && !unavailable.has(lang));
+  const languageInputs = await Promise.all(
+    requested.map(async (lang) => ({ lang, input: await loadShikiLanguage(lang) })),
+  );
+  const availableInputs = languageInputs.flatMap(({ input }) => (input ? [input] : []));
+  if (availableInputs.length > 0) {
+    await highlighter.loadLanguage(...availableInputs);
+    for (const loadedLanguage of highlighter.getLoadedLanguages()) {
+      loaded.add(String(loadedLanguage));
     }
-    try {
-      await highlighter.loadLanguage(lang as L);
-      loaded.add(lang);
-    } catch {
-      // Unknown language: fallback to plaintext in fence renderer.
+  }
+  for (const { lang, input } of languageInputs) {
+    if (!input) {
+      unavailable.add(lang);
     }
   }
 }
@@ -256,8 +332,8 @@ function isStandaloneImageParagraph(tokens: RuleTokens, idx: number): boolean {
   return children.length === 1 && children[0]?.type === "image";
 }
 
-function createMarkdownIt<L extends string, T extends string>(
-  highlighter: HighlighterGeneric<L, T>,
+function createMarkdownIt(
+  highlighter: HighlighterCore,
   theme: string,
   gfm: boolean,
 ): MarkdownIt {
@@ -395,19 +471,17 @@ function createMarkdownIt<L extends string, T extends string>(
 }
 
 export async function createMarkdownRenderer(options: BuildOptions): Promise<MarkdownRenderer> {
-  const createHighlighter = createBundledHighlighter({
-    langs: bundledLanguages,
-    themes: bundledThemes,
-    engine: () => createJavaScriptRegexEngine(),
-  });
-
-  const highlighter = await createHighlighter({
-    themes: [options.shikiTheme],
-    langs: ["text", "plaintext", "markdown", "bash", "json", "typescript", "javascript"],
+  const theme = await loadShikiTheme(options.shikiTheme);
+  const highlighter = await createHighlighterCore({
+    themes: [theme],
+    langs: DEFAULT_SHIKI_LANGUAGES,
+    engine: createJavaScriptRegexEngine(),
   });
   const loadedLanguages = new Set(highlighter.getLoadedLanguages().map(String));
+  const unavailableLanguages = new Set<string>();
+  let languageLoadQueue = Promise.resolve();
 
-  const md = createMarkdownIt(highlighter, options.shikiTheme, options.gfm);
+  const md = createMarkdownIt(highlighter, theme.name ?? options.shikiTheme, options.gfm);
   if (options.allowUnsafeHtml) {
     console.warn(
       "[security] markdown.allowUnsafeHtml=true disables rendered HTML sanitization. Only use trusted vault content.",
@@ -417,7 +491,11 @@ export async function createMarkdownRenderer(options: BuildOptions): Promise<Mar
   return {
     async render(markdown: string, resolver: WikiResolver): Promise<RenderResult> {
       const { markdown: preprocessed, warnings } = preprocessMarkdown(markdown, resolver, options.imagePolicy, options.wikilinks);
-      await loadFenceLanguages(highlighter, loadedLanguages, preprocessed);
+      const languageLoad = languageLoadQueue.then(() =>
+        loadFenceLanguages(highlighter, loadedLanguages, unavailableLanguages, preprocessed),
+      );
+      languageLoadQueue = languageLoad.catch(() => undefined);
+      await languageLoad;
       const renderedHtml = md.render(preprocessed);
       const html = options.allowUnsafeHtml ? renderedHtml : sanitizeHtml(renderedHtml, SAFE_HTML_OPTIONS);
       return { html, warnings };

--- a/tests/e2e/shiki-loading.spec.ts
+++ b/tests/e2e/shiki-loading.spec.ts
@@ -1,0 +1,101 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { createMarkdownRenderer } from "../../src/markdown";
+import type { BuildOptions, WikiResolver } from "../../src/types";
+
+const resolver: WikiResolver = {
+  resolve: () => null,
+};
+
+function buildOptions(shikiTheme = "github-dark"): BuildOptions {
+  return {
+    vaultDir: ".",
+    outDir: "dist",
+    exclude: [],
+    staticPaths: [],
+    newWithinDays: 7,
+    recentLimit: 5,
+    pinnedMenu: null,
+    wikilinks: false,
+    imagePolicy: "omit-local",
+    gfm: true,
+    allowUnsafeHtml: false,
+    shikiTheme,
+    mermaid: {
+      enabled: false,
+      cdnUrl: "",
+      theme: "default",
+    },
+    seo: null,
+  };
+}
+
+test.describe("fine-grained Shiki loading", () => {
+  test("default grammar와 선택한 theme를 full registry 없이 로드한다", async () => {
+    const defaultRenderer = await createMarkdownRenderer(buildOptions());
+    const defaultResult = await defaultRenderer.render(
+      "```ts\nconst answer: number = 42;\n```",
+      resolver,
+    );
+    expect(defaultResult.html).toContain('class="shiki github-dark"');
+    expect(defaultResult.html).toContain('<span style="color:#F97583">const</span>');
+
+    const selectedThemeRenderer = await createMarkdownRenderer(buildOptions("nord"));
+    const selectedThemeResult = await selectedThemeRenderer.render(
+      "```json\n{\"answer\": 42}\n```",
+      resolver,
+    );
+    expect(selectedThemeResult.html).toContain('class="shiki nord"');
+  });
+
+  test("fence에서 발견한 추가 언어와 비파일명 alias를 on demand로 로드한다", async () => {
+    const renderer = await createMarkdownRenderer(buildOptions());
+    const [python, cpp] = await Promise.all([
+      renderer.render("```python\ndef greet(name):\n    return name\n```", resolver),
+      renderer.render("```c++\nint main() { return 0; }\n```", resolver),
+    ]);
+
+    expect(python.html).toContain('<span style="color:#F97583">def</span>');
+    expect(cpp.html).toContain('<span style="color:#F97583">int</span>');
+    expect(cpp.html).toContain('<span class="code-filename">c++</span>');
+  });
+
+  test("알 수 없는 fence 언어는 escaped plaintext로 렌더링한다", async () => {
+    const renderer = await createMarkdownRenderer(buildOptions());
+    const result = await renderer.render("```eiam-unknown\n<tag> & data\n```", resolver);
+
+    expect(result.html).toContain('<span class="code-filename">eiam-unknown</span>');
+    expect(result.html).toContain("<span>&lt;tag&gt; &amp; data</span>");
+  });
+
+  test("알 수 없거나 안전하지 않은 theme module 이름을 명확히 거부한다", async () => {
+    await expect(createMarkdownRenderer(buildOptions("eiam-unknown"))).rejects.toThrow(
+      '[markdown] Unknown Shiki theme: "eiam-unknown".',
+    );
+    await expect(createMarkdownRenderer(buildOptions("../github-dark"))).rejects.toThrow(
+      '[markdown] Invalid Shiki theme: "../github-dark".',
+    );
+  });
+
+  test("umbrella package와 generated registry import가 dependency graph에 재진입하지 않는다", () => {
+    const repoRoot = process.cwd();
+    const source = fs.readFileSync(path.join(repoRoot, "src/markdown.ts"), "utf8");
+    const packageJson = JSON.parse(fs.readFileSync(path.join(repoRoot, "package.json"), "utf8"));
+    const lockfile = fs.readFileSync(path.join(repoRoot, "bun.lock"), "utf8");
+
+    expect(source).not.toMatch(/from ["']shiki(?:\/|["'])/);
+    expect(source).not.toMatch(/from ["']@shikijs\/(?:langs|themes)["']/);
+    expect(source).not.toContain("bundledLanguages");
+    expect(source).not.toContain("bundledThemes");
+    expect(packageJson.dependencies).not.toHaveProperty("shiki");
+    expect(packageJson.dependencies).toMatchObject({
+      "@shikijs/core": "4.2.0",
+      "@shikijs/engine-javascript": "4.2.0",
+      "@shikijs/langs": "4.2.0",
+      "@shikijs/themes": "4.2.0",
+    });
+    expect(lockfile).not.toMatch(/^    "shiki": \[/m);
+    expect(lockfile).not.toMatch(/^    "@shikijs\/engine-oniguruma": \[/m);
+  });
+});


### PR DESCRIPTION
Part of #22. Implements the detailed acceptance criteria retained in #26.

## Summary

- Replace the umbrella Shiki bundle and registries with direct core/engine/default module imports
- Dynamically import only selected non-default themes and known languages found in fences
- Preserve c++, c#, and f# aliases and escaped plaintext fallback for unknown languages
- Remove the unused Oniguruma engine from the production dependency closure
- Record fresh/incremental build and packed-install measurements

## DnD

- [x] Default languages and the selected theme load without full registries
- [x] Additional known fence languages load on demand
- [x] Unknown languages render as escaped plaintext
- [x] Fresh and incremental build benchmarks are recorded
- [x] Published package install footprint is compared

## Measurement

- Fresh build median: 1,626.0 ms -> 1,554.0 ms (-4.4%)
- Incremental build median: 149.5 ms -> 128.2 ms (-14.2%)
- Production install: 43,084 KiB -> 38,508 KiB (-4,576 KiB, -10.6%)
- Installed package entries: 90 -> 88

## Verification

- bun install --frozen-lockfile
- bunx --package typescript tsc --noEmit
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size
- bun run check:reproducible (17 stable files)
- Shiki focused E2E: 5 passed
- Full E2E: 58 passed
- npm packed production install smoke: nord theme + Python fence passed
- benchmark document markdownlint: passed