### PR TITLE
perf: strip built-in tree icon catalog

### DIFF
--- a/README.md
+++ b/README.md
@@ -470,7 +470,8 @@ The generated site includes a client-side runtime that powers navigation without
 
 Main behaviors:
 
-- searchable sidebar tree rendered by the vanilla `@pierre/trees` runtime
+- searchable sidebar tree rendered by the exact-pinned vanilla `@pierre/trees`
+  runtime with a five-symbol generic icon sprite
 - `Recent` virtual folder
 - optional pinned virtual folder
 - prefix/title file labels without visible `.md` extensions, plus NEW badges when `ui.newWithinDays` matches

--- a/docs/solutions/20260719-tree-icon-payload.md
+++ b/docs/solutions/20260719-tree-icon-payload.md
@@ -1,0 +1,60 @@
+# Tree icon payload reduction
+
+## Context
+
+`@pierre/trees@1.0.0-beta.4` provides the search, keyboard, selection,
+virtualization, and ARIA behavior used by the sidebar. Its root entry also
+imports a 46,827-byte built-in icon module containing file-name rules,
+extension rules, and SVGs for 53 file types.
+
+The public `icons: "minimal"` option changes which sprite is selected at
+runtime, but the generated catalog still remains in the browser bundle. A
+control build with that option and no shim was 288,323 bytes raw / 83,608 bytes
+gzip and still contained all 53 file-type symbol IDs.
+
+## Implementation
+
+- Keep `@pierre/trees` exact-pinned at `1.0.0-beta.4`.
+- Configure `FileTree` with the supported `icons: "minimal"` option.
+- During the browser build, redirect the pinned package internal
+  `builtInIcons.js` imports to EIAM's five-symbol generic sprite shim.
+- Fail the build if the pinned module layout no longer matches or a
+  `file-tree-builtin-*` marker remains.
+- Enforce 260,000 raw / 75,000 gzip JavaScript budgets and verify all five
+  required generic symbol IDs in `check:size`.
+
+The shim retains only chevron, dot, ellipsis, file, and lock symbols. It does
+not replace the tree controller or renderer, so keyboard handling, search,
+virtualization, selection, and ARIA semantics continue to come from the pinned
+dependency.
+
+## Bundle composition
+
+Measurements use the minified browser output from `test-vault` and gzip level
+9, before and after this change.
+
+<!-- markdownlint-disable MD013 -->
+
+| Metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Runtime JavaScript | 288,307 B | 244,503 B | -43,804 B (-15.2%) |
+| Runtime JavaScript gzip | 83,595 B | 69,381 B | -14,214 B (-17.0%) |
+| Built-in file-type symbol IDs | 53 | 0 | -53 |
+| Required generic symbol IDs | 5 | 5 | unchanged |
+
+<!-- markdownlint-enable MD013 -->
+
+The package installation footprint is intentionally unchanged. The dependency
+remains available for its supported tree model and rendering behavior; only
+the unused browser icon catalog is removed from generated output.
+
+## Regression coverage
+
+- `check:size` rejects a reintroduced built-in catalog and enforces the lower
+  gzip ceiling.
+- Browser coverage asserts the exact five-symbol sprite and generic file icon
+  references.
+- The same browser coverage verifies `tree`/`treeitem` ARIA state, selected-row
+  metadata, ArrowDown focus movement, and the virtualized scroller.
+- Existing tree-search, responsive virtualization, navigation-selection, and
+  mobile focus tests remain in the full E2E suite.

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -24,9 +24,16 @@ interface SizeBudget {
 }
 
 const BUDGETS: Record<AssetKind, SizeBudget> = {
-  js: { raw: 300_000, gzip: 90_000 },
+  js: { raw: 260_000, gzip: 75_000 },
   css: { raw: 31_000, gzip: 7_000 },
 };
+const REQUIRED_MINIMAL_TREE_ICONS = [
+  "file-tree-icon-chevron",
+  "file-tree-icon-dot",
+  "file-tree-icon-ellipsis",
+  "file-tree-icon-file",
+  "file-tree-icon-lock",
+] as const;
 const MANIFEST_RATIO_MIN_LEGACY_BYTES = 8_000;
 
 function parseOutDir(argv: string[]): string {
@@ -69,6 +76,17 @@ function checkAsset(assetPath: string, kind: AssetKind): string[] {
   }
   if (gzipBytes > budget.gzip) {
     failures.push(`${fileName} gzip ${gzipBytes} exceeds ${budget.gzip}`);
+  }
+  if (kind === "js") {
+    const source = bytes.toString("utf8");
+    if (source.includes("file-tree-builtin-")) {
+      failures.push(`${fileName} ships the @pierre/trees built-in file icon catalog`);
+    }
+    for (const iconName of REQUIRED_MINIMAL_TREE_ICONS) {
+      if (!source.includes(iconName)) {
+        failures.push(`${fileName} is missing required minimal tree icon ${iconName}`);
+      }
+    }
   }
 
   console.log(

--- a/src/build.ts
+++ b/src/build.ts
@@ -1472,7 +1472,30 @@ function buildAppShellAssetsForOutput(outputPath: string, runtimeAssets: Runtime
   };
 }
 
+function createMinimalTreeIconPlugin(): { plugin: Bun.BunPlugin; replacementCount: () => number } {
+  const minimalIconModule = path.join(import.meta.dir, "runtime", "tree-icons-minimal.js");
+  let replacements = 0;
+
+  return {
+    plugin: {
+      name: "eiam-minimal-tree-icons",
+      setup(builder) {
+        builder.onResolve({ filter: /builtInIcons[.]js$/ }, (args) => {
+          const importer = toPosixPath(args.importer);
+          if (!importer.includes("/node_modules/@pierre/trees/dist/")) {
+            return undefined;
+          }
+          replacements += 1;
+          return { path: minimalIconModule };
+        });
+      },
+    },
+    replacementCount: () => replacements,
+  };
+}
+
 async function bundleRuntimeJs(entrypoint: string): Promise<string> {
+  const minimalTreeIcons = createMinimalTreeIconPlugin();
   const result = await Bun.build({
     entrypoints: [entrypoint],
     target: "browser",
@@ -1480,6 +1503,7 @@ async function bundleRuntimeJs(entrypoint: string): Promise<string> {
     splitting: false,
     sourcemap: "none",
     minify: true,
+    plugins: [minimalTreeIcons.plugin],
   });
 
   if (!result.success) {
@@ -1492,7 +1516,15 @@ async function bundleRuntimeJs(entrypoint: string): Promise<string> {
     throw new Error("Failed to bundle runtime app.js: no JavaScript output was produced");
   }
 
-  return output.text();
+  if (minimalTreeIcons.replacementCount() === 0) {
+    throw new Error("Failed to replace the pinned @pierre/trees built-in icon module");
+  }
+
+  const runtimeJs = await output.text();
+  if (runtimeJs.includes("file-tree-builtin-")) {
+    throw new Error("Failed to remove the @pierre/trees built-in file icon catalog");
+  }
+  return runtimeJs;
 }
 
 async function bundleRuntimeCss(entrypoint: string): Promise<string> {

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1930,6 +1930,7 @@ async function start() {
         },
         fileTreeSearchMode: "hide-non-matches",
         flattenEmptyDirectories: false,
+        icons: "minimal",
         initialExpansion: 1,
         initialSelectedPaths: selectedTreePath ? [selectedTreePath] : [],
         itemHeight: 38,

--- a/src/runtime/tree-icons-minimal.js
+++ b/src/runtime/tree-icons-minimal.js
@@ -1,0 +1,36 @@
+const MINIMAL_TREE_ICON_SPRITE = `<svg data-icon-sprite aria-hidden="true" width="0" height="0">
+  <symbol id="file-tree-icon-chevron" viewBox="0 0 16 16">
+    <path d="m3.5 5.5 4.5 4.5 4.5-4.5" fill="none" stroke="currentColor" stroke-linecap="round" stroke-linejoin="round" stroke-width="1.5"/>
+  </symbol>
+  <symbol id="file-tree-icon-dot" viewBox="0 0 6 6">
+    <circle cx="3" cy="3" r="3" fill="currentColor"/>
+  </symbol>
+  <symbol id="file-tree-icon-file" viewBox="0 0 16 16">
+    <path d="M3 1.75h6l4 4v8.5H3z" fill="currentColor" opacity=".45"/>
+    <path d="M9 1.75v4h4" fill="none" stroke="currentColor" stroke-linejoin="round"/>
+  </symbol>
+  <symbol id="file-tree-icon-lock" viewBox="0 0 16 16">
+    <path d="M4.5 7V5a3.5 3.5 0 0 1 7 0v2M3 7h10v7H3z" fill="none" stroke="currentColor" stroke-linejoin="round" stroke-width="1.5"/>
+  </symbol>
+  <symbol id="file-tree-icon-ellipsis" viewBox="0 0 16 16">
+    <circle cx="3.5" cy="8" r="1.25" fill="currentColor"/>
+    <circle cx="8" cy="8" r="1.25" fill="currentColor"/>
+    <circle cx="12.5" cy="8" r="1.25" fill="currentColor"/>
+  </symbol>
+</svg>`;
+
+export function getBuiltInSpriteSheet() {
+  return MINIMAL_TREE_ICON_SPRITE;
+}
+
+export function getBuiltInFileIconName() {
+  return "file-tree-icon-file";
+}
+
+export function isColoredBuiltInIconSet() {
+  return false;
+}
+
+export function resolveBuiltInFileIconToken() {
+  return undefined;
+}

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -141,6 +141,26 @@ test.describe("빌드 회귀 가드", () => {
   const sizeCheckPath = path.join(repoRoot, "scripts/check-output-size.ts");
   const vaultPath = path.join(repoRoot, "test-vault");
 
+  test("runtime size gate는 built-in file icon catalog 재진입을 거부한다", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-tree-icon-size-"));
+    const outDir = path.join(workDir, "dist");
+
+    try {
+      const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      expect(build.status, build.output).toBe(0);
+      const assetsDir = path.join(outDir, "assets");
+      const runtimeJs = fs.readdirSync(assetsDir).find((fileName) => /^app\.[a-f0-9]{12}\.js$/.test(fileName));
+      expect(runtimeJs).toBeDefined();
+      fs.appendFileSync(path.join(assetsDir, runtimeJs!), '"file-tree-builtin-astro";\n', "utf8");
+
+      const sizeCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
+      expect(sizeCheck.status).toBe(1);
+      expect(sizeCheck.output).toContain("ships the @pierre/trees built-in file icon catalog");
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("manifest size gate는 tiny vault의 고정 overhead를 허용한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-small-manifest-size-"));
     const vaultDir = path.join(workDir, "vault");

--- a/tests/e2e/tree-icon-payload.spec.ts
+++ b/tests/e2e/tree-icon-payload.spec.ts
@@ -1,0 +1,69 @@
+import fs from "node:fs";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+const MINIMAL_TREE_ICON_IDS = [
+  "file-tree-icon-chevron",
+  "file-tree-icon-dot",
+  "file-tree-icon-ellipsis",
+  "file-tree-icon-file",
+  "file-tree-icon-lock",
+];
+
+test.describe("minimal Trees icon payload", () => {
+  test("beta dependency를 exact version으로 유지한다", () => {
+    const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
+    const lockfile = fs.readFileSync(path.join(process.cwd(), "bun.lock"), "utf8");
+
+    expect(packageJson.dependencies["@pierre/trees"]).toBe("1.0.0-beta.4");
+    expect(lockfile).toContain('"@pierre/trees": "1.0.0-beta.4"');
+    expect(lockfile).toContain('"@pierre/trees@1.0.0-beta.4"');
+  });
+
+  test("generic icon만 사용하면서 keyboard, virtualization, selection, ARIA 동작을 유지한다", async ({ page }) => {
+    await page.goto("/BC-VO-00/");
+    await waitForAppReady(page);
+
+    const state = await page.locator("#tree-root").evaluate((treeRoot) => {
+      const host = treeRoot.querySelector("file-tree-container");
+      const root = host?.shadowRoot;
+      const tree = root?.querySelector('[role="tree"]');
+      const selected = root?.querySelector('[role="treeitem"][aria-selected="true"]');
+      const fileIconUses = Array.from(
+        root?.querySelectorAll('[data-item-type="file"] [data-item-section="icon"] use') ?? [],
+        (use) => use.getAttribute("href"),
+      );
+      return {
+        builtInFileIconCount: root?.querySelectorAll('[id^="file-tree-builtin-"]').length ?? -1,
+        fileIconUses,
+        hasVirtualScroller: Boolean(root?.querySelector('[data-file-tree-virtualized-scroll="true"]')),
+        iconIds: Array.from(root?.querySelectorAll("svg[data-icon-sprite] symbol") ?? [], (icon) => icon.id).sort(),
+        selectedAriaLabel: selected?.getAttribute("aria-label") ?? "",
+        selectedAriaLevel: selected?.getAttribute("aria-level") ?? "",
+        selectedPath: selected?.getAttribute("data-item-path") ?? "",
+        treeRole: tree?.getAttribute("role") ?? "",
+      };
+    });
+
+    expect(state.iconIds).toEqual([...MINIMAL_TREE_ICON_IDS].sort());
+    expect(state.builtInFileIconCount).toBe(0);
+    expect(state.fileIconUses.length).toBeGreaterThan(0);
+    expect(state.fileIconUses.every((href) => href === "#file-tree-icon-file")).toBe(true);
+    expect(state.treeRole).toBe("tree");
+    expect(state.selectedPath).not.toBe("");
+    expect(state.selectedAriaLabel).not.toBe("");
+    expect(Number(state.selectedAriaLevel)).toBeGreaterThan(0);
+    expect(state.hasVirtualScroller).toBe(true);
+
+    const selectedRow = page.locator(
+      '#tree-root [role="treeitem"][aria-selected="true"][data-item-path]',
+    ).first();
+    await selectedRow.focus();
+    const beforePath = await selectedRow.getAttribute("data-item-path");
+    await page.keyboard.press("ArrowDown");
+    const focusedRow = page.locator('#tree-root [role="treeitem"][data-item-focused="true"]');
+    await expect(focusedRow).toHaveCount(1);
+    await expect(focusedRow).not.toHaveAttribute("data-item-path", beforePath ?? "");
+  });
+});


### PR DESCRIPTION
Part of #22. Detailed context: #24.

## Summary

- keep `@pierre/trees@1.0.0-beta.4` exact-pinned for its search, keyboard, selection, virtualization, and ARIA behavior
- select the supported minimal icon mode and replace the pinned internal built-in catalog with an EIAM five-symbol generic sprite during browser bundling
- fail builds and size checks if the package layout drifts or any built-in file icon catalog returns
- document before and after bundle composition and cover the retained behavior in Playwright

## DnD

- [x] Bundle composition documented before and after
- [x] Unused built-in file icons are absent from generated output
- [x] Search, keyboard behavior, virtualization, selection, and accessibility remain covered
- [x] Beta dependency remains exact-pinned at `1.0.0-beta.4`
- [x] Lower JavaScript raw and gzip budgets enforce the reduction
- [x] Packed production install builds with the minimal sprite intact

## Bundle result

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Runtime JS | 288,307 B | 244,503 B | -15.2% |
| Runtime JS gzip | 83,595 B | 69,381 B | -17.0% |
| Built-in file-type symbols | 53 | 0 | -53 |
| Required generic symbols | 5 | 5 | unchanged |

## Verification

- `bun install --frozen-lockfile`
- `bunx --package typescript tsc --noEmit`
- `bun run test:e2e` — 61 passed
- `bun run build --vault ./test-vault --out ./dist`
- `bun run check:size`
- `bun run check:reproducible` — 17 files stable
- `bunx markdownlint-cli2 docs/solutions/20260719-tree-icon-payload.md`
- packed tarball production install and build smoke — 244,503 B, zero built-in markers, five generic symbols

The full historical README still reports its existing MD013 line-length baseline; the two changed README lines are 78 and 48 characters.