### PR TITLE
perf: defer tree runtime until after content paint

### DIFF
--- a/README.md
+++ b/README.md
@@ -217,7 +217,22 @@ Key points:
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v1-<namespace>/build-index.json`.
 
-CI enforces raw and gzip budgets for the generated runtime assets. After a sample build, run `bun run check:size` to apply the same limits locally. The current budgets are 300,000 raw / 90,000 gzip bytes for JavaScript and 31,000 raw / 7,000 gzip bytes for CSS. The same command requires each EIAM-generated route HTML runtime bootstrap to contain only `manifestUrl`/`pathBase` and stay within 256 bytes; copied static HTML is left untouched. It also always validates manifest schema v2 canonical document references. Once the reconstructed legacy projection reaches 8,000 bytes, it requires at least 25% raw and 5% gzip reduction versus that duplicated tree/document projection. Smaller manifests skip only this relative ratio because fixed schema/gzip overhead dominates when there is not yet enough duplicated payload to measure reliably.
+CI enforces raw and gzip budgets for the generated runtime assets. After a
+sample build, run `bun run check:size` to apply the same limits locally. The
+critical app JavaScript is limited to 45,000 raw / 15,000 gzip bytes, the
+deferred tree chunk to 220,000 raw / 60,000 gzip bytes, and their combined
+payload to 260,000 raw / 78,000 gzip bytes. CSS is limited to 31,000 raw /
+7,000 gzip bytes.
+
+The same command requires each EIAM-generated route HTML runtime bootstrap to
+contain only `manifestUrl`, `pathBase`, and the hashed `treeModuleUrl`, and to
+stay within 256 bytes; copied static HTML is left untouched. It also always
+validates manifest schema v2 canonical document references. Once the
+reconstructed legacy projection reaches 8,000 bytes, it requires at least 25%
+raw and 5% gzip reduction versus that duplicated tree/document projection.
+Smaller manifests skip only this relative ratio because fixed schema/gzip
+overhead dominates when there is not yet enough duplicated payload to measure
+reliably.
 
 Run `bun run check:reproducible` to perform two no-op builds into the same output and compare SHA-256 hashes for every generated file. CI applies the same double-build check.
 
@@ -472,6 +487,8 @@ Main behaviors:
 
 - searchable sidebar tree rendered by the exact-pinned vanilla `@pierre/trees`
   runtime with a five-symbol generic icon sprite
+- tree dependency loading deferred until after the first content paint on
+  desktop, and until sidebar/search interaction on compact layouts
 - `Recent` virtual folder
 - optional pinned virtual folder
 - prefix/title file labels without visible `.md` extensions, plus NEW badges when `ui.newWithinDays` matches

--- a/docs/solutions/20260719-deferred-tree-runtime.md
+++ b/docs/solutions/20260719-deferred-tree-runtime.md
@@ -1,0 +1,79 @@
+# Deferred tree runtime
+
+## Context
+
+The generated route HTML already contains the article title, metadata, body,
+backlinks, and previous/next navigation. The browser entry nevertheless
+imported `@pierre/trees` statically, so readers parsed the largest dependency
+before the application could finish initializing.
+
+The mother branch produced one 244,503-byte runtime file (69,381 bytes gzip).
+Tree behavior was useful in the sidebar, but it was not required to paint or
+read the server-rendered article.
+
+## Runtime split
+
+The build now emits two independently hashed JavaScript assets:
+
+- `app.<hash>.js` initializes theme, article navigation, history, content
+  enhancement, and the mobile sidebar shell.
+- `tree.<hash>.js` contains `@pierre/trees`, its EIAM integration CSS, and the
+  five-symbol generic icon sprite.
+
+Each route bootstrap includes a same-origin, path-base-aware `treeModuleUrl`.
+The app validates the hashed asset path before using dynamic `import()`.
+
+Tree import is not permitted until two animation frames after the initial
+article state is ready. On desktop, the visible sidebar then loads the module
+during idle time. Compact layouts do not request the chunk until the sidebar
+opens or tree search becomes relevant. Resizing to desktop also triggers the
+deferred load safely.
+
+## Failure behavior
+
+A missing or invalid tree chunk does not reject the main app startup and does
+not replace the server-rendered article. The sidebar shows:
+
+- an accessible error message;
+- a retry action that uses a new module URL query to avoid a cached failed
+  module fetch;
+- ordinary links for every document in the active branch.
+
+Those links work as client navigation while the app is running and retain real
+`href` values as a navigation fallback.
+
+## Critical-path composition
+
+Measurements use the minified browser output from `test-vault` and gzip level
+9 before and after the split.
+
+<!-- markdownlint-disable MD013 -->
+
+| Metric | Before | After | Change |
+| --- | ---: | ---: | ---: |
+| Critical-path JavaScript | 244,503 B | 36,965 B | -207,538 B (-84.9%) |
+| Critical-path JavaScript gzip | 69,381 B | 12,264 B | -57,117 B (-82.3%) |
+| Deferred tree JavaScript | 0 B | 210,934 B | +210,934 B |
+| Deferred tree JavaScript gzip | 0 B | 58,719 B | +58,719 B |
+| Total JavaScript | 244,503 B | 247,899 B | +3,396 B (+1.4%) |
+| Total JavaScript gzip | 69,381 B | 70,983 B | +1,602 B (+2.3%) |
+
+<!-- markdownlint-enable MD013 -->
+
+The small total increase is the cost of separate module wrappers and gzip
+streams. CI limits the critical app to 45,000 raw / 15,000 gzip bytes and also
+keeps separate tree and combined budgets, preventing the dependency from
+returning to the critical entry.
+
+## Regression coverage
+
+- The size gate verifies exactly one hashed app entry and one hashed tree
+  chunk, with minimal icons present only in the deferred asset.
+- Route bootstrap checks require the exact hashed tree URL for every generated
+  route and enforce the existing 256-byte ceiling.
+- Browser coverage aborts the first tree request, verifies that article content
+  and fallback links remain usable, and then recovers through retry.
+- Performance marks and the browser first-contentful-paint entry verify that
+  tree loading begins no earlier than the post-paint opportunity.
+- Compact-layout coverage confirms there is no tree request before sidebar
+  interaction and that the mounted tree retains existing behavior afterward.

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -3,7 +3,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { gzipSync } from "node:zlib";
 
-type AssetKind = "js" | "css";
+type AssetKind = "app-js" | "tree-js" | "css";
 
 interface ManifestDoc {
   id: string;
@@ -24,9 +24,11 @@ interface SizeBudget {
 }
 
 const BUDGETS: Record<AssetKind, SizeBudget> = {
-  js: { raw: 260_000, gzip: 75_000 },
+  "app-js": { raw: 45_000, gzip: 15_000 },
+  "tree-js": { raw: 220_000, gzip: 60_000 },
   css: { raw: 31_000, gzip: 7_000 },
 };
+const TOTAL_JS_BUDGET: SizeBudget = { raw: 260_000, gzip: 78_000 };
 const REQUIRED_MINIMAL_TREE_ICONS = [
   "file-tree-icon-chevron",
   "file-tree-icon-dot",
@@ -49,16 +51,16 @@ function parseOutDir(argv: string[]): string {
   return path.resolve(value);
 }
 
-function findRuntimeAsset(assetsDir: string, kind: AssetKind): string {
-  const pattern = new RegExp(`^app\\.([a-f0-9]{12})\\.${kind}$`);
+function findRuntimeAsset(assetsDir: string, stem: "app" | "tree", extension: "js" | "css"): string {
+  const pattern = new RegExp(`^${stem}\\.([a-f0-9]{12})\\.${extension}$`);
   const matches = fs.readdirSync(assetsDir).filter((entry) => pattern.test(entry));
   if (matches.length !== 1) {
-    throw new Error(`[size] Expected exactly one app.*.${kind} asset, found ${matches.length}`);
+    throw new Error(`[size] Expected exactly one ${stem}.*.${extension} asset, found ${matches.length}`);
   }
   return path.join(assetsDir, matches[0]);
 }
 
-function checkAsset(assetPath: string, kind: AssetKind): string[] {
+function inspectAsset(assetPath: string, kind: AssetKind): { failures: string[]; gzipBytes: number; rawBytes: number } {
   const bytes = fs.readFileSync(assetPath);
   const rawBytes = bytes.byteLength;
   const gzipBytes = gzipSync(bytes, { level: 9 }).byteLength;
@@ -77,14 +79,22 @@ function checkAsset(assetPath: string, kind: AssetKind): string[] {
   if (gzipBytes > budget.gzip) {
     failures.push(`${fileName} gzip ${gzipBytes} exceeds ${budget.gzip}`);
   }
-  if (kind === "js") {
+  if (kind === "app-js" || kind === "tree-js") {
     const source = bytes.toString("utf8");
     if (source.includes("file-tree-builtin-")) {
       failures.push(`${fileName} ships the @pierre/trees built-in file icon catalog`);
     }
-    for (const iconName of REQUIRED_MINIMAL_TREE_ICONS) {
-      if (!source.includes(iconName)) {
-        failures.push(`${fileName} is missing required minimal tree icon ${iconName}`);
+    if (kind === "app-js") {
+      for (const iconName of REQUIRED_MINIMAL_TREE_ICONS) {
+        if (source.includes(iconName)) {
+          failures.push(`${fileName} ships deferred tree icon ${iconName} on the critical path`);
+        }
+      }
+    } else {
+      for (const iconName of REQUIRED_MINIMAL_TREE_ICONS) {
+        if (!source.includes(iconName)) {
+          failures.push(`${fileName} is missing required minimal tree icon ${iconName}`);
+        }
       }
     }
   }
@@ -92,7 +102,7 @@ function checkAsset(assetPath: string, kind: AssetKind): string[] {
   console.log(
     `[size] ${kind} raw=${rawBytes}/${budget.raw} gzip=${gzipBytes}/${budget.gzip} hash=${finalHash}`,
   );
-  return failures;
+  return { failures, gzipBytes, rawBytes };
 }
 
 function isRecord(value: unknown): value is Record<string, unknown> {
@@ -232,7 +242,7 @@ function findRouteHtmlFiles(outDir: string): string[] {
   return Array.from(relativePaths, (relativePath) => path.join(outDir, relativePath)).sort();
 }
 
-function checkRouteHtml(outDir: string): string[] {
+function checkRouteHtml(outDir: string, treeAssetFileName: string): string[] {
   const failures: string[] = [];
   const routeHtmlFiles = findRouteHtmlFiles(outDir);
   let maxBootstrapBytes = 0;
@@ -271,8 +281,13 @@ function checkRouteHtml(outDir: string): string[] {
       failures.push(`${relativePath} runtime bootstrap is not valid JSON`);
       continue;
     }
-    if (!isRecord(payload) || Object.keys(payload).sort().join(",") !== "manifestUrl,pathBase") {
-      failures.push(`${relativePath} runtime bootstrap must contain only manifestUrl and pathBase`);
+    if (
+      !isRecord(payload) ||
+      Object.keys(payload).sort().join(",") !== "manifestUrl,pathBase,treeModuleUrl"
+    ) {
+      failures.push(
+        `${relativePath} runtime bootstrap must contain only manifestUrl, pathBase, and treeModuleUrl`,
+      );
       continue;
     }
     const pathBase = typeof payload.pathBase === "string" ? payload.pathBase.replace(/\/+$/, "") : "";
@@ -283,6 +298,16 @@ function checkRouteHtml(outDir: string): string[] {
       .join("/");
     if (payload.manifestUrl !== expectedManifestUrl) {
       failures.push(`${relativePath} runtime bootstrap has an invalid manifestUrl`);
+    }
+    const rawTreeModuleUrl = pathBase
+      ? `${pathBase}/assets/${treeAssetFileName}`
+      : `/assets/${treeAssetFileName}`;
+    const expectedTreeModuleUrl = rawTreeModuleUrl
+      .split("/")
+      .map((segment, index) => (index === 0 && segment === "" ? "" : encodeURIComponent(segment)))
+      .join("/");
+    if (payload.treeModuleUrl !== expectedTreeModuleUrl) {
+      failures.push(`${relativePath} runtime bootstrap has an invalid treeModuleUrl`);
     }
   }
 
@@ -295,11 +320,26 @@ function checkRouteHtml(outDir: string): string[] {
 
 const outDir = parseOutDir(process.argv.slice(2));
 const assetsDir = path.join(outDir, "assets");
-const failures = (["js", "css"] as const).flatMap((kind) =>
-  checkAsset(findRuntimeAsset(assetsDir, kind), kind),
+const appJsPath = findRuntimeAsset(assetsDir, "app", "js");
+const treeJsPath = findRuntimeAsset(assetsDir, "tree", "js");
+const cssPath = findRuntimeAsset(assetsDir, "app", "css");
+const appJs = inspectAsset(appJsPath, "app-js");
+const treeJs = inspectAsset(treeJsPath, "tree-js");
+const css = inspectAsset(cssPath, "css");
+const failures = [...appJs.failures, ...treeJs.failures, ...css.failures];
+const totalJsRaw = appJs.rawBytes + treeJs.rawBytes;
+const totalJsGzip = appJs.gzipBytes + treeJs.gzipBytes;
+console.log(
+  `[size] total-js raw=${totalJsRaw}/${TOTAL_JS_BUDGET.raw} gzip=${totalJsGzip}/${TOTAL_JS_BUDGET.gzip}`,
 );
+if (totalJsRaw > TOTAL_JS_BUDGET.raw) {
+  failures.push(`total JavaScript raw ${totalJsRaw} exceeds ${TOTAL_JS_BUDGET.raw}`);
+}
+if (totalJsGzip > TOTAL_JS_BUDGET.gzip) {
+  failures.push(`total JavaScript gzip ${totalJsGzip} exceeds ${TOTAL_JS_BUDGET.gzip}`);
+}
 failures.push(...checkManifest(path.join(outDir, "manifest.json")));
-failures.push(...checkRouteHtml(outDir));
+failures.push(...checkRouteHtml(outDir, path.basename(treeJsPath)));
 
 if (failures.length > 0) {
   for (const failure of failures) {

--- a/src/build.ts
+++ b/src/build.ts
@@ -54,6 +54,7 @@ interface OutputWriteContext {
 interface RuntimeAssets {
   cssRelPath: string;
   jsRelPath: string;
+  treeJsRelPath: string;
 }
 
 interface WikiLookup {
@@ -1469,6 +1470,7 @@ function buildAppShellAssetsForOutput(outputPath: string, runtimeAssets: Runtime
   return {
     cssHref: toRelativeAssetPath(outputPath, runtimeAssets.cssRelPath),
     jsSrc: toRelativeAssetPath(outputPath, runtimeAssets.jsRelPath),
+    treeModulePath: `/${runtimeAssets.treeJsRelPath}`,
   };
 }
 
@@ -1494,8 +1496,11 @@ function createMinimalTreeIconPlugin(): { plugin: Bun.BunPlugin; replacementCoun
   };
 }
 
-async function bundleRuntimeJs(entrypoint: string): Promise<string> {
-  const minimalTreeIcons = createMinimalTreeIconPlugin();
+async function bundleRuntimeJs(
+  entrypoint: string,
+  options: { label: string; replaceTreeIcons: boolean },
+): Promise<string> {
+  const minimalTreeIcons = options.replaceTreeIcons ? createMinimalTreeIconPlugin() : null;
   const result = await Bun.build({
     entrypoints: [entrypoint],
     target: "browser",
@@ -1503,20 +1508,20 @@ async function bundleRuntimeJs(entrypoint: string): Promise<string> {
     splitting: false,
     sourcemap: "none",
     minify: true,
-    plugins: [minimalTreeIcons.plugin],
+    plugins: minimalTreeIcons ? [minimalTreeIcons.plugin] : [],
   });
 
   if (!result.success) {
     const details = result.logs.map((log) => String(log)).filter(Boolean).join("\n");
-    throw new Error(`Failed to bundle runtime app.js${details ? `:\n${details}` : ""}`);
+    throw new Error(`Failed to bundle runtime ${options.label}${details ? `:\n${details}` : ""}`);
   }
 
   const output = result.outputs.find((artifact) => artifact.path.endsWith(".js")) ?? result.outputs[0];
   if (!output) {
-    throw new Error("Failed to bundle runtime app.js: no JavaScript output was produced");
+    throw new Error(`Failed to bundle runtime ${options.label}: no JavaScript output was produced`);
   }
 
-  if (minimalTreeIcons.replacementCount() === 0) {
+  if (minimalTreeIcons && minimalTreeIcons.replacementCount() === 0) {
     throw new Error("Failed to replace the pinned @pierre/trees built-in icon module");
   }
 
@@ -1550,17 +1555,28 @@ async function bundleRuntimeCss(entrypoint: string): Promise<string> {
 
 async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeAssets> {
   const runtimeDir = path.join(import.meta.dir, "runtime");
-  const runtimeJs = await bundleRuntimeJs(path.join(runtimeDir, "app.js"));
-  const runtimeCss = await bundleRuntimeCss(path.join(runtimeDir, "app.css"));
+  const [runtimeJs, treeRuntimeJs, runtimeCss] = await Promise.all([
+    bundleRuntimeJs(path.join(runtimeDir, "app.js"), {
+      label: "app.js",
+      replaceTreeIcons: false,
+    }),
+    bundleRuntimeJs(path.join(runtimeDir, "tree-runtime.js"), {
+      label: "tree-runtime.js",
+      replaceTreeIcons: true,
+    }),
+    bundleRuntimeCss(path.join(runtimeDir, "app.css")),
+  ]);
 
   const jsRelPath = `assets/app.${makeHash(runtimeJs).slice(0, 12)}.js`;
+  const treeJsRelPath = `assets/tree.${makeHash(treeRuntimeJs).slice(0, 12)}.js`;
   const cssRelPath = `assets/app.${makeHash(runtimeCss).slice(0, 12)}.css`;
 
   for (const previousPath of Object.keys(context.previousHashes)) {
     const isLegacyRuntimeAsset =
-      previousPath.startsWith("assets/app") &&
+      (previousPath.startsWith("assets/app") || previousPath.startsWith("assets/tree")) &&
       (previousPath.endsWith(".js") || previousPath.endsWith(".css")) &&
       previousPath !== jsRelPath &&
+      previousPath !== treeJsRelPath &&
       previousPath !== cssRelPath;
     if (!isLegacyRuntimeAsset) {
       continue;
@@ -1569,11 +1585,13 @@ async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeA
   }
 
   await writeOutputIfChanged(context, jsRelPath, runtimeJs);
+  await writeOutputIfChanged(context, treeJsRelPath, treeRuntimeJs);
   await writeOutputIfChanged(context, cssRelPath, runtimeCss);
 
   return {
     cssRelPath,
     jsRelPath,
+    treeJsRelPath,
   };
 }
 

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -565,6 +565,79 @@ a:hover {
   padding: 12px 12px 24px;
 }
 
+.tree-load-status,
+.tree-load-fallback {
+  box-sizing: border-box;
+  width: 100%;
+  min-height: 96px;
+  margin: 0;
+  border: 1px solid var(--latte-surface0);
+  border-radius: 8px;
+  background: color-mix(in srgb, var(--latte-mantle) 72%, transparent);
+  color: var(--latte-subtext1);
+  font-size: 0.78rem;
+}
+
+.tree-load-status {
+  display: grid;
+  place-items: center;
+  padding: 16px;
+  text-align: center;
+}
+
+.tree-load-fallback {
+  max-height: 100%;
+  overflow: auto;
+  padding: 12px;
+}
+
+.tree-load-fallback-message {
+  margin: 0 0 10px;
+  line-height: 1.5;
+}
+
+.tree-load-retry {
+  width: 100%;
+  min-height: 34px;
+  border: 1px solid var(--latte-surface1);
+  border-radius: 7px;
+  background: var(--latte-base);
+  color: var(--latte-text);
+  cursor: pointer;
+  font: inherit;
+  font-weight: 700;
+}
+
+.tree-load-retry:focus-visible,
+.tree-load-fallback-links a:focus-visible {
+  outline: 2px solid var(--latte-blue);
+  outline-offset: 2px;
+}
+
+.tree-load-fallback-links {
+  display: grid;
+  gap: 4px;
+  margin: 12px 0 0;
+  padding: 0;
+  list-style: none;
+}
+
+.tree-load-fallback-links a {
+  display: block;
+  overflow: hidden;
+  padding: 6px 8px;
+  border-radius: 5px;
+  color: var(--latte-subtext1);
+  text-decoration: none;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tree-load-fallback-links a:hover {
+  background: var(--latte-surface0);
+  color: var(--latte-text);
+}
+
 .tree-root file-tree-container {
   --trees-bg-override: transparent;
   --trees-bg-muted-override: color-mix(in srgb, var(--latte-surface0) 44%, transparent);

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,4 +1,3 @@
-import { FileTree, prepareFileTreeInput } from "@pierre/trees";
 import { getRuntimeManifestDocs, normalizeManifestPayload } from "./manifest-adapter.js";
 import { buildTreesAdapterInput } from "./tree-adapter.js";
 
@@ -16,85 +15,9 @@ const DEFAULT_BRANCH = "dev";
 const DEFAULT_SITE_TITLE = "File-System Blog";
 const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
+const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-const TREE_UNSAFE_CSS = `
-[data-type='item'][data-item-selected] {
-  border-left: 4px solid var(--trees-accent-override, currentColor);
-  box-shadow: inset 0 0 0 1px var(--trees-selected-focused-border-color-override, transparent);
-  padding-left: calc(var(--trees-item-padding-x) - 4px);
-}
-
-[data-type='item'][data-item-selected] [data-item-section='content'] {
-  font-weight: var(--trees-font-weight-semibold);
-}
-
-/* EIAM owns the visible search controls while Trees keeps search projection enabled. */
-[data-file-tree-search-container] {
-  display: none;
-}
-
-[data-item-section='decoration'] > span {
-  flex: 0 0 auto;
-  width: auto;
-  padding: 2px 6px;
-  border-radius: 999px;
-  background: var(--trees-new-badge-bg, #d20f39);
-  color: var(--trees-new-badge-fg, #ffffff);
-  font-size: 0.625rem;
-  font-weight: 800;
-  line-height: 1;
-}
-
-[data-type='item'][data-item-type='file'] [data-item-section='content'] {
-  display: flex;
-  align-items: center;
-  flex: 1 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.tree-item-label {
-  display: inline-flex;
-  align-items: center;
-  gap: 7px;
-  min-width: 0;
-  max-width: 100%;
-  overflow: hidden;
-}
-
-.tree-item-prefix-badge {
-  flex: 0 0 auto;
-  max-width: 6.5rem;
-  overflow: hidden;
-  padding: 2px 6px;
-  border: 1px solid var(--trees-prefix-badge-border, rgba(203, 166, 247, 0.38));
-  border-radius: 999px;
-  background: var(--trees-prefix-badge-bg, rgba(203, 166, 247, 0.14));
-  color: var(--trees-prefix-badge-fg, currentColor);
-  font-size: 0.66rem;
-  font-weight: 800;
-  line-height: 1.15;
-  letter-spacing: 0.02em;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-.tree-item-title {
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-}
-
-[data-type='item'][data-item-type='file'] [data-item-section='decoration'] {
-  flex: 0 0 auto;
-  margin-left: 6px;
-  min-width: max-content;
-}
-`;
 const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
 const MERMAID_DEFAULT_THEME = "default";
 const MERMAID_SELECTOR = "pre.mermaid";
@@ -682,11 +605,26 @@ function loadInitialRuntimeData() {
 
     const pathBase = normalizePathBase(parsed.pathBase);
     const manifestUrl = typeof parsed.manifestUrl === "string" ? parsed.manifestUrl : "";
+    const treeModuleUrl = typeof parsed.treeModuleUrl === "string" ? parsed.treeModuleUrl : "";
     if (!manifestUrl || manifestUrl !== toPathWithBase("/manifest.json", pathBase)) {
       return null;
     }
 
-    return { manifestUrl, pathBase };
+    let resolvedTreeModuleUrl;
+    try {
+      resolvedTreeModuleUrl = new URL(treeModuleUrl, document.baseURI);
+    } catch {
+      return null;
+    }
+    const treeModulePath = stripPathBase(resolvedTreeModuleUrl.pathname, pathBase);
+    if (
+      resolvedTreeModuleUrl.origin !== window.location.origin ||
+      !/^\/assets\/tree\.[a-f0-9]{12}\.js$/.test(treeModulePath)
+    ) {
+      return null;
+    }
+
+    return { manifestUrl, pathBase, treeModuleUrl: resolvedTreeModuleUrl.href };
   } catch {
     return null;
   }
@@ -1157,8 +1095,16 @@ function setAppReadyState(state) {
   document.documentElement.setAttribute(APP_READY_STATE_ATTR, state);
 }
 
+function setTreeRuntimeState(state) {
+  if (!(document.documentElement instanceof HTMLElement)) {
+    return;
+  }
+  document.documentElement.setAttribute(TREE_RUNTIME_STATE_ATTR, state);
+}
+
 async function start() {
   setAppReadyState("booting");
+  setTreeRuntimeState("idle");
 
   const treeRoot = document.getElementById("tree-root");
   const treeSearchInput = document.getElementById("tree-search-input");
@@ -1199,6 +1145,15 @@ async function start() {
   let treePathOrder = new Map();
   let treeSearchValue = "";
   let renderedTreeBranch = "";
+  let treeRuntime = null;
+  let treeLoadPromise = null;
+  let treeRetryCount = 0;
+  let treeLoadAllowed = false;
+  let pendingTreeLoadReason = "";
+  let requestTreeLoad = (reason) => {
+    pendingTreeLoadReason = reason;
+    return Promise.resolve(false);
+  };
 
   const announceA11yStatus = (message) => {
     if (!(a11yStatusEl instanceof HTMLElement)) {
@@ -1364,6 +1319,7 @@ async function start() {
     }
     document.body.classList.add("menu-open");
     syncSidebarA11y(true);
+    void requestTreeLoad("mobile-sidebar");
     const focusables = getFocusableElements(sidebar);
     if (focusables.length > 0) {
       focusables[0].focus();
@@ -1394,6 +1350,9 @@ async function start() {
       }
       syncSidebarA11y(false);
       syncDesktopSidebarWidth(false);
+      if (treeLoadAllowed) {
+        void requestTreeLoad("desktop-layout");
+      }
       return;
     }
     closeSidebar();
@@ -1575,6 +1534,7 @@ async function start() {
   const initialRuntimeData = loadInitialRuntimeData();
   const initialPathBase = normalizePathBase(initialRuntimeData?.pathBase);
   const manifestUrl = initialRuntimeData?.manifestUrl ?? toPathWithBase("/manifest.json", initialPathBase);
+  const treeModuleUrl = initialRuntimeData?.treeModuleUrl ?? "";
   const manifestRes = await fetch(manifestUrl);
   if (!manifestRes.ok) {
     throw new Error(`Failed to load manifest: ${manifestRes.status}`);
@@ -1729,8 +1689,12 @@ async function start() {
   };
 
   if (treeSearchInput instanceof HTMLInputElement) {
+    treeSearchInput.addEventListener("focus", () => {
+      void requestTreeLoad("tree-search");
+    });
     treeSearchInput.addEventListener("input", () => {
       applyTreeSearch(treeSearchInput.value);
+      void requestTreeLoad("tree-search");
     });
     treeSearchInput.addEventListener("keydown", (event) => {
       if (event.key === "Enter") {
@@ -1848,8 +1812,11 @@ async function start() {
   };
 
   const prepareTreesInput = () => {
+    if (!treeRuntime) {
+      throw new Error("Tree runtime is not loaded");
+    }
     treePathOrder = new Map(view.trees.paths.map((treePath, index) => [treePath, index]));
-    return prepareFileTreeInput(view.trees.paths, { sort: compareTreesByBranchOrder });
+    return treeRuntime.prepareFileTreeInput(view.trees.paths, { sort: compareTreesByBranchOrder });
   };
 
   const renderTreeRowDecoration = ({ item }) => {
@@ -1906,7 +1873,7 @@ async function start() {
   };
 
   const renderTree = (state) => {
-    if (!(treeRoot instanceof HTMLElement)) {
+    if (!(treeRoot instanceof HTMLElement) || !treeRuntime) {
       return;
     }
 
@@ -1920,7 +1887,8 @@ async function start() {
       : null;
 
     if (!fileTree) {
-      fileTree = new FileTree({
+      treeRoot.replaceChildren();
+      fileTree = new treeRuntime.FileTree({
         composition: {
           contextMenu: {
             enabled: true,
@@ -1954,7 +1922,7 @@ async function start() {
         search: true,
         searchBlurBehavior: "retain",
         stickyFolders: true,
-        unsafeCSS: TREE_UNSAFE_CSS,
+        unsafeCSS: treeRuntime.TREE_UNSAFE_CSS,
       });
       fileTree.render({ containerWrapper: treeRoot });
     } else {
@@ -1970,6 +1938,133 @@ async function start() {
     syncActiveTreeSelection(state.currentDocId || "");
     applyTreeSearch(treeSearchValue);
     setupTreeLabelDecorations(treeRoot, view.trees.metadataByTreePath);
+  };
+
+  const renderTreeLoadingState = () => {
+    if (!(treeRoot instanceof HTMLElement) || fileTree) {
+      return;
+    }
+    const status = document.createElement("p");
+    status.className = "tree-load-status";
+    status.setAttribute("role", "status");
+    status.textContent = "문서 탐색기를 불러오는 중입니다.";
+    treeRoot.replaceChildren(status);
+  };
+
+  const renderTreeFallback = (error) => {
+    if (!(treeRoot instanceof HTMLElement)) {
+      return;
+    }
+
+    const fallback = document.createElement("section");
+    fallback.className = "tree-load-fallback";
+    fallback.setAttribute("aria-label", "간이 문서 탐색기");
+
+    const message = document.createElement("p");
+    message.className = "tree-load-fallback-message";
+    message.setAttribute("role", "alert");
+    message.textContent = "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.";
+
+    const retry = document.createElement("button");
+    retry.className = "tree-load-retry";
+    retry.type = "button";
+    retry.textContent = "탐색기 다시 불러오기";
+    retry.addEventListener("click", () => {
+      void requestTreeLoad("retry", { retry: true });
+    });
+
+    const links = document.createElement("ul");
+    links.className = "tree-load-fallback-links";
+    for (const doc of view.docs) {
+      const item = document.createElement("li");
+      const link = document.createElement("a");
+      link.href = toPathWithBase(doc.route, pathBase);
+      link.textContent = doc.title;
+      link.addEventListener("click", (event) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        event.preventDefault();
+        void state.navigate(doc.route, true);
+      });
+      item.appendChild(link);
+      links.appendChild(item);
+    }
+
+    fallback.append(message, retry, links);
+    fallback.dataset.error = error instanceof Error ? error.name : "TreeLoadError";
+    treeRoot.replaceChildren(fallback);
+  };
+
+  const loadTreeRuntime = ({ reason, retry = false }) => {
+    if (treeRuntime) {
+      renderTree(state);
+      return Promise.resolve(true);
+    }
+    if (treeLoadPromise) {
+      return treeLoadPromise;
+    }
+    if (!treeModuleUrl) {
+      const error = new Error("Tree module URL is unavailable");
+      setTreeRuntimeState("error");
+      renderTreeFallback(error);
+      return Promise.resolve(false);
+    }
+
+    const importUrl = new URL(treeModuleUrl);
+    if (retry) {
+      treeRetryCount += 1;
+      importUrl.searchParams.set("retry", String(treeRetryCount));
+    }
+
+    setTreeRuntimeState("loading");
+    if (treeRoot instanceof HTMLElement) {
+      treeRoot.setAttribute("aria-busy", "true");
+      treeRoot.dataset.treeLoadReason = reason;
+    }
+    renderTreeLoadingState();
+    window.performance?.mark?.("eiam-tree-load-start");
+
+    treeLoadPromise = import(importUrl.href)
+      .then((module) => {
+        if (
+          typeof module.FileTree !== "function" ||
+          typeof module.prepareFileTreeInput !== "function" ||
+          typeof module.TREE_UNSAFE_CSS !== "string"
+        ) {
+          throw new Error("Tree runtime exports are invalid");
+        }
+        treeRuntime = module;
+        renderTree(state);
+        if (treeRoot instanceof HTMLElement) {
+          treeRoot.setAttribute("aria-busy", "false");
+        }
+        setTreeRuntimeState("ready");
+        window.performance?.mark?.("eiam-tree-ready");
+        return true;
+      })
+      .catch((error) => {
+        destroyFileTree();
+        treeRuntime = null;
+        treeLoadPromise = null;
+        if (treeRoot instanceof HTMLElement) {
+          treeRoot.setAttribute("aria-busy", "false");
+        }
+        setTreeRuntimeState("error");
+        renderTreeFallback(error);
+        announceA11yStatus("문서 트리를 불러오지 못했습니다. 간이 링크 탐색기를 사용할 수 있습니다.");
+        console.error("Tree runtime load failed:", error);
+        return false;
+      });
+
+    return treeLoadPromise;
   };
 
   const updateBacklinks = (doc) => {
@@ -2005,7 +2100,9 @@ async function start() {
           activeBranch = targetBranch;
           view = getBranchView(activeBranch);
           updateBranchInfo();
-          renderTree(state);
+          if (treeRuntime) {
+            renderTree(state);
+          }
           localStorage.setItem(BRANCH_KEY, activeBranch);
           id = view.routeMap[route];
         }
@@ -2088,6 +2185,41 @@ async function start() {
       }
       announceA11yStatus(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
     },
+  };
+
+  requestTreeLoad = (reason, options = {}) => {
+    if (!treeLoadAllowed) {
+      pendingTreeLoadReason = reason;
+      return Promise.resolve(false);
+    }
+    pendingTreeLoadReason = "";
+    return loadTreeRuntime({ reason, retry: options.retry === true });
+  };
+
+  const scheduleTreeLoadAfterFirstContentPaint = () => {
+    window.requestAnimationFrame(() => {
+      window.requestAnimationFrame(() => {
+        treeLoadAllowed = true;
+        window.performance?.mark?.("eiam-first-content-paint-opportunity");
+
+        if (pendingTreeLoadReason) {
+          void requestTreeLoad(pendingTreeLoadReason);
+          return;
+        }
+        if (isCompactLayout()) {
+          return;
+        }
+
+        const loadForDesktop = () => {
+          void requestTreeLoad("desktop-idle");
+        };
+        if (typeof window.requestIdleCallback === "function") {
+          window.requestIdleCallback(loadForDesktop, { timeout: 500 });
+        } else {
+          window.setTimeout(loadForDesktop, 0);
+        }
+      });
+    });
   };
 
   if (contentEl instanceof HTMLElement) {
@@ -2185,7 +2317,7 @@ async function start() {
     view = getBranchView(activeBranch);
     localStorage.setItem(BRANCH_KEY, activeBranch);
     updateBranchInfo();
-    renderTree(state);
+    void requestTreeLoad("branch");
 
     const currentRoute = resolveRouteFromLocation(view.routeMap, pathBase);
     if (view.routeMap[currentRoute]) {
@@ -2199,13 +2331,14 @@ async function start() {
 
   renderBranchPills();
   updateBranchInfo();
-  renderTree(state);
 
   const currentRoute = resolveRouteFromLocation(view.routeMap, pathBase);
   const initialRoute = currentRoute === "/" ? pickHomeRoute(view) : currentRoute;
   handleLayoutChange();
   await state.navigate(initialRoute, currentRoute === "/" && initialRoute !== "/");
   setAppReadyState("ready");
+  window.performance?.mark?.("eiam-app-ready");
+  scheduleTreeLoadAfterFirstContentPaint();
 
   window.addEventListener("popstate", async () => {
     await state.navigate(resolveRouteFromLocation(view.routeMap, pathBase), false);

--- a/src/runtime/tree-runtime.js
+++ b/src/runtime/tree-runtime.js
@@ -1,0 +1,81 @@
+import { FileTree, prepareFileTreeInput } from "@pierre/trees";
+
+const TREE_UNSAFE_CSS = `
+[data-type='item'][data-item-selected] {
+  border-left: 4px solid var(--trees-accent-override, currentColor);
+  box-shadow: inset 0 0 0 1px var(--trees-selected-focused-border-color-override, transparent);
+  padding-left: calc(var(--trees-item-padding-x) - 4px);
+}
+
+[data-type='item'][data-item-selected] [data-item-section='content'] {
+  font-weight: var(--trees-font-weight-semibold);
+}
+
+/* EIAM owns the visible search controls while Trees keeps search projection enabled. */
+[data-file-tree-search-container] {
+  display: none;
+}
+
+[data-item-section='decoration'] > span {
+  flex: 0 0 auto;
+  width: auto;
+  padding: 2px 6px;
+  border-radius: 999px;
+  background: var(--trees-new-badge-bg, #d20f39);
+  color: var(--trees-new-badge-fg, #ffffff);
+  font-size: 0.625rem;
+  font-weight: 800;
+  line-height: 1;
+}
+
+[data-type='item'][data-item-type='file'] [data-item-section='content'] {
+  display: flex;
+  align-items: center;
+  flex: 1 1 auto;
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tree-item-label {
+  display: inline-flex;
+  align-items: center;
+  gap: 7px;
+  min-width: 0;
+  max-width: 100%;
+  overflow: hidden;
+}
+
+.tree-item-prefix-badge {
+  flex: 0 0 auto;
+  max-width: 6.5rem;
+  overflow: hidden;
+  padding: 2px 6px;
+  border: 1px solid var(--trees-prefix-badge-border, rgba(203, 166, 247, 0.38));
+  border-radius: 999px;
+  background: var(--trees-prefix-badge-bg, rgba(203, 166, 247, 0.14));
+  color: var(--trees-prefix-badge-fg, currentColor);
+  font-size: 0.66rem;
+  font-weight: 800;
+  line-height: 1.15;
+  letter-spacing: 0.02em;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.tree-item-title {
+  min-width: 0;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+[data-type='item'][data-item-type='file'] [data-item-section='decoration'] {
+  flex: 0 0 auto;
+  margin-left: 6px;
+  min-width: max-content;
+}
+`;
+
+export { FileTree, prepareFileTreeInput, TREE_UNSAFE_CSS };

--- a/src/template.ts
+++ b/src/template.ts
@@ -27,6 +27,7 @@ export interface AppShellMeta {
 export interface AppShellAssets {
   cssHref: string;
   jsSrc: string;
+  treeModulePath: string;
 }
 
 export interface AppShellInitialView {
@@ -51,11 +52,13 @@ interface AppShellManifestPayload extends Manifest {}
 interface AppShellRuntimePayload {
   manifestUrl: string;
   pathBase: string;
+  treeModuleUrl: string;
 }
 
 const DEFAULT_ASSETS: AppShellAssets = {
   cssHref: "/assets/app.css",
   jsSrc: "/assets/app.js",
+  treeModulePath: "/assets/tree.js",
 };
 
 function normalizeJsonLd(value: unknown | unknown[] | undefined): unknown[] {
@@ -165,23 +168,28 @@ function renderInitialViewScript(initialView: AppShellInitialView | null): strin
   return `\n    <script id="initial-view-data" type="application/json">${payload}</script>`;
 }
 
-function toManifestUrl(pathBase: string): string {
-  const normalized = pathBase.trim().replace(/\/+$/, "");
-  const rawPath = normalized ? `${normalized}/manifest.json` : "/manifest.json";
+function toPublicUrl(pathBase: string, pathname: string): string {
+  const normalizedBase = pathBase.trim().replace(/^\/+|\/+$/g, "");
+  const normalizedPath = pathname.trim().replace(/^\/+/g, "");
+  const rawPath = `/${[normalizedBase, normalizedPath].filter(Boolean).join("/")}`;
   return rawPath
     .split("/")
     .map((segment, index) => (index === 0 && segment === "" ? "" : encodeURIComponent(segment)))
     .join("/");
 }
 
-function renderRuntimeBootstrapScript(manifest: AppShellManifestPayload | null): string {
+function renderRuntimeBootstrapScript(
+  manifest: AppShellManifestPayload | null,
+  assets: AppShellAssets,
+): string {
   if (!manifest) {
     return "";
   }
 
   const payloadData: AppShellRuntimePayload = {
-    manifestUrl: toManifestUrl(manifest.pathBase),
+    manifestUrl: toPublicUrl(manifest.pathBase, "/manifest.json"),
     pathBase: manifest.pathBase,
+    treeModuleUrl: toPublicUrl(manifest.pathBase, assets.treeModulePath),
   };
   const payload = JSON.stringify(payloadData)
     .replaceAll("<", "\\u003c")
@@ -199,7 +207,7 @@ export function renderAppShellHtml(
 ): string {
   const headMeta = renderHeadMeta(meta);
   const initialViewScript = renderInitialViewScript(initialView);
-  const runtimeBootstrapScript = renderRuntimeBootstrapScript(manifest);
+  const runtimeBootstrapScript = renderRuntimeBootstrapScript(manifest, assets);
   const symbolFontStylesheet =
     "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
   const appTitle = typeof manifest?.siteTitle === "string" && manifest.siteTitle.trim().length > 0

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -49,6 +49,14 @@ function extractRuntimeAssetPath(html: string, extension: "js" | "css"): string 
   return match[0];
 }
 
+function extractTreeRuntimeAssetPath(html: string): string {
+  const match = html.match(/assets\/tree\.[a-f0-9]+\.js/);
+  if (!match) {
+    throw new Error("deferred tree 런타임 자산 경로를 찾지 못했습니다.");
+  }
+  return match[0];
+}
+
 function runCli(cwd: string, args: string[], timeout?: number): CliResult {
   const result = spawnSync("bun", args, {
     cwd,
@@ -319,7 +327,7 @@ ALPHA
     }
   });
 
-  test("증분 빌드에서 누락된 해시 런타임 자산(js/css)을 복구한다", async () => {
+  test("증분 빌드에서 누락된 해시 런타임 자산(app/tree/css)을 복구한다", async () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-build-runtime-regression-"));
     const outDir = path.join(workDir, "dist");
 
@@ -332,21 +340,27 @@ ALPHA
       const entryHtml = fs.readFileSync(entryHtmlPath, "utf8");
 
       const runtimeJsRelPath = extractRuntimeAssetPath(entryHtml, "js");
+      const treeRuntimeJsRelPath = extractTreeRuntimeAssetPath(entryHtml);
       const runtimeCssRelPath = extractRuntimeAssetPath(entryHtml, "css");
       const runtimeJsPath = path.join(outDir, runtimeJsRelPath);
+      const treeRuntimeJsPath = path.join(outDir, treeRuntimeJsRelPath);
       const runtimeCssPath = path.join(outDir, runtimeCssRelPath);
 
       expect(fs.existsSync(runtimeJsPath)).toBe(true);
+      expect(fs.existsSync(treeRuntimeJsPath)).toBe(true);
       expect(fs.existsSync(runtimeCssPath)).toBe(true);
 
       fs.rmSync(runtimeJsPath);
+      fs.rmSync(treeRuntimeJsPath);
       fs.rmSync(runtimeCssPath);
       expect(fs.existsSync(runtimeJsPath)).toBe(false);
+      expect(fs.existsSync(treeRuntimeJsPath)).toBe(false);
       expect(fs.existsSync(runtimeCssPath)).toBe(false);
 
       const secondBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(secondBuild.status, secondBuild.output).toBe(0);
       expect(fs.existsSync(runtimeJsPath)).toBe(true);
+      expect(fs.existsSync(treeRuntimeJsPath)).toBe(true);
       expect(fs.existsSync(runtimeCssPath)).toBe(true);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });

--- a/tests/e2e/deferred-tree-runtime.spec.ts
+++ b/tests/e2e/deferred-tree-runtime.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
+
+const TREE_MODULE_PATTERN = /\/assets\/tree\.[a-f0-9]{12}\.js(?:\?.*)?$/;
+
+test.describe("deferred tree runtime", () => {
+  test("tree chunk 실패가 SSR content를 막지 않고 fallback 탐색과 재시도를 제공한다", async ({ page }) => {
+    let treeRequestCount = 0;
+    await page.route(TREE_MODULE_PATTERN, async (route) => {
+      treeRequestCount += 1;
+      if (treeRequestCount === 1) {
+        await route.abort("failed");
+        return;
+      }
+      await route.continue();
+    });
+
+    await page.goto("/BC-VO-00/");
+    await waitForAppReady(page);
+
+    await expect(page.locator("#viewer-title")).toHaveText("About");
+    await expect(page.locator("#viewer-content")).not.toBeEmpty();
+    await expect(page.locator("html")).toHaveAttribute("data-tree-runtime", "error");
+    expect(treeRequestCount).toBe(1);
+
+    const timing = await page.evaluate(() => {
+      const mark = (name: string) => performance.getEntriesByName(name).at(-1)?.startTime ?? -1;
+      return {
+        appReady: mark("eiam-app-ready"),
+        firstPaintOpportunity: mark("eiam-first-content-paint-opportunity"),
+        firstContentfulPaint:
+          performance.getEntriesByType("paint").find((entry) => entry.name === "first-contentful-paint")
+            ?.startTime ?? -1,
+        treeLoadStart: mark("eiam-tree-load-start"),
+      };
+    });
+    expect(timing.appReady).toBeGreaterThanOrEqual(0);
+    expect(timing.firstPaintOpportunity).toBeGreaterThan(timing.appReady);
+    expect(timing.treeLoadStart).toBeGreaterThanOrEqual(timing.firstPaintOpportunity);
+    if (timing.firstContentfulPaint >= 0) {
+      expect(timing.treeLoadStart).toBeGreaterThanOrEqual(timing.firstContentfulPaint);
+    }
+
+    const fallback = page.locator("#tree-root .tree-load-fallback");
+    await expect(fallback).toBeVisible();
+    await expect(fallback.getByRole("button", { name: "탐색기 다시 불러오기" })).toBeVisible();
+    const setupGuideLink = fallback.locator('a[href$="/BC-VO-02/"]');
+    await expect(setupGuideLink).toBeVisible();
+    await setupGuideLink.click();
+    await expect(page).toHaveURL(/\/BC-VO-02\/$/);
+    await expect(page.locator("#viewer-title")).toHaveText("Setup Guide");
+
+    await fallback.getByRole("button", { name: "탐색기 다시 불러오기" }).click();
+    await waitForTreeReady(page);
+    expect(treeRequestCount).toBe(2);
+    await expect(page.locator("#tree-root file-tree-container")).toBeVisible();
+  });
+
+  test("compact layout은 sidebar interaction 전에는 tree chunk를 요청하지 않는다", async ({ page }) => {
+    await page.setViewportSize({ width: 390, height: 844 });
+    let treeRequestCount = 0;
+    page.on("request", (request) => {
+      if (TREE_MODULE_PATTERN.test(request.url())) {
+        treeRequestCount += 1;
+      }
+    });
+
+    await page.goto("/BC-VO-01/");
+    await waitForAppReady(page);
+    await page.waitForTimeout(250);
+
+    expect(treeRequestCount).toBe(0);
+    await expect(page.locator("html")).toHaveAttribute("data-tree-runtime", "idle");
+    await expect(page.locator("#viewer-title")).not.toBeEmpty();
+
+    await page.getByRole("button", { name: "탐색기 열기" }).click();
+    await waitForTreeReady(page);
+
+    expect(treeRequestCount).toBe(1);
+    await expect(page.locator("#sidebar-panel")).toHaveAttribute("role", "dialog");
+    await expect(page.locator("#tree-root file-tree-container")).toBeVisible();
+  });
+});

--- a/tests/e2e/mobile-sidebar-focus-trap.spec.ts
+++ b/tests/e2e/mobile-sidebar-focus-trap.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { waitForAppReady } from "./utils/app-ready";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
 
 test.describe("모바일 사이드바 포커스 트랩", () => {
   test("Tab/Shift+Tab 이동이 사이드바 내부에 머무른다", async ({ page }) => {
@@ -14,6 +14,7 @@ test.describe("모바일 사이드바 포커스 트랩", () => {
     await expect(toggle).toBeVisible();
     await expect(toggle).toHaveAttribute("aria-expanded", "false");
     await toggle.click();
+    await waitForTreeReady(page);
     await expect(page.locator("#sidebar-toggle")).toHaveAttribute("aria-expanded", "true");
     await expect(sidebar).toHaveAttribute("role", "dialog");
     await expect(sidebar).toHaveAttribute("aria-modal", "true");

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -5,6 +5,7 @@ import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+import { waitForTreeReady } from "./utils/app-ready";
 
 function runCli(cwd: string, args: string[]): { status: number | null; output: string } {
   const result = spawnSync("bun", args, { cwd, encoding: "utf8" });
@@ -142,6 +143,9 @@ test.describe("pathBase 정식 지원", () => {
       expect(encodedIndexHtml).toContain(
         '\"manifestUrl\":\"/docs%20guides/%ED%95%9C%EA%B8%80/manifest.json\"',
       );
+      expect(encodedIndexHtml).toMatch(
+        /"treeModuleUrl":"\/docs%20guides\/%ED%95%9C%EA%B8%80\/assets\/tree\.[a-f0-9]{12}\.js"/,
+      );
 
       const encodedServer = await startStaticServer(outDir, "/docs guides/한글");
       try {
@@ -187,6 +191,7 @@ test.describe("pathBase 정식 지원", () => {
     try {
       await page.goto(`${server.baseUrl}/blog/BC-VO-00/`);
       await expect(page.locator("#viewer-title")).toHaveText("About");
+      await waitForTreeReady(page);
 
       const setupRow = page
         .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')

--- a/tests/e2e/responsive-sidebar-layout.spec.ts
+++ b/tests/e2e/responsive-sidebar-layout.spec.ts
@@ -5,7 +5,7 @@ import type { AddressInfo } from "node:net";
 import os from "node:os";
 import path from "node:path";
 import { expect, type Page, test } from "@playwright/test";
-import { waitForAppReady } from "./utils/app-ready";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
 
 interface Rect {
   bottom: number;
@@ -134,6 +134,7 @@ async function openSidebar(page: Page, baseUrl: string): Promise<void> {
   await expect(toggle).toBeVisible();
   await toggle.click();
   await expect(page.locator("#sidebar-panel")).toHaveAttribute("role", "dialog");
+  await waitForTreeReady(page);
 }
 
 async function getRect(page: Page, selector: string): Promise<Rect> {

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -1,5 +1,5 @@
 import { expect, test } from "@playwright/test";
-import { waitForAppReady } from "./utils/app-ready";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
 
 test.describe("런타임 렌더링 XSS 가드", () => {
   test("내비게이션/트리에서 악성 title이 HTML로 해석되지 않는다", async ({ page }) => {
@@ -9,6 +9,7 @@ test.describe("런타임 렌더링 XSS 가드", () => {
 
     await page.goto("/BC-VO-02/");
     await waitForAppReady(page);
+    await waitForTreeReady(page);
     await expect(page.locator("#tree-root")).toBeVisible();
     await expect(
       page
@@ -79,6 +80,7 @@ test.describe("런타임 렌더링 XSS 가드", () => {
 
     await page.goto("/BC-VO-02/");
     await waitForAppReady(page);
+    await waitForTreeReady(page);
     const xssRow = page
       .locator('#tree-root [data-type="item"][data-item-type="file"]')
       .filter({ hasText: "Unsafe" })

--- a/tests/e2e/tree-icon-payload.spec.ts
+++ b/tests/e2e/tree-icon-payload.spec.ts
@@ -1,7 +1,7 @@
 import fs from "node:fs";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
-import { waitForAppReady } from "./utils/app-ready";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
 
 const MINIMAL_TREE_ICON_IDS = [
   "file-tree-icon-chevron",
@@ -24,6 +24,7 @@ test.describe("minimal Trees icon payload", () => {
   test("generic icon만 사용하면서 keyboard, virtualization, selection, ARIA 동작을 유지한다", async ({ page }) => {
     await page.goto("/BC-VO-00/");
     await waitForAppReady(page);
+    await waitForTreeReady(page);
 
     const state = await page.locator("#tree-root").evaluate((treeRoot) => {
       const host = treeRoot.querySelector("file-tree-container");

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -1,10 +1,11 @@
 import { expect, test } from "@playwright/test";
-import { waitForAppReady } from "./utils/app-ready";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
 
 test.describe("Trees sidebar search", () => {
   test("검색 결과를 필터링하고 clear 후 일반 트리로 복귀한다", async ({ page }) => {
     await page.goto("/");
     await waitForAppReady(page);
+    await waitForTreeReady(page);
 
     const searchInput = page.locator("#tree-search-input");
     const searchCount = page.locator("#tree-search-count");

--- a/tests/e2e/utils/app-ready.ts
+++ b/tests/e2e/utils/app-ready.ts
@@ -26,3 +26,30 @@ export async function waitForAppReady(page: Page): Promise<void> {
     `앱 준비 상태 대기 시간(${timeoutMs}ms) 초과. 마지막 상태: ${lastState ?? "unset"}`,
   ).toHaveAttribute("data-app-ready", "ready", { timeout: 1 });
 }
+
+export async function waitForTreeReady(page: Page): Promise<void> {
+  const timeoutMs = 10_000;
+  const pollIntervalMs = 100;
+  const deadline = Date.now() + timeoutMs;
+  let lastState: string | null = null;
+
+  while (Date.now() < deadline) {
+    const state = await page.evaluate(() => document.documentElement.getAttribute("data-tree-runtime"));
+    lastState = state;
+
+    if (state === "ready") {
+      return;
+    }
+
+    if (state === "error") {
+      throw new Error(`트리 초기화 실패 상태를 감지했습니다. data-tree-runtime=error, url=${page.url()}`);
+    }
+
+    await page.waitForTimeout(pollIntervalMs);
+  }
+
+  await expect(
+    page.locator("html"),
+    `트리 준비 상태 대기 시간(${timeoutMs}ms) 초과. 마지막 상태: ${lastState ?? "unset"}`,
+  ).toHaveAttribute("data-tree-runtime", "ready", { timeout: 1 });
+}


### PR DESCRIPTION
Part of #22. Detailed context: #28.

## Summary

- split the browser runtime into a 36,965-byte critical app entry and a separately hashed deferred tree module
- permit dynamic tree import only after the initial article is ready and two animation frames have elapsed; desktop then uses idle time, while compact layouts wait for sidebar or search interaction
- keep SSR title, body, backlinks, and previous/next navigation usable when the tree asset fails
- provide an accessible retry action and ordinary document links as a recoverable sidebar fallback
- validate same-origin path-base-aware tree URLs and enforce per-entry plus combined JavaScript budgets

## DnD

- [x] SSR content remains functional when the tree chunk is unavailable
- [x] Tree loading begins only after the first content paint opportunity
- [x] Desktop idle loading and compact sidebar/search interactions trigger loading safely
- [x] Errors expose retry and real document links without changing app-ready to error
- [x] Critical-path JavaScript is measured before and after and enforced in CI
- [x] Hashed app/tree/css assets recover during incremental builds and remain reproducible

## Bundle result

| Metric | Before | After | Change |
| --- | ---: | ---: | ---: |
| Critical JS | 244,503 B | 36,965 B | -84.9% |
| Critical JS gzip | 69,381 B | 12,264 B | -82.3% |
| Deferred tree JS | 0 B | 210,934 B | +210,934 B |
| Deferred tree gzip | 0 B | 58,719 B | +58,719 B |
| Total JS | 244,503 B | 247,899 B | +1.4% |
| Total JS gzip | 69,381 B | 70,983 B | +2.3% |

## Verification

- `bun install --frozen-lockfile`
- `bunx --package typescript tsc --noEmit`
- `bun run build --vault ./test-vault --out ./dist`
- `bun run check:size`
- `bun run check:reproducible` — 18 files stable, digest `5e15a9722e20`
- focused pathBase, runtime asset recovery, responsive, XSS, and deferred-loading E2E — 13 passed
- `bun run test:e2e` — 63 passed
- `bunx markdownlint-cli2 docs/solutions/20260719-deferred-tree-runtime.md`
- packed production install/build smoke — one critical app asset, one deferred tree asset, tree icons only in deferred output

The historical README MD013 baseline decreases from 42 to 41 existing issues; all changed README lines conform.