### PR TITLE
refactor: extract runtime navigation controllers

### DIFF
--- a/docs/solutions/20260719-runtime-navigation-contract.md
+++ b/docs/solutions/20260719-runtime-navigation-contract.md
@@ -1,0 +1,36 @@
+# Runtime navigation contract
+
+Issue #29 makes browser navigation state explicit before the remaining UI controllers are extracted.
+
+## Ownership
+
+`navigation-state.js` is the single owner of:
+
+- the normalized default and active branch;
+- the branch-filtered document/tree projection;
+- the current document id;
+- route normalization and automatic branch switching;
+- path-base encoding and location-to-route conversion.
+
+`content-controller.js` owns the navigation lifecycle around that state:
+
+- delegated previous/next and backlink clicks;
+- browser history and `popstate` handling;
+- content fetches and initial SSR-content reuse;
+- breadcrumb, metadata, backlink, and previous/next updates;
+- content enhancement and accessibility callbacks;
+- setup and cleanup of its event listeners.
+
+The controller receives renderers and lifecycle callbacks instead of importing tree, sidebar, Mermaid, or presentation implementations. This keeps those concerns replaceable in the following sub PRs.
+
+## State transition
+
+1. Normalize the requested route.
+2. Resolve it in the active branch projection.
+3. If the route belongs to another branch, switch the state projection once.
+4. Commit the current document id.
+5. Update history when requested.
+6. Reuse matching initial SSR content or fetch the document body.
+7. Render view chrome, enhance content, synchronize tree selection, and announce completion.
+
+Unknown routes clear the current document selection without changing unrelated controller state.

--- a/docs/solutions/20260719-runtime-navigation-contract.md
+++ b/docs/solutions/20260719-runtime-navigation-contract.md
@@ -21,6 +21,8 @@ Issue #29 makes browser navigation state explicit before the remaining UI contro
 - content enhancement and accessibility callbacks;
 - setup and cleanup of its event listeners.
 
+The app destroys controller listeners on `pagehide` and calls `setup()` again when a persisted `pageshow` restores the page from the back-forward cache.
+
 The controller receives renderers and lifecycle callbacks instead of importing tree, sidebar, Mermaid, or presentation implementations. This keeps those concerns replaceable in the following sub PRs.
 
 ## State transition

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,5 +1,14 @@
-import { getRuntimeManifestDocs, normalizeManifestPayload } from "./manifest-adapter.js";
-import { buildTreesAdapterInput } from "./tree-adapter.js";
+import { normalizeManifestPayload } from "./manifest-adapter.js";
+import { createContentController } from "./content-controller.js";
+import {
+  createNavigationState,
+  normalizePathBase,
+  normalizeRoute,
+  pickHomeRoute,
+  resolveRouteFromLocation,
+  stripPathBase,
+  toPathWithBase,
+} from "./navigation-state.js";
 
 const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
 const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
@@ -11,7 +20,6 @@ const DESKTOP_SIDEBAR_MIN = 320;
 const DESKTOP_VIEWER_MIN = 680;
 const DESKTOP_SPLITTER_WIDTH = 10;
 const DESKTOP_SPLITTER_STEP = 24;
-const DEFAULT_BRANCH = "dev";
 const DEFAULT_SITE_TITLE = "File-System Blog";
 const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
@@ -479,78 +487,6 @@ async function renderMermaidBlocks(config) {
   }
 }
 
-function toSafeUrlPath(input) {
-  const value = String(input);
-  return value
-    .split("/")
-    .map((segment, index) => {
-      if (index === 0 && segment === "") {
-        return "";
-      }
-      return encodeURIComponent(segment);
-    })
-    .join("/");
-}
-
-function normalizePathname(pathname) {
-  let normalized = "/";
-  try {
-    normalized = decodeURIComponent(pathname || "/");
-  } catch {
-    normalized = String(pathname || "/");
-  }
-  if (!normalized.startsWith("/")) {
-    normalized = `/${normalized}`;
-  }
-  return normalized.replace(/\/+/g, "/") || "/";
-}
-
-function normalizeRoute(pathname) {
-  const normalized = normalizePathname(pathname);
-  if (normalized.endsWith("/")) {
-    return normalized;
-  }
-  return `${normalized}/`;
-}
-
-function normalizePathBase(pathBase) {
-  if (typeof pathBase !== "string") {
-    return "";
-  }
-
-  const cleaned = pathBase.trim().replace(/\\/g, "/");
-  if (!cleaned || cleaned === "/") {
-    return "";
-  }
-
-  return `/${cleaned.replace(/^\/+/, "").replace(/\/+$/, "")}`;
-}
-
-function stripPathBase(pathname, pathBase) {
-  const normalizedPath = normalizePathname(pathname);
-  if (!pathBase) {
-    return normalizedPath;
-  }
-  if (normalizedPath === pathBase) {
-    return "/";
-  }
-  if (normalizedPath.startsWith(`${pathBase}/`)) {
-    return normalizedPath.slice(pathBase.length) || "/";
-  }
-  return normalizedPath;
-}
-
-function toPathWithBase(pathname, pathBase) {
-  const normalizedPath = normalizePathname(pathname);
-  if (!pathBase) {
-    return toSafeUrlPath(normalizedPath);
-  }
-  if (normalizedPath === "/") {
-    return toSafeUrlPath(`${pathBase}/`);
-  }
-  return toSafeUrlPath(`${pathBase}${normalizedPath}`);
-}
-
 function loadInitialViewData() {
   const script = document.getElementById("initial-view-data");
   if (!(script instanceof HTMLScriptElement)) {
@@ -630,11 +566,6 @@ function loadInitialRuntimeData() {
   }
 }
 
-function resolveRouteFromLocation(routeMap, pathBase) {
-  const direct = normalizeRoute(stripPathBase(location.pathname, pathBase));
-  return routeMap[direct] ? direct : direct;
-}
-
 function resolveSiteTitle(manifest) {
   const value = typeof manifest?.siteTitle === "string" ? manifest.siteTitle.trim() : "";
   return value || DEFAULT_SITE_TITLE;
@@ -674,110 +605,6 @@ function normalizeTags(tags) {
   return tags
     .map((tag) => String(tag).trim().replace(/^#+/, ""))
     .filter(Boolean);
-}
-
-function normalizeBranch(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function isDocVisibleInBranch(doc, branch, defaultBranch) {
-  const docBranch = normalizeBranch(doc.branch);
-  if (!docBranch) {
-    return branch === defaultBranch;
-  }
-  return docBranch === branch;
-}
-
-function parseDateToEpochMs(value) {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    return null;
-  }
-
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function getRecentSortEpochMs(doc) {
-  return parseDateToEpochMs(doc.updatedDate) ?? parseDateToEpochMs(doc.date);
-}
-
-function compareDocsByRecentDateThenRoute(left, right) {
-  const leftEpoch = getRecentSortEpochMs(left);
-  const rightEpoch = getRecentSortEpochMs(right);
-
-  if (leftEpoch != null && rightEpoch != null) {
-    const byDate = rightEpoch - leftEpoch;
-    if (byDate !== 0) {
-      return byDate;
-    }
-  } else if (leftEpoch != null && rightEpoch == null) {
-    return -1;
-  } else if (leftEpoch == null && rightEpoch != null) {
-    return 1;
-  }
-
-  return left.route.localeCompare(right.route, "ko-KR");
-}
-
-function cloneFilteredTree(nodes, visibleDocIds) {
-  const filteredNodes = [];
-
-  for (const node of nodes) {
-    if (node.type === "file") {
-      if (visibleDocIds.has(node.id)) {
-        filteredNodes.push(node);
-      }
-      continue;
-    }
-
-    const children = cloneFilteredTree(node.children, visibleDocIds);
-    if (children.length === 0 && !node.virtual) {
-      continue;
-    }
-
-    filteredNodes.push({
-      ...node,
-      children,
-    });
-  }
-
-  return filteredNodes;
-}
-
-function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
-  const docs = manifestDocs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
-  const visibleDocIds = new Set(docs.map((doc) => doc.id));
-  const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
-  const trees = buildTreesAdapterInput(tree, docs);
-  const routeMap = {};
-  const docIndexById = new Map();
-  for (const doc of docs) {
-    routeMap[doc.route] = doc.id;
-  }
-  for (let i = 0; i < docs.length; i += 1) {
-    docIndexById.set(docs[i].id, i);
-  }
-
-  return {
-    docs,
-    visibleDocIds,
-    tree,
-    trees,
-    routeMap,
-    docIndexById,
-  };
-}
-
-function pickHomeRoute(view) {
-  if (view.routeMap["/index/"]) {
-    return "/index/";
-  }
-  return [...view.docs].sort(compareDocsByRecentDateThenRoute)[0]?.route || "/";
 }
 
 function loadMenuTogglePosition() {
@@ -1134,7 +961,7 @@ async function start() {
   const a11yStatusEl = document.getElementById("a11y-status");
   const viewerEl = document.querySelector(".viewer");
   const initialViewData = loadInitialViewData();
-  let hasHydratedInitialView = false;
+  let contentController = null;
 
   let desktopSidebarWidth = clampDesktopSidebarWidth(loadDesktopSidebarWidth());
   let activeResizePointerId = null;
@@ -1546,33 +1373,11 @@ async function start() {
   const mermaidConfig = resolveMermaidConfig(manifest);
   const pathBase = normalizePathBase(manifest.pathBase);
   const siteTitle = resolveSiteTitle(manifest);
-  const defaultBranch = normalizeBranch(manifest.defaultBranch) || DEFAULT_BRANCH;
-  const availableBranchSet = new Set([defaultBranch]);
-  const manifestDocs = getRuntimeManifestDocs(manifest);
-  for (const doc of manifestDocs) {
-    const docBranch = normalizeBranch(doc.branch);
-    if (docBranch) {
-      availableBranchSet.add(docBranch);
-    }
-  }
-  if (Array.isArray(manifest.branches)) {
-    for (const branch of manifest.branches) {
-      const normalized = normalizeBranch(branch);
-      if (normalized) {
-        availableBranchSet.add(normalized);
-      }
-    }
-  }
-
-  const availableBranches = Array.from(availableBranchSet).sort((left, right) => {
-    if (left === defaultBranch) {
-      return -1;
-    }
-    if (right === defaultBranch) {
-      return 1;
-    }
-    return left.localeCompare(right, "ko-KR");
+  const navigation = createNavigationState(manifest, {
+    savedBranch: localStorage.getItem(BRANCH_KEY),
+    initialDocId: initialViewData?.docId,
   });
+  const availableBranches = navigation.availableBranches;
 
   const renderBranchPills = () => {
     if (!(sidebarBranchPills instanceof HTMLElement)) {
@@ -1594,35 +1399,19 @@ async function start() {
     }
   };
 
-  const savedBranch = normalizeBranch(localStorage.getItem(BRANCH_KEY));
-  let activeBranch = savedBranch && availableBranchSet.has(savedBranch) ? savedBranch : defaultBranch;
-  const branchViewCache = new Map();
-  const getBranchView = (branch) => {
-    const cached = branchViewCache.get(branch);
-    if (cached) {
-      return cached;
-    }
-    const nextView = buildBranchView(manifest, manifestDocs, branch, defaultBranch);
-    branchViewCache.set(branch, nextView);
-    return nextView;
-  };
-  let view = getBranchView(activeBranch);
-
-  const docsById = new Map(manifestDocs.map((doc) => [doc.id, doc]));
-
   const updateBranchInfo = () => {
     if (sidebarBranchInfo instanceof HTMLElement) {
       sidebarBranchInfo.textContent =
-        activeBranch === defaultBranch
-          ? `publish: true · ${activeBranch} + unclassified`
-          : `publish: true · ${activeBranch} only`;
+        navigation.activeBranch === navigation.defaultBranch
+          ? `publish: true · ${navigation.activeBranch} + unclassified`
+          : `publish: true · ${navigation.activeBranch} only`;
     }
     if (sidebarBranchPills instanceof HTMLElement) {
       for (const pill of sidebarBranchPills.querySelectorAll(".branch-pill")) {
         if (!(pill instanceof HTMLButtonElement)) {
           continue;
         }
-        const isActive = pill.dataset.branch === activeBranch;
+        const isActive = pill.dataset.branch === navigation.activeBranch;
         pill.classList.toggle("is-active", isActive);
         pill.setAttribute("aria-pressed", String(isActive));
       }
@@ -1731,7 +1520,7 @@ async function start() {
       return;
     }
 
-    const treePath = view.trees.docIdToPrimaryTreePath.get(docId);
+    const treePath = navigation.view.trees.docIdToPrimaryTreePath.get(docId);
     if (!treePath) {
       return;
     }
@@ -1815,12 +1604,12 @@ async function start() {
     if (!treeRuntime) {
       throw new Error("Tree runtime is not loaded");
     }
-    treePathOrder = new Map(view.trees.paths.map((treePath, index) => [treePath, index]));
-    return treeRuntime.prepareFileTreeInput(view.trees.paths, { sort: compareTreesByBranchOrder });
+    treePathOrder = new Map(navigation.view.trees.paths.map((treePath, index) => [treePath, index]));
+    return treeRuntime.prepareFileTreeInput(navigation.view.trees.paths, { sort: compareTreesByBranchOrder });
   };
 
   const renderTreeRowDecoration = ({ item }) => {
-    const metadata = view.trees.metadataByTreePath.get(item.path);
+    const metadata = navigation.view.trees.metadataByTreePath.get(item.path);
     if (metadata?.kind !== "file" || metadata.isNew !== true) {
       return null;
     }
@@ -1832,7 +1621,7 @@ async function start() {
   };
 
   const renderTreeContextMenu = (item, context) => {
-    const route = view.trees.treePathToRoute.get(item.path);
+    const route = navigation.view.trees.treePathToRoute.get(item.path);
     if (!route) {
       return null;
     }
@@ -1865,25 +1654,25 @@ async function start() {
       }
       event.preventDefault();
       context.close();
-      void state.navigate(route, true);
+      void contentController?.navigate(route, true);
     });
 
     menu.appendChild(link);
     return menu;
   };
 
-  const renderTree = (state) => {
+  const renderTree = () => {
     if (!(treeRoot instanceof HTMLElement) || !treeRuntime) {
       return;
     }
 
-    if (fileTree && renderedTreeBranch !== activeBranch) {
+    if (fileTree && renderedTreeBranch !== navigation.activeBranch) {
       destroyFileTree();
     }
 
     const preparedInput = prepareTreesInput();
-    const selectedTreePath = state.currentDocId
-      ? view.trees.docIdToPrimaryTreePath.get(state.currentDocId)
+    const selectedTreePath = navigation.currentDocId
+      ? navigation.view.trees.docIdToPrimaryTreePath.get(navigation.currentDocId)
       : null;
 
     if (!fileTree) {
@@ -1908,13 +1697,13 @@ async function start() {
           }
 
           const selectedPath = selectedPaths.at(-1);
-          const route = selectedPath ? view.trees.treePathToRoute.get(selectedPath) : null;
+          const route = selectedPath ? navigation.view.trees.treePathToRoute.get(selectedPath) : null;
           if (!route) {
-            window.queueMicrotask(() => syncActiveTreeSelection(state.currentDocId, { scroll: false }));
+            window.queueMicrotask(() => syncActiveTreeSelection(navigation.currentDocId, { scroll: false }));
             return;
           }
 
-          void state.navigate(route, true);
+          void contentController?.navigate(route, true);
         },
         preparedInput,
         renderRowDecoration: renderTreeRowDecoration,
@@ -1934,10 +1723,10 @@ async function start() {
       }
     }
 
-    renderedTreeBranch = activeBranch;
-    syncActiveTreeSelection(state.currentDocId || "");
+    renderedTreeBranch = navigation.activeBranch;
+    syncActiveTreeSelection(navigation.currentDocId || "");
     applyTreeSearch(treeSearchValue);
-    setupTreeLabelDecorations(treeRoot, view.trees.metadataByTreePath);
+    setupTreeLabelDecorations(treeRoot, navigation.view.trees.metadataByTreePath);
   };
 
   const renderTreeLoadingState = () => {
@@ -1975,7 +1764,7 @@ async function start() {
 
     const links = document.createElement("ul");
     links.className = "tree-load-fallback-links";
-    for (const doc of view.docs) {
+    for (const doc of navigation.view.docs) {
       const item = document.createElement("li");
       const link = document.createElement("a");
       link.href = toPathWithBase(doc.route, pathBase);
@@ -1992,7 +1781,7 @@ async function start() {
           return;
         }
         event.preventDefault();
-        void state.navigate(doc.route, true);
+        void contentController?.navigate(doc.route, true);
       });
       item.appendChild(link);
       links.appendChild(item);
@@ -2005,7 +1794,7 @@ async function start() {
 
   const loadTreeRuntime = ({ reason, retry = false }) => {
     if (treeRuntime) {
-      renderTree(state);
+      renderTree();
       return Promise.resolve(true);
     }
     if (treeLoadPromise) {
@@ -2042,7 +1831,7 @@ async function start() {
           throw new Error("Tree runtime exports are invalid");
         }
         treeRuntime = module;
-        renderTree(state);
+        renderTree();
         if (treeRoot instanceof HTMLElement) {
           treeRoot.setAttribute("aria-busy", "false");
         }
@@ -2067,125 +1856,55 @@ async function start() {
     return treeLoadPromise;
   };
 
-  const updateBacklinks = (doc) => {
-    if (!(backlinksEl instanceof HTMLElement)) {
-      return;
-    }
-    if (!doc) {
-      backlinksEl.innerHTML = "";
-      backlinksEl.hidden = true;
-      return;
-    }
-    const html = renderBacklinks(doc, pathBase);
-    backlinksEl.innerHTML = html;
-    backlinksEl.hidden = html.length === 0;
-  };
-
-  const state = {
-    currentDocId: initialViewData?.docId ?? "",
-    async navigate(rawRoute, push) {
-      if (isCompactLayout()) {
-        closeSidebar();
-      }
-
-      const route = normalizeRoute(rawRoute);
-      let id = view.routeMap[route];
-
-      if (!id) {
-        const globalId = manifest.routeMap?.[route];
-        const globalDoc = globalId ? docsById.get(globalId) : null;
-        const globalDocBranch = normalizeBranch(globalDoc?.branch);
-        const targetBranch = globalDocBranch ?? defaultBranch;
-        if (globalDoc && targetBranch !== activeBranch && availableBranchSet.has(targetBranch)) {
-          activeBranch = targetBranch;
-          view = getBranchView(activeBranch);
-          updateBranchInfo();
-          if (treeRuntime) {
-            renderTree(state);
-          }
-          localStorage.setItem(BRANCH_KEY, activeBranch);
-          id = view.routeMap[route];
-        }
-      }
-      
-      if (!id) {
-        state.currentDocId = "";
-        clearTreeSelection();
-        breadcrumbEl.innerHTML = renderBreadcrumb(route);
-        titleEl.textContent = "문서를 찾을 수 없습니다";
-        metaEl.innerHTML = "";
-        contentEl.innerHTML = '<p class="placeholder">요청한 경로에 해당하는 문서가 없습니다.</p>';
-        updateBacklinks(null);
-        navEl.innerHTML = "";
-        announceA11yStatus("탐색 실패: 요청한 문서를 찾을 수 없습니다.");
-        if (push) {
-          history.pushState(null, "", toPathWithBase(route, pathBase));
-        }
-        return;
-      }
-
-      const doc = docsById.get(id);
-      if (!doc) {
-        return;
-      }
-
-      if (push) {
-        history.pushState(null, "", toPathWithBase(route, pathBase));
-      }
-
-      state.currentDocId = id;
-      syncActiveTreeSelection(id);
-
-      const shouldUseInitialView =
-        !hasHydratedInitialView &&
-        initialViewData &&
-        initialViewData.docId === id &&
-        initialViewData.route === route;
-
-      if (shouldUseInitialView) {
-        hasHydratedInitialView = true;
-        breadcrumbEl.innerHTML = renderBreadcrumb(route);
-        titleEl.textContent = doc.title;
-        metaEl.innerHTML = renderMeta(doc);
-        updateBacklinks(doc);
-        navEl.innerHTML = renderNav(view.docs, view.docIndexById, id, pathBase);
-        enhanceContentImages(contentEl);
-        await renderMermaidBlocks(mermaidConfig);
-        document.title = composeDocumentTitle(doc.title, siteTitle);
-        if (viewerEl instanceof HTMLElement) {
-          viewerEl.scrollTo(0, 0);
-        }
-        announceA11yStatus(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
-        return;
-      }
-
-      breadcrumbEl.innerHTML = renderBreadcrumb(route);
-      titleEl.textContent = doc.title;
-      metaEl.innerHTML = renderMeta(doc);
-
-      const res = await fetch(toPathWithBase(doc.contentUrl, pathBase));
-      if (!res.ok) {
-        contentEl.innerHTML = '<p class="placeholder">본문을 불러오지 못했습니다.</p>';
-        updateBacklinks(null);
-        navEl.innerHTML = "";
-        announceA11yStatus(`탐색 실패: ${doc.title} 문서를 불러오지 못했습니다.`);
-        return;
-      }
-
-      contentEl.innerHTML = await res.text();
-
-      updateBacklinks(doc);
-      navEl.innerHTML = renderNav(view.docs, view.docIndexById, id, pathBase);
-      enhanceContentImages(contentEl);
-      await renderMermaidBlocks(mermaidConfig);
-
-      document.title = composeDocumentTitle(doc.title, siteTitle);
-      if (viewerEl instanceof HTMLElement) {
-        viewerEl.scrollTo(0, 0);
-      }
-      announceA11yStatus(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
+  contentController = createContentController({
+    navigation,
+    elements: {
+      breadcrumb: breadcrumbEl,
+      title: titleEl,
+      meta: metaEl,
+      content: contentEl,
+      backlinks: backlinksEl,
+      nav: navEl,
+      viewer: viewerEl,
     },
-  };
+    initialViewData,
+    pathBase,
+    siteTitle,
+    renderers: {
+      breadcrumb: renderBreadcrumb,
+      meta: renderMeta,
+      backlinks: renderBacklinks,
+      nav: (currentView, docId, base) => renderNav(currentView.docs, currentView.docIndexById, docId, base),
+      documentTitle: composeDocumentTitle,
+    },
+    lifecycle: {
+      beforeNavigate() {
+        if (isCompactLayout()) {
+          closeSidebar();
+        }
+      },
+      onBranchChange(branch) {
+        updateBranchInfo();
+        if (treeRuntime) {
+          renderTree();
+        }
+        localStorage.setItem(BRANCH_KEY, branch);
+      },
+      onCurrentDocChange(docId) {
+        syncActiveTreeSelection(docId);
+      },
+      onMissingSelection: clearTreeSelection,
+      async enhanceContent(target) {
+        enhanceContentImages(target);
+        await renderMermaidBlocks(mermaidConfig);
+      },
+      announce: announceA11yStatus,
+      resolveLocationRoute(pathname) {
+        return resolveRouteFromLocation(pathBase, pathname);
+      },
+    },
+  });
+  contentController.setup();
 
   requestTreeLoad = (reason, options = {}) => {
     if (!treeLoadAllowed) {
@@ -2259,90 +1978,37 @@ async function start() {
     });
   }
 
-  if (navEl instanceof HTMLElement) {
-    navEl.addEventListener("click", (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) {
-        return;
-      }
-
-      const link = target.closest(".nav-link");
-      if (!(link instanceof HTMLAnchorElement) || !navEl.contains(link)) {
-        return;
-      }
-
-      event.preventDefault();
-      const route = link.dataset.route;
-      if (!route) {
-        return;
-      }
-      state.navigate(route, true);
-      if (viewerEl instanceof HTMLElement) {
-        viewerEl.scrollTo(0, 0);
-      }
-    });
-  }
-
-  if (backlinksEl instanceof HTMLElement) {
-    backlinksEl.addEventListener("click", (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) {
-        return;
-      }
-
-      const link = target.closest(".backlink-link");
-      if (!(link instanceof HTMLAnchorElement) || !backlinksEl.contains(link)) {
-        return;
-      }
-
-      event.preventDefault();
-      const route = link.dataset.route;
-      if (!route) {
-        return;
-      }
-      state.navigate(route, true);
-      if (viewerEl instanceof HTMLElement) {
-        viewerEl.scrollTo(0, 0);
-      }
-    });
-  }
-
   const setActiveBranch = async (nextBranch) => {
-    const normalized = normalizeBranch(nextBranch);
-    if (!normalized || !availableBranchSet.has(normalized)) {
+    if (!navigation.setActiveBranch(nextBranch)) {
       return;
     }
 
-    activeBranch = normalized;
-    view = getBranchView(activeBranch);
-    localStorage.setItem(BRANCH_KEY, activeBranch);
+    localStorage.setItem(BRANCH_KEY, navigation.activeBranch);
     updateBranchInfo();
     void requestTreeLoad("branch");
 
-    const currentRoute = resolveRouteFromLocation(view.routeMap, pathBase);
-    if (view.routeMap[currentRoute]) {
-      await state.navigate(currentRoute, false);
+    const currentRoute = resolveRouteFromLocation(pathBase);
+    if (navigation.view.routeMap[currentRoute]) {
+      await contentController.navigate(currentRoute, false);
       return;
     }
 
-    const fallbackRoute = pickHomeRoute(view);
-    await state.navigate(fallbackRoute, true);
+    const fallbackRoute = pickHomeRoute(navigation.view);
+    await contentController.navigate(fallbackRoute, true);
   };
 
   renderBranchPills();
   updateBranchInfo();
 
-  const currentRoute = resolveRouteFromLocation(view.routeMap, pathBase);
-  const initialRoute = currentRoute === "/" ? pickHomeRoute(view) : currentRoute;
+  const currentRoute = resolveRouteFromLocation(pathBase);
+  const initialRoute = currentRoute === "/" ? pickHomeRoute(navigation.view) : currentRoute;
   handleLayoutChange();
-  await state.navigate(initialRoute, currentRoute === "/" && initialRoute !== "/");
+  await contentController.navigate(initialRoute, currentRoute === "/" && initialRoute !== "/");
   setAppReadyState("ready");
   window.performance?.mark?.("eiam-app-ready");
   scheduleTreeLoadAfterFirstContentPaint();
 
-  window.addEventListener("popstate", async () => {
-    await state.navigate(resolveRouteFromLocation(view.routeMap, pathBase), false);
-  });
+  window.addEventListener("pagehide", () => contentController?.destroy(), { once: true });
 }
 
 start().catch((error) => {

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -2008,7 +2008,12 @@ async function start() {
   window.performance?.mark?.("eiam-app-ready");
   scheduleTreeLoadAfterFirstContentPaint();
 
-  window.addEventListener("pagehide", () => contentController?.destroy(), { once: true });
+  window.addEventListener("pagehide", () => contentController?.destroy());
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) {
+      contentController?.setup();
+    }
+  });
 }
 
 start().catch((error) => {

--- a/src/runtime/content-controller.js
+++ b/src/runtime/content-controller.js
@@ -1,0 +1,162 @@
+import { toPathWithBase } from "./navigation-state.js";
+
+function setHtml(element, value) {
+  if (element) {
+    element.innerHTML = value;
+  }
+}
+
+function setText(element, value) {
+  if (element) {
+    element.textContent = value;
+  }
+}
+
+export function createContentController(options) {
+  const {
+    navigation,
+    elements,
+    initialViewData,
+    pathBase,
+    siteTitle,
+    renderers,
+    lifecycle = {},
+    fetchContent = (url) => fetch(url),
+    historyApi = globalThis.history,
+    locationApi = globalThis.location,
+    setPageTitle = (value) => {
+      document.title = value;
+    },
+  } = options;
+  let hasHydratedInitialView = false;
+  let isSetup = false;
+
+  const updateBacklinks = (doc) => {
+    if (!elements.backlinks) {
+      return;
+    }
+    const html = doc ? renderers.backlinks(doc, pathBase) : "";
+    elements.backlinks.innerHTML = html;
+    elements.backlinks.hidden = html.length === 0;
+  };
+
+  const renderChrome = (route, doc) => {
+    setHtml(elements.breadcrumb, renderers.breadcrumb(route));
+    setText(elements.title, doc.title);
+    setHtml(elements.meta, renderers.meta(doc));
+    updateBacklinks(doc);
+    setHtml(elements.nav, renderers.nav(navigation.view, doc.id, pathBase));
+  };
+
+  const finishNavigation = async (doc) => {
+    await lifecycle.enhanceContent?.(elements.content);
+    setPageTitle(renderers.documentTitle(doc.title, siteTitle));
+    elements.viewer?.scrollTo?.(0, 0);
+    lifecycle.announce?.(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
+  };
+
+  const renderMissingRoute = (route, push) => {
+    navigation.setCurrentDocId("");
+    lifecycle.onMissingSelection?.();
+    setHtml(elements.breadcrumb, renderers.breadcrumb(route));
+    setText(elements.title, "문서를 찾을 수 없습니다");
+    setHtml(elements.meta, "");
+    setHtml(elements.content, '<p class="placeholder">요청한 경로에 해당하는 문서가 없습니다.</p>');
+    updateBacklinks(null);
+    setHtml(elements.nav, "");
+    lifecycle.announce?.("탐색 실패: 요청한 문서를 찾을 수 없습니다.");
+    if (push) {
+      historyApi?.pushState?.(null, "", toPathWithBase(route, pathBase));
+    }
+  };
+
+  const navigate = async (rawRoute, push) => {
+    lifecycle.beforeNavigate?.();
+    const resolved = navigation.resolve(rawRoute);
+    if (resolved.branchChanged) {
+      lifecycle.onBranchChange?.(navigation.activeBranch);
+    }
+
+    if (!resolved.id || !resolved.doc) {
+      renderMissingRoute(resolved.route, push);
+      return false;
+    }
+
+    if (push) {
+      historyApi?.pushState?.(null, "", toPathWithBase(resolved.route, pathBase));
+    }
+
+    navigation.setCurrentDocId(resolved.id);
+    lifecycle.onCurrentDocChange?.(resolved.id);
+
+    const shouldUseInitialView =
+      !hasHydratedInitialView &&
+      initialViewData &&
+      initialViewData.docId === resolved.id &&
+      initialViewData.route === resolved.route;
+
+    renderChrome(resolved.route, resolved.doc);
+    if (shouldUseInitialView) {
+      hasHydratedInitialView = true;
+      await finishNavigation(resolved.doc);
+      return true;
+    }
+
+    const response = await fetchContent(toPathWithBase(resolved.doc.contentUrl, pathBase));
+    if (!response.ok) {
+      setHtml(elements.content, '<p class="placeholder">본문을 불러오지 못했습니다.</p>');
+      updateBacklinks(null);
+      setHtml(elements.nav, "");
+      lifecycle.announce?.(`탐색 실패: ${resolved.doc.title} 문서를 불러오지 못했습니다.`);
+      return false;
+    }
+
+    setHtml(elements.content, await response.text());
+    await finishNavigation(resolved.doc);
+    return true;
+  };
+
+  const handleLinkClick = (event) => {
+    const target = event.target;
+    if (!(target instanceof Element)) {
+      return;
+    }
+    const link = target.closest(".nav-link, .backlink-link");
+    if (!(link instanceof HTMLAnchorElement)) {
+      return;
+    }
+    const owner = link.closest("#viewer-nav, #viewer-backlinks");
+    if (owner !== elements.nav && owner !== elements.backlinks) {
+      return;
+    }
+    const route = link.dataset.route;
+    if (!route) {
+      return;
+    }
+    event.preventDefault();
+    void navigate(route, true);
+  };
+
+  const handlePopState = () => {
+    const route = lifecycle.resolveLocationRoute?.(locationApi?.pathname ?? "/") ?? "/";
+    void navigate(route, false);
+  };
+
+  return {
+    navigate,
+    setup() {
+      if (isSetup) return;
+      isSetup = true;
+      elements.nav?.addEventListener?.("click", handleLinkClick);
+      elements.backlinks?.addEventListener?.("click", handleLinkClick);
+      globalThis.addEventListener?.("popstate", handlePopState);
+    },
+    destroy() {
+      if (!isSetup) return;
+      isSetup = false;
+      elements.nav?.removeEventListener?.("click", handleLinkClick);
+      elements.backlinks?.removeEventListener?.("click", handleLinkClick);
+      globalThis.removeEventListener?.("popstate", handlePopState);
+    },
+  };
+}

--- a/src/runtime/navigation-state.js
+++ b/src/runtime/navigation-state.js
@@ -1,0 +1,267 @@
+import { getRuntimeManifestDocs } from "./manifest-adapter.js";
+import { buildTreesAdapterInput } from "./tree-adapter.js";
+
+const DEFAULT_BRANCH = "dev";
+
+function toSafeUrlPath(input) {
+  return String(input)
+    .split("/")
+    .map((segment, index) => {
+      if (index === 0 && segment === "") {
+        return "";
+      }
+      return encodeURIComponent(segment);
+    })
+    .join("/");
+}
+
+export function normalizePathname(pathname) {
+  let normalized = "/";
+  try {
+    normalized = decodeURIComponent(pathname || "/");
+  } catch {
+    normalized = String(pathname || "/");
+  }
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+  return normalized.replace(/\/+/g, "/") || "/";
+}
+
+export function normalizeRoute(pathname) {
+  const normalized = normalizePathname(pathname);
+  return normalized.endsWith("/") ? normalized : `${normalized}/`;
+}
+
+export function normalizePathBase(pathBase) {
+  if (typeof pathBase !== "string") {
+    return "";
+  }
+
+  const cleaned = pathBase.trim().replace(/\\/g, "/");
+  if (!cleaned || cleaned === "/") {
+    return "";
+  }
+
+  return `/${cleaned.replace(/^\/+/, "").replace(/\/+$/, "")}`;
+}
+
+export function stripPathBase(pathname, pathBase) {
+  const normalizedPath = normalizePathname(pathname);
+  if (!pathBase) {
+    return normalizedPath;
+  }
+  if (normalizedPath === pathBase) {
+    return "/";
+  }
+  if (normalizedPath.startsWith(`${pathBase}/`)) {
+    return normalizedPath.slice(pathBase.length) || "/";
+  }
+  return normalizedPath;
+}
+
+export function toPathWithBase(pathname, pathBase) {
+  const normalizedPath = normalizePathname(pathname);
+  if (!pathBase) {
+    return toSafeUrlPath(normalizedPath);
+  }
+  if (normalizedPath === "/") {
+    return toSafeUrlPath(`${pathBase}/`);
+  }
+  return toSafeUrlPath(`${pathBase}${normalizedPath}`);
+}
+
+export function resolveRouteFromLocation(pathBase, pathname = globalThis.location?.pathname ?? "/") {
+  return normalizeRoute(stripPathBase(pathname, pathBase));
+}
+
+export function normalizeBranch(value) {
+  if (typeof value !== "string") {
+    return null;
+  }
+
+  const normalized = value.trim().toLowerCase();
+  return normalized.length > 0 ? normalized : null;
+}
+
+function isDocVisibleInBranch(doc, branch, defaultBranch) {
+  const docBranch = normalizeBranch(doc.branch);
+  return docBranch ? docBranch === branch : branch === defaultBranch;
+}
+
+function parseDateToEpochMs(value) {
+  if (typeof value !== "string" || value.trim().length === 0) {
+    return null;
+  }
+
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+function getRecentSortEpochMs(doc) {
+  return parseDateToEpochMs(doc.updatedDate) ?? parseDateToEpochMs(doc.date);
+}
+
+function compareDocsByRecentDateThenRoute(left, right) {
+  const leftEpoch = getRecentSortEpochMs(left);
+  const rightEpoch = getRecentSortEpochMs(right);
+
+  if (leftEpoch != null && rightEpoch != null) {
+    const byDate = rightEpoch - leftEpoch;
+    if (byDate !== 0) {
+      return byDate;
+    }
+  } else if (leftEpoch != null) {
+    return -1;
+  } else if (rightEpoch != null) {
+    return 1;
+  }
+
+  return left.route.localeCompare(right.route, "ko-KR");
+}
+
+function cloneFilteredTree(nodes, visibleDocIds) {
+  const filteredNodes = [];
+
+  for (const node of nodes) {
+    if (node.type === "file") {
+      if (visibleDocIds.has(node.id)) {
+        filteredNodes.push(node);
+      }
+      continue;
+    }
+
+    const children = cloneFilteredTree(node.children, visibleDocIds);
+    if (children.length === 0 && !node.virtual) {
+      continue;
+    }
+
+    filteredNodes.push({ ...node, children });
+  }
+
+  return filteredNodes;
+}
+
+function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
+  const docs = manifestDocs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
+  const visibleDocIds = new Set(docs.map((doc) => doc.id));
+  const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
+  const trees = buildTreesAdapterInput(tree, docs);
+  const routeMap = {};
+  const docIndexById = new Map();
+
+  for (let index = 0; index < docs.length; index += 1) {
+    const doc = docs[index];
+    routeMap[doc.route] = doc.id;
+    docIndexById.set(doc.id, index);
+  }
+
+  return { docs, visibleDocIds, tree, trees, routeMap, docIndexById };
+}
+
+export function pickHomeRoute(view) {
+  if (view.routeMap["/index/"]) {
+    return "/index/";
+  }
+  return [...view.docs].sort(compareDocsByRecentDateThenRoute)[0]?.route || "/";
+}
+
+function collectAvailableBranches(manifest, manifestDocs, defaultBranch) {
+  const branchSet = new Set([defaultBranch]);
+  for (const doc of manifestDocs) {
+    const branch = normalizeBranch(doc.branch);
+    if (branch) {
+      branchSet.add(branch);
+    }
+  }
+  if (Array.isArray(manifest.branches)) {
+    for (const value of manifest.branches) {
+      const branch = normalizeBranch(value);
+      if (branch) {
+        branchSet.add(branch);
+      }
+    }
+  }
+
+  return Array.from(branchSet).sort((left, right) => {
+    if (left === defaultBranch) return -1;
+    if (right === defaultBranch) return 1;
+    return left.localeCompare(right, "ko-KR");
+  });
+}
+
+export function createNavigationState(manifest, options = {}) {
+  const defaultBranch = normalizeBranch(manifest.defaultBranch) || DEFAULT_BRANCH;
+  const docs = getRuntimeManifestDocs(manifest);
+  const docsById = new Map(docs.map((doc) => [doc.id, doc]));
+  const availableBranches = collectAvailableBranches(manifest, docs, defaultBranch);
+  const availableBranchSet = new Set(availableBranches);
+  const savedBranch = normalizeBranch(options.savedBranch);
+  const branchViewCache = new Map();
+  let activeBranch = savedBranch && availableBranchSet.has(savedBranch) ? savedBranch : defaultBranch;
+  let currentDocId = typeof options.initialDocId === "string" ? options.initialDocId : "";
+
+  const getBranchView = (branch) => {
+    const cached = branchViewCache.get(branch);
+    if (cached) {
+      return cached;
+    }
+    const nextView = buildBranchView(manifest, docs, branch, defaultBranch);
+    branchViewCache.set(branch, nextView);
+    return nextView;
+  };
+
+  let view = getBranchView(activeBranch);
+
+  const setActiveBranch = (value) => {
+    const branch = normalizeBranch(value);
+    if (!branch || !availableBranchSet.has(branch)) {
+      return false;
+    }
+    activeBranch = branch;
+    view = getBranchView(branch);
+    return true;
+  };
+
+  const resolve = (rawRoute) => {
+    const route = normalizeRoute(rawRoute);
+    const previousBranch = activeBranch;
+    let id = view.routeMap[route];
+
+    if (!id) {
+      const globalId = manifest.routeMap?.[route];
+      const globalDoc = globalId ? docsById.get(globalId) : null;
+      const targetBranch = normalizeBranch(globalDoc?.branch) ?? defaultBranch;
+      if (globalDoc && targetBranch !== activeBranch && availableBranchSet.has(targetBranch)) {
+        setActiveBranch(targetBranch);
+        id = view.routeMap[route];
+      }
+    }
+
+    return {
+      route,
+      id: id ?? null,
+      doc: id ? docsById.get(id) ?? null : null,
+      branchChanged: previousBranch !== activeBranch,
+    };
+  };
+
+  return {
+    availableBranches,
+    defaultBranch,
+    get activeBranch() {
+      return activeBranch;
+    },
+    get currentDocId() {
+      return currentDocId;
+    },
+    get view() {
+      return view;
+    },
+    setActiveBranch,
+    setCurrentDocId(value) {
+      currentDocId = typeof value === "string" ? value : "";
+    },
+    resolve,
+  };
+}

--- a/tests/e2e/runtime-navigation-controller.spec.ts
+++ b/tests/e2e/runtime-navigation-controller.spec.ts
@@ -175,6 +175,11 @@ test.describe("runtime navigation contracts", () => {
       throw new Error("다음 문서 route를 찾지 못했습니다.");
     }
 
+    await page.evaluate(() => {
+      window.dispatchEvent(new PageTransitionEvent("pagehide", { persisted: true }));
+      window.dispatchEvent(new PageTransitionEvent("pageshow", { persisted: true }));
+    });
+
     await nextLink.click();
     await expect(page).toHaveURL(new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
 

--- a/tests/e2e/runtime-navigation-controller.spec.ts
+++ b/tests/e2e/runtime-navigation-controller.spec.ts
@@ -1,0 +1,188 @@
+import { expect, test } from "@playwright/test";
+import { createContentController } from "../../src/runtime/content-controller.js";
+import {
+  createNavigationState,
+  normalizePathBase,
+  normalizeRoute,
+  pickHomeRoute,
+  stripPathBase,
+  toPathWithBase,
+} from "../../src/runtime/navigation-state.js";
+import { waitForAppReady } from "./utils/app-ready";
+
+function createManifest() {
+  const docs = [
+    {
+      id: "base",
+      route: "/BASE/",
+      title: "Base",
+      contentUrl: "/content/base.html",
+      date: "2026-07-19",
+      branch: null,
+      backlinks: [],
+    },
+    {
+      id: "dev",
+      route: "/DEV/",
+      title: "Dev",
+      contentUrl: "/content/dev.html",
+      date: "2026-07-18",
+      branch: "dev",
+      backlinks: [],
+    },
+    {
+      id: "main",
+      route: "/MAIN/",
+      title: "Main",
+      contentUrl: "/content/main.html",
+      date: "2026-07-17",
+      branch: "main",
+      backlinks: [],
+    },
+  ];
+
+  return {
+    schemaVersion: 2,
+    defaultBranch: "dev",
+    branches: ["dev", "main"],
+    ui: { newWithinDays: 0 },
+    docIds: docs.map((doc) => doc.id),
+    docsById: Object.fromEntries(docs.map((doc) => [doc.id, doc])),
+    routeMap: Object.fromEntries(docs.map((doc) => [doc.route, doc.id])),
+    tree: [
+      {
+        type: "folder",
+        name: "Docs",
+        path: "Docs",
+        children: docs.map((doc) => ({ type: "file", name: `${doc.id}.md`, id: doc.id })),
+      },
+    ],
+  };
+}
+
+class ListenerElement {
+  innerHTML = "";
+  textContent = "";
+  hidden = false;
+  added: string[] = [];
+  removed: string[] = [];
+
+  addEventListener(type: string) {
+    this.added.push(type);
+  }
+
+  removeEventListener(type: string) {
+    this.removed.push(type);
+  }
+}
+
+test.describe("runtime navigation contracts", () => {
+  test("branch, route, current document는 navigation state 한 곳에서 전환된다", () => {
+    const navigation = createNavigationState(createManifest(), { savedBranch: "main" });
+
+    expect(navigation.activeBranch).toBe("main");
+    expect(navigation.view.docs.map((doc: { id: string }) => doc.id)).toEqual(["main"]);
+
+    const resolved = navigation.resolve("/BASE");
+    expect(resolved).toMatchObject({ route: "/BASE/", id: "base", branchChanged: true });
+    expect(navigation.activeBranch).toBe("dev");
+    expect(navigation.view.docs.map((doc: { id: string }) => doc.id)).toEqual(["base", "dev"]);
+
+    navigation.setCurrentDocId("base");
+    expect(navigation.currentDocId).toBe("base");
+    expect(pickHomeRoute(navigation.view)).toBe("/BASE/");
+    expect(navigation.setActiveBranch("unknown")).toBe(false);
+    expect(navigation.activeBranch).toBe("dev");
+  });
+
+  test("pathBase 경로 규칙은 독립 모듈에서 정규화된다", () => {
+    expect(normalizePathBase(" docs guides/한글/ ")).toBe("/docs guides/한글");
+    expect(normalizeRoute("BASE")).toBe("/BASE/");
+    expect(stripPathBase("/blog/BASE/", "/blog")).toBe("/BASE/");
+    expect(toPathWithBase("/BASE/", "/docs guides/한글")).toBe(
+      "/docs%20guides/%ED%95%9C%EA%B8%80/BASE/",
+    );
+  });
+
+  test("content controller는 navigation 결과를 렌더하고 setup/destroy lifecycle을 제공한다", async () => {
+    const navigation = createNavigationState(createManifest());
+    const nav = new ListenerElement();
+    const backlinks = new ListenerElement();
+    const elements = {
+      breadcrumb: new ListenerElement(),
+      title: new ListenerElement(),
+      meta: new ListenerElement(),
+      content: new ListenerElement(),
+      backlinks,
+      nav,
+      viewer: { scrollToCalls: 0, scrollTo() { this.scrollToCalls += 1; } },
+    };
+    const pushed: string[] = [];
+    const announcements: string[] = [];
+    let pageTitle = "";
+    let enhanced = 0;
+
+    const controller = createContentController({
+      navigation,
+      elements,
+      initialViewData: null,
+      pathBase: "/blog",
+      siteTitle: "Site",
+      renderers: {
+        breadcrumb: (route: string) => `crumb:${route}`,
+        meta: (doc: { id: string }) => `meta:${doc.id}`,
+        backlinks: (doc: { id: string }) => `backlinks:${doc.id}`,
+        nav: (_view: unknown, docId: string) => `nav:${docId}`,
+        documentTitle: (title: string, siteTitle: string) => `${title} - ${siteTitle}`,
+      },
+      lifecycle: {
+        async enhanceContent() { enhanced += 1; },
+        announce(message: string) { announcements.push(message); },
+      },
+      fetchContent: async (url: string) => ({ ok: true, text: async () => `content:${url}` }),
+      historyApi: { pushState: (_state: unknown, _unused: string, url: string) => pushed.push(url) },
+      setPageTitle: (value: string) => { pageTitle = value; },
+    });
+
+    controller.setup();
+    controller.setup();
+    expect(nav.added).toEqual(["click"]);
+    expect(backlinks.added).toEqual(["click"]);
+
+    await controller.navigate("/BASE/", true);
+    expect(navigation.currentDocId).toBe("base");
+    expect(elements.breadcrumb.innerHTML).toBe("crumb:/BASE/");
+    expect(elements.content.innerHTML).toBe("content:/blog/content/base.html");
+    expect(elements.nav.innerHTML).toBe("nav:base");
+    expect(pushed).toEqual(["/blog/BASE/"]);
+    expect(pageTitle).toBe("Base - Site");
+    expect(enhanced).toBe(1);
+    expect(announcements.at(-1)).toContain("Base");
+
+    controller.destroy();
+    controller.destroy();
+    expect(nav.removed).toEqual(["click"]);
+    expect(backlinks.removed).toEqual(["click"]);
+  });
+
+  test("browser back/forward는 content controller의 popstate lifecycle을 따른다", async ({ page }) => {
+    await page.goto("/BC-VO-00/");
+    await waitForAppReady(page);
+
+    const nextLink = page.locator("#viewer-nav .nav-link-next");
+    const nextRoute = await nextLink.getAttribute("data-route");
+    if (!nextRoute) {
+      throw new Error("다음 문서 route를 찾지 못했습니다.");
+    }
+
+    await nextLink.click();
+    await expect(page).toHaveURL(new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+
+    await page.goBack();
+    await expect(page).toHaveURL(/\/BC-VO-00\/$/);
+    await expect(page.locator("#viewer-title")).toHaveText("About");
+
+    await page.goForward();
+    await expect(page).toHaveURL(new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+  });
+});


### PR DESCRIPTION
Part of #29. Depends on #70.

## Goal

Give browser branch, route, and current-document state one owner and move content navigation behind a lifecycle-aware controller.

## Scope

- Add navigation-state.js for branch projections, route/pathBase rules, automatic branch switching, and current document state
- Add content-controller.js for content fetch, history/popstate, initial SSR reuse, nav/backlink delegation, viewer updates, and setup/destroy
- Rewire app.js tree/sidebar integration through controller callbacks
- Add independent state/controller tests plus browser back/forward coverage
- Document the runtime navigation ownership contract

## Excluded

- Tree/search, sidebar/layout, settings/theme, Mermaid, and image controller extraction
- Shared SSR/client presentation rendering contracts

## DnD

- [x] Branch, filtered view, route resolution, and current document have one source of truth
- [x] Content navigation exposes setup and cleanup behavior
- [x] Cross-branch routes, manual branch selection, history, pathBase, nav, backlinks, and tree selection remain synchronized
- [x] Navigation state and content controller can be tested independently
- [x] Accessibility completion/failure announcements remain wired through lifecycle callbacks

## Verification

- bunx tsc --noEmit
- bun run build -- --vault ./test-vault --out ./dist
- bunx playwright test tests/e2e/runtime-navigation-controller.spec.ts (4 passed)
- targeted routing/branch/pathBase/XSS/tree/deferred integration suite (10 passed)
- bun run check:size
- bun run check:reproducible
- bun run test:e2e (69 passed)

## Size

- app JS: 38,438 / 45,000 raw bytes; 13,038 / 15,000 gzip bytes

Issue: #29