### PR TITLE
refactor: split remaining runtime controllers

### DIFF
--- a/docs/solutions/20260719-runtime-controller-boundaries.md
+++ b/docs/solutions/20260719-runtime-controller-boundaries.md
@@ -1,0 +1,43 @@
+# Browser runtime controller boundaries
+
+## 문제
+
+`src/runtime/app.js`가 bootstrap, navigation wiring, tree/search, responsive sidebar, settings, Mermaid, image와 copy 보강을 모두 직접 소유했다. 기능별 listener와 mutable state가 한 함수에 섞여 있어 다음 문제가 있었다.
+
+- 개별 기능을 import하거나 lifecycle만 독립 검증하기 어려웠다.
+- listener 등록과 정리의 소유자가 불분명했다.
+- branch projection, tree selection, content navigation이 서로의 지역 상태를 직접 참조했다.
+- 작은 UI 변경도 2천 줄이 넘는 `start()`의 회귀 범위를 넓혔다.
+
+## 경계
+
+runtime을 다음 계약으로 분리했다.
+
+| 모듈 | 소유 책임 | 공개 lifecycle/동작 |
+| --- | --- | --- |
+| `runtime-bootstrap.js` | SSR bootstrap JSON 검증, manifest fetch, pathBase와 tree asset URL 검증 | `loadRuntimeBootstrap()` |
+| `content-controller.js` | route 해석 결과의 content fetch, history/popstate, viewer 갱신 | `setup()`, `destroy()`, `navigate()` |
+| `tree-controller.js` | branch pills, tree projection/selection, search, deferred chunk, fallback/retry | `setup()`, `destroy()`, `requestLoad()`, selection/branch callbacks |
+| `sidebar-layout-controller.js` | mobile modal, focus trap, overlay, desktop splitter | `setup()`, `destroy()`, `open()`, `close()`, `isCompact()` |
+| `settings-controller.js` | theme, system color scheme, menu toggle 위치, settings popover | `setup()`, `destroy()`, `close()` |
+| `mermaid-controller.js` | Mermaid script/config/render와 partial failure 격리 | `setup()`, `destroy()`, `render()` |
+| `content-enhancement-controller.js` | image 비율 분류, code copy delegation, Mermaid 연결 | `setup()`, `destroy()`, `enhance()` |
+| `controller-lifecycle.js` | listener 등록과 역순 cleanup | `createEventScope()` |
+
+`app.js`는 이 controller들을 만들고 callback을 연결한 뒤 초기 route를 여는 composition root만 담당한다.
+
+## 상태 원칙
+
+- branch, 현재 문서, branch별 docs/tree projection은 계속 `navigation-state.js` 한 곳만 변경한다.
+- tree controller는 navigation state를 읽어 UI를 projection하며 별도 branch/current-document 사본을 만들지 않는다.
+- content controller가 자동 branch 전환을 발견하면 tree controller의 `handleBranchChange()`에 알린다.
+- tree selection과 branch pill은 content controller의 `navigate()`만 호출하며 content/history를 직접 변경하지 않는다.
+- 모든 controller의 `setup()`과 `destroy()`는 반복 호출에 안전하다.
+- bfcache 진입 시 history listener를 소유한 content controller만 suspend하고 persisted `pageshow`에서 복원한다. 실제 unload에서는 controller들을 역순으로 정리한다.
+- desktop tree chunk는 초기 content paint 기회 뒤 idle 단계에서 로드하고, compact layout에서는 sidebar/search 상호작용 전까지 요청하지 않는다.
+
+## 회귀 검증
+
+- `runtime-controller-lifecycle.spec.ts`가 event scope와 content/settings/layout/tree controller의 중복 없는 setup/destroy를 독립 import로 검증한다.
+- 기존 navigation, branch, pathBase, tree search/deferred load, mobile focus trap, responsive layout, Mermaid/image 테스트를 그대로 유지한다.
+- output size와 reproducible build guardrail은 bundle 경계 변경 뒤에도 동일하게 적용한다.

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -1,54 +1,22 @@
-import { normalizeManifestPayload } from "./manifest-adapter.js";
 import { createContentController } from "./content-controller.js";
+import { createContentEnhancementController } from "./content-enhancement-controller.js";
+import { createMermaidController, resolveMermaidConfig } from "./mermaid-controller.js";
 import {
   createNavigationState,
-  normalizePathBase,
   normalizeRoute,
   pickHomeRoute,
   resolveRouteFromLocation,
-  stripPathBase,
   toPathWithBase,
 } from "./navigation-state.js";
+import { loadRuntimeBootstrap } from "./runtime-bootstrap.js";
+import { createSettingsController } from "./settings-controller.js";
+import { createSidebarLayoutController } from "./sidebar-layout-controller.js";
+import { createTreeController } from "./tree-controller.js";
 
-const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
-const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
-const THEME_MODE_KEY = "fsblog.themeMode";
-const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
-const SIDEBAR_WIDTH_KEY = "fsblog.desktopSidebarWidth";
-const DESKTOP_SIDEBAR_DEFAULT = 420;
-const DESKTOP_SIDEBAR_MIN = 320;
-const DESKTOP_VIEWER_MIN = 680;
-const DESKTOP_SPLITTER_WIDTH = 10;
-const DESKTOP_SPLITTER_STEP = 24;
-const DEFAULT_SITE_TITLE = "File-System Blog";
 const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
 const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
-const FOCUSABLE_SELECTOR =
-  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
-const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
-const MERMAID_DEFAULT_THEME = "default";
-const MERMAID_SELECTOR = "pre.mermaid";
-const MERMAID_ERROR_CLASS = "mermaid-render-error";
-const MERMAID_THEME_VALIDATION_RE = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
-const MERMAID_URL_VALIDATION_RE = /^(https?:\/\/|\/|\.{1,2}\/)[^\s"'<>]+$/;
-const MERMAID_WIDE_RATIO = 2.4;
-const MERMAID_TALL_RATIO = 0.85;
-const MERMAID_BLOCK_WIDE_CLASS = "is-wide";
-const MERMAID_BLOCK_TALL_CLASS = "is-tall";
-const CONTENT_IMAGE_LANDSCAPE_CLASS = "is-landscape";
-const CONTENT_IMAGE_PORTRAIT_CLASS = "is-portrait";
-const CONTENT_IMAGE_SQUARE_CLASS = "is-square";
-const CONTENT_IMAGE_LANDSCAPE_THRESHOLD = 1.1;
-const CONTENT_IMAGE_PORTRAIT_THRESHOLD = 0.9;
-const contentImageDimensionCache = new Map();
-const mermaidRuntime = {
-  initialized: false,
-  loadingPromise: null,
-  scriptElement: null,
-  lastCdnUrl: "",
-  lastTheme: "",
-};
+const DEFAULT_SITE_TITLE = "File-System Blog";
 
 function escapeHtmlAttr(input) {
   return String(input)
@@ -56,519 +24,6 @@ function escapeHtmlAttr(input) {
     .replace(/"/g, "&quot;")
     .replace(/</g, "&lt;")
     .replace(/>/g, "&gt;");
-}
-
-function resolveMermaidConfig(manifest) {
-  const mermaid = manifest?.mermaid;
-  return {
-    enabled: mermaid?.enabled !== false,
-    cdnUrl:
-      typeof mermaid?.cdnUrl === "string" && mermaid.cdnUrl.trim()
-        ? mermaid.cdnUrl.trim()
-        : MERMAID_CDN,
-    theme:
-      typeof mermaid?.theme === "string" &&
-      MERMAID_THEME_VALIDATION_RE.test(mermaid.theme.trim())
-        ? mermaid.theme.trim()
-        : MERMAID_DEFAULT_THEME,
-  };
-}
-
-function toAbsoluteUrl(value) {
-  try {
-    return new URL(value, window.location.href).href;
-  } catch {
-    return value;
-  }
-}
-
-function normalizeMermaidTheme(value) {
-  const normalized = typeof value === "string" ? value.trim() : "";
-  if (!normalized || !MERMAID_THEME_VALIDATION_RE.test(normalized)) {
-    return MERMAID_DEFAULT_THEME;
-  }
-  return normalized;
-}
-
-function normalizeMermaidUrl(value) {
-  const normalized = typeof value === "string" ? value.trim() : "";
-  if (!normalized || !MERMAID_URL_VALIDATION_RE.test(normalized)) {
-    return MERMAID_CDN;
-  }
-  return normalized;
-}
-
-function createMermaidLoadError(message) {
-  const paragraph = document.createElement("p");
-  paragraph.className = MERMAID_ERROR_CLASS;
-  paragraph.textContent = message;
-  return paragraph;
-}
-
-function removeMermaidErrorMessage(container) {
-  if (!(container instanceof HTMLElement)) {
-    return;
-  }
-
-  for (const message of container.querySelectorAll(`.${MERMAID_ERROR_CLASS}`)) {
-    message.remove();
-  }
-}
-
-function showMermaidError(preview, message) {
-  if (!(preview instanceof HTMLElement) || !(preview.parentElement instanceof HTMLElement)) {
-    return;
-  }
-
-  removeMermaidErrorMessage(preview.parentElement);
-  preview.parentElement.appendChild(createMermaidLoadError(message));
-}
-
-function normalizeRenderedMermaidSvg(block) {
-  if (!(block instanceof HTMLElement)) {
-    return;
-  }
-
-  const container = block.parentElement instanceof HTMLElement ? block.parentElement : null;
-  const svg = block.querySelector("svg");
-  if (!(svg instanceof SVGElement)) {
-    return;
-  }
-
-  if (container) {
-    container.classList.remove(MERMAID_BLOCK_WIDE_CLASS, MERMAID_BLOCK_TALL_CLASS);
-  }
-
-  svg.style.display = "block";
-  svg.style.width = "auto";
-  svg.style.height = "auto";
-  svg.style.margin = "0 auto";
-  svg.style.maxWidth = "min(100%, var(--content-visual-max-width, 880px))";
-  svg.style.removeProperty("max-height");
-
-  const viewBox = svg.viewBox?.baseVal;
-  const intrinsicWidth =
-    viewBox && Number.isFinite(viewBox.width) && viewBox.width > 0
-      ? viewBox.width
-      : Number.parseFloat(svg.getAttribute("width") ?? "");
-  const intrinsicHeight =
-    viewBox && Number.isFinite(viewBox.height) && viewBox.height > 0
-      ? viewBox.height
-      : Number.parseFloat(svg.getAttribute("height") ?? "");
-
-  if (!(intrinsicWidth > 0) || !(intrinsicHeight > 0)) {
-    return;
-  }
-
-  const aspectRatio = intrinsicWidth / intrinsicHeight;
-  if (container && aspectRatio >= MERMAID_WIDE_RATIO) {
-    container.classList.add(MERMAID_BLOCK_WIDE_CLASS);
-    svg.style.maxWidth = "min(100%, var(--mermaid-wide-max-width, 820px))";
-  }
-
-  if (container && aspectRatio <= MERMAID_TALL_RATIO) {
-    container.classList.add(MERMAID_BLOCK_TALL_CLASS);
-    svg.style.maxHeight = "min(var(--mermaid-tall-max-height, 560px), 68vh)";
-  }
-}
-
-function clearContentImageClasses(target) {
-  if (!(target instanceof Element)) {
-    return;
-  }
-
-  target.classList.remove(
-    CONTENT_IMAGE_LANDSCAPE_CLASS,
-    CONTENT_IMAGE_PORTRAIT_CLASS,
-    CONTENT_IMAGE_SQUARE_CLASS,
-  );
-}
-
-function syncContentImageClasses(image, className) {
-  if (!(image instanceof HTMLImageElement)) {
-    return;
-  }
-
-  clearContentImageClasses(image);
-  image.classList.add(className);
-
-  const figure = image.closest("figure");
-  if (
-    figure instanceof HTMLElement &&
-    (figure.classList.contains("content-image") || figure.classList.contains("image-frame"))
-  ) {
-    clearContentImageClasses(figure);
-    figure.classList.add(className);
-  }
-}
-
-function readIntrinsicImageDimensions(imageLike) {
-  if (!(imageLike instanceof HTMLImageElement)) {
-    return null;
-  }
-
-  const width =
-    imageLike.naturalWidth > 0
-      ? imageLike.naturalWidth
-      : Number.parseFloat(imageLike.getAttribute("width") ?? "");
-  const height =
-    imageLike.naturalHeight > 0
-      ? imageLike.naturalHeight
-      : Number.parseFloat(imageLike.getAttribute("height") ?? "");
-
-  if (!(width > 0) || !(height > 0)) {
-    return null;
-  }
-
-  return { width, height };
-}
-
-function classifyContentImageByDimensions(image, dimensions) {
-  if (!(image instanceof HTMLImageElement) || !dimensions) {
-    return;
-  }
-
-  const aspectRatio = dimensions.width / dimensions.height;
-  if (aspectRatio >= CONTENT_IMAGE_LANDSCAPE_THRESHOLD) {
-    syncContentImageClasses(image, CONTENT_IMAGE_LANDSCAPE_CLASS);
-    return;
-  }
-
-  if (aspectRatio <= CONTENT_IMAGE_PORTRAIT_THRESHOLD) {
-    syncContentImageClasses(image, CONTENT_IMAGE_PORTRAIT_CLASS);
-    return;
-  }
-
-  syncContentImageClasses(image, CONTENT_IMAGE_SQUARE_CLASS);
-}
-
-function resolveContentImageDimensions(image) {
-  const immediate = readIntrinsicImageDimensions(image);
-  if (immediate) {
-    return Promise.resolve(immediate);
-  }
-
-  const source = image.currentSrc || image.getAttribute("src") || "";
-  if (!source) {
-    return Promise.resolve(null);
-  }
-
-  const cached = contentImageDimensionCache.get(source);
-  if (cached) {
-    return cached;
-  }
-
-  const pending = new Promise((resolve) => {
-    const probe = new Image();
-    const finalize = () => {
-      resolve(readIntrinsicImageDimensions(probe));
-    };
-
-    probe.addEventListener("load", finalize, { once: true });
-    probe.addEventListener("error", () => resolve(null), { once: true });
-    probe.src = source;
-
-    if (probe.complete) {
-      if (typeof probe.decode === "function") {
-        probe.decode().then(finalize).catch(finalize);
-      } else {
-        finalize();
-      }
-    }
-  });
-
-  contentImageDimensionCache.set(source, pending);
-  return pending;
-}
-
-function prepareContentImage(image) {
-  if (!(image instanceof HTMLImageElement) || image.closest(".mermaid-block")) {
-    return;
-  }
-
-  const figure = image.closest("figure");
-  if (
-    figure instanceof HTMLElement &&
-    (figure.classList.contains("content-image") || figure.classList.contains("image-frame"))
-  ) {
-    clearContentImageClasses(figure);
-  }
-  clearContentImageClasses(image);
-
-  const handleLoad = () => {
-    resolveContentImageDimensions(image)
-      .then((dimensions) => {
-        if (!dimensions) {
-          handleError();
-          return;
-        }
-        classifyContentImageByDimensions(image, dimensions);
-      })
-      .catch(() => {
-        handleError();
-      });
-  };
-  const handleError = () => {
-    clearContentImageClasses(image);
-    if (
-      figure instanceof HTMLElement &&
-      (figure.classList.contains("content-image") || figure.classList.contains("image-frame"))
-    ) {
-      clearContentImageClasses(figure);
-    }
-  };
-
-  image.addEventListener("load", handleLoad, { once: true });
-  image.addEventListener("error", handleError, { once: true });
-
-  if (image.complete) {
-    handleLoad();
-  }
-}
-
-function enhanceContentImages(root) {
-  if (!(root instanceof HTMLElement)) {
-    return;
-  }
-
-  for (const image of root.querySelectorAll("img")) {
-    prepareContentImage(image);
-  }
-}
-
-function parseMermaidNodes() {
-  const contentEl = document.getElementById("viewer-content");
-  if (!(contentEl instanceof HTMLElement)) {
-    return [];
-  }
-
-  return Array.from(contentEl.querySelectorAll(MERMAID_SELECTOR));
-}
-
-function resetMermaidNodes(nodes) {
-  for (const node of nodes) {
-    node.removeAttribute("data-mermaid-rendered");
-    if (node.parentElement instanceof HTMLElement) {
-      node.parentElement.classList.remove(MERMAID_BLOCK_WIDE_CLASS, MERMAID_BLOCK_TALL_CLASS);
-      removeMermaidErrorMessage(node.parentElement);
-    }
-  }
-}
-
-async function loadMermaidLibrary(config) {
-  if (!config.enabled) {
-    return null;
-  }
-
-  const normalized = {
-    ...config,
-    theme: normalizeMermaidTheme(config.theme),
-    cdnUrl: normalizeMermaidUrl(config.cdnUrl),
-  };
-
-  if (window.mermaid) {
-    if (!mermaidRuntime.initialized || mermaidRuntime.lastTheme !== normalized.theme) {
-      window.mermaid.initialize({
-        startOnLoad: false,
-        theme: normalized.theme,
-      });
-      mermaidRuntime.initialized = true;
-      mermaidRuntime.lastTheme = normalized.theme;
-    }
-    return window.mermaid;
-  }
-
-  if (mermaidRuntime.loadingPromise) {
-    return mermaidRuntime.loadingPromise;
-  }
-
-  const expectedAbsoluteUrl = toAbsoluteUrl(normalized.cdnUrl);
-  const existingScript = document.getElementById("mermaid-runtime");
-  if (existingScript instanceof HTMLScriptElement) {
-    // 이전 로드가 비정상 종료된 스크립트 잔존을 막기 위해 재시도 전에 정리한다.
-    existingScript.remove();
-    mermaidRuntime.scriptElement = null;
-    mermaidRuntime.initialized = false;
-    mermaidRuntime.lastTheme = "";
-    mermaidRuntime.lastCdnUrl = "";
-  }
-
-  mermaidRuntime.loadingPromise = new Promise((resolve, reject) => {
-    let script = mermaidRuntime.scriptElement;
-    if (!(script instanceof HTMLScriptElement)) {
-      script = document.createElement("script");
-      script.id = "mermaid-runtime";
-      script.src = normalized.cdnUrl;
-      script.async = true;
-      script.crossOrigin = "anonymous";
-      mermaidRuntime.scriptElement = script;
-      mermaidRuntime.lastCdnUrl = expectedAbsoluteUrl;
-    }
-
-    const finalize = (error) => {
-      mermaidRuntime.loadingPromise = null;
-      if (error) {
-        if (mermaidRuntime.scriptElement instanceof HTMLScriptElement) {
-          mermaidRuntime.scriptElement.remove();
-          mermaidRuntime.scriptElement = null;
-        }
-        mermaidRuntime.initialized = false;
-        mermaidRuntime.lastTheme = "";
-        mermaidRuntime.lastCdnUrl = "";
-        reject(error);
-        return;
-      }
-      resolve(window.mermaid ?? null);
-    };
-
-    script.addEventListener("load", () => {
-      if (window.mermaid && (!mermaidRuntime.initialized || mermaidRuntime.lastTheme !== normalized.theme)) {
-        window.mermaid.initialize({
-          startOnLoad: false,
-          theme: normalized.theme,
-        });
-        mermaidRuntime.initialized = true;
-        mermaidRuntime.lastTheme = normalized.theme;
-      }
-      finalize();
-    });
-    script.addEventListener("error", () => {
-      finalize(new Error(`Mermaid 라이브러리 로드 실패: ${normalized.cdnUrl}`));
-    });
-
-    if (!script.isConnected) {
-      document.head.appendChild(script);
-    }
-  });
-
-  return mermaidRuntime.loadingPromise;
-}
-
-async function renderMermaidBlocks(config) {
-  const blocks = parseMermaidNodes();
-  if (blocks.length === 0) {
-    return;
-  }
-
-  resetMermaidNodes(blocks);
-
-  try {
-    const mermaid = await loadMermaidLibrary(config);
-    if (!mermaid) {
-      for (const block of blocks) {
-        showMermaidError(block, "Mermaid 렌더링이 비활성화되어 코드 블록을 그대로 표시합니다.");
-      }
-      return;
-    }
-
-    for (const block of blocks) {
-      try {
-        if (typeof mermaid.run === "function") {
-          await mermaid.run({ nodes: [block] });
-          normalizeRenderedMermaidSvg(block);
-          continue;
-        }
-        if (typeof mermaid.init === "function") {
-          await mermaid.init({ startOnLoad: false }, [block]);
-          normalizeRenderedMermaidSvg(block);
-          continue;
-        }
-        throw new Error("Mermaid 렌더러 API가 존재하지 않습니다.");
-      } catch (error) {
-        const message = `Mermaid 렌더링 실패: ${error instanceof Error ? error.message : String(error)}`;
-        showMermaidError(block, message);
-      }
-    }
-  } catch (error) {
-    const message = `Mermaid 렌더링 실패: ${error instanceof Error ? error.message : String(error)}`;
-    for (const block of blocks) {
-      showMermaidError(block, message);
-    }
-  }
-}
-
-function loadInitialViewData() {
-  const script = document.getElementById("initial-view-data");
-  if (!(script instanceof HTMLScriptElement)) {
-    return null;
-  }
-
-  const raw = script.textContent;
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-
-    const route = typeof parsed.route === "string" ? normalizeRoute(parsed.route) : null;
-    const docId = typeof parsed.docId === "string" ? parsed.docId : null;
-    const title = typeof parsed.title === "string" ? parsed.title : null;
-
-    if (!route || !docId || !title) {
-      return null;
-    }
-
-    return {
-      route,
-      docId,
-      title,
-    };
-  } catch {
-    return null;
-  }
-}
-
-function loadInitialRuntimeData() {
-  const script = document.getElementById("initial-runtime-data");
-  if (!(script instanceof HTMLScriptElement)) {
-    return null;
-  }
-
-  const raw = script.textContent;
-  if (!raw) {
-    return null;
-  }
-
-  try {
-    const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") {
-      return null;
-    }
-
-    const pathBase = normalizePathBase(parsed.pathBase);
-    const manifestUrl = typeof parsed.manifestUrl === "string" ? parsed.manifestUrl : "";
-    const treeModuleUrl = typeof parsed.treeModuleUrl === "string" ? parsed.treeModuleUrl : "";
-    if (!manifestUrl || manifestUrl !== toPathWithBase("/manifest.json", pathBase)) {
-      return null;
-    }
-
-    let resolvedTreeModuleUrl;
-    try {
-      resolvedTreeModuleUrl = new URL(treeModuleUrl, document.baseURI);
-    } catch {
-      return null;
-    }
-    const treeModulePath = stripPathBase(resolvedTreeModuleUrl.pathname, pathBase);
-    if (
-      resolvedTreeModuleUrl.origin !== window.location.origin ||
-      !/^\/assets\/tree\.[a-f0-9]{12}\.js$/.test(treeModulePath)
-    ) {
-      return null;
-    }
-
-    return { manifestUrl, pathBase, treeModuleUrl: resolvedTreeModuleUrl.href };
-  } catch {
-    return null;
-  }
-}
-
-function resolveSiteTitle(manifest) {
-  const value = typeof manifest?.siteTitle === "string" ? manifest.siteTitle.trim() : "";
-  return value || DEFAULT_SITE_TITLE;
 }
 
 function composeDocumentTitle(pageTitle, siteTitle) {
@@ -588,7 +43,6 @@ function formatMetaDateTime(value) {
   if (!Number.isFinite(parsed.getTime())) {
     return null;
   }
-
   const yyyy = parsed.getFullYear();
   const mm = String(parsed.getMonth() + 1).padStart(2, "0");
   const dd = String(parsed.getDate()).padStart(2, "0");
@@ -601,235 +55,9 @@ function normalizeTags(tags) {
   if (!Array.isArray(tags)) {
     return [];
   }
-
   return tags
     .map((tag) => String(tag).trim().replace(/^#+/, ""))
     .filter(Boolean);
-}
-
-function loadMenuTogglePosition() {
-  const raw = localStorage.getItem(MENU_TOGGLE_POSITION_KEY);
-  return raw === "left" ? "left" : "right";
-}
-
-function persistMenuTogglePosition(position) {
-  localStorage.setItem(MENU_TOGGLE_POSITION_KEY, position);
-}
-
-function normalizeThemeMode(mode) {
-  if (mode === "light" || mode === "dark" || mode === "system") {
-    return mode;
-  }
-  return "system";
-}
-
-function loadThemeMode() {
-  return normalizeThemeMode(localStorage.getItem(THEME_MODE_KEY));
-}
-
-function persistThemeMode(mode) {
-  localStorage.setItem(THEME_MODE_KEY, mode);
-}
-
-function resolveAppliedTheme(mode, prefersDark) {
-  if (mode === "system") {
-    return prefersDark ? "dark" : "light";
-  }
-  return mode;
-}
-
-function applyTheme(mode, prefersDark) {
-  const appliedTheme = resolveAppliedTheme(mode, prefersDark);
-  document.documentElement.dataset.theme = appliedTheme;
-  document.documentElement.style.colorScheme = appliedTheme;
-}
-
-function loadDesktopSidebarWidth() {
-  const raw = localStorage.getItem(SIDEBAR_WIDTH_KEY);
-  const parsed = Number.parseInt(raw ?? "", 10);
-  if (!Number.isFinite(parsed)) {
-    return DESKTOP_SIDEBAR_DEFAULT;
-  }
-  return parsed;
-}
-
-function persistDesktopSidebarWidth(width) {
-  localStorage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(width)));
-}
-
-function getDesktopSidebarBounds() {
-  const max = Math.max(
-    DESKTOP_SIDEBAR_MIN,
-    window.innerWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
-  );
-
-  return {
-    min: DESKTOP_SIDEBAR_MIN,
-    max,
-  };
-}
-
-function clampDesktopSidebarWidth(width) {
-  const { min, max } = getDesktopSidebarBounds();
-  return Math.min(Math.max(width, min), max);
-}
-
-function applyMenuTogglePosition(position) {
-  document.body.classList.toggle("mobile-toggle-left", position === "left");
-}
-
-function getFocusableElements(container) {
-  if (!container) {
-    return [];
-  }
-
-  const candidates = [];
-  const collect = (root) => {
-    for (const el of root.querySelectorAll("*")) {
-      if (!(el instanceof HTMLElement)) {
-        continue;
-      }
-      if (el.matches(FOCUSABLE_SELECTOR)) {
-        candidates.push(el);
-      }
-      if (el.shadowRoot) {
-        collect(el.shadowRoot);
-      }
-    }
-  };
-
-  collect(container);
-
-  return candidates.filter((el) => {
-    if (!(el instanceof HTMLElement)) {
-      return false;
-    }
-
-    if (el.hasAttribute("hidden") || el.getAttribute("aria-hidden") === "true") {
-      return false;
-    }
-
-    if (el.closest("[hidden], [inert], [aria-hidden='true']")) {
-      return false;
-    }
-
-    if (el instanceof HTMLInputElement && el.type === "hidden") {
-      return false;
-    }
-
-    const style = window.getComputedStyle(el);
-    if (style.display === "none" || style.visibility === "hidden") {
-      return false;
-    }
-
-    return el.getClientRects().length > 0;
-  });
-}
-
-function normalizeTreeLabelText(value, fallback = "") {
-  const normalized = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
-  return normalized || fallback;
-}
-
-function getTreeLabelRenderRoot(host) {
-  return host?.shadowRoot || host || null;
-}
-
-function decorateTreeLabels(host) {
-  const metadataByTreePath = host?.__eiamMetadataByTreePath;
-  if (!(metadataByTreePath instanceof Map)) {
-    return;
-  }
-
-  const renderRoot = getTreeLabelRenderRoot(host);
-  if (!renderRoot) {
-    return;
-  }
-
-  const rows = renderRoot.querySelectorAll("[data-type='item'][data-item-type='file'][data-item-path]");
-  for (const row of rows) {
-    const treePath = row.getAttribute("data-item-path") || "";
-    const metadata = metadataByTreePath.get(treePath);
-    if (!metadata || metadata.kind !== "file") {
-      continue;
-    }
-
-    const prefix = normalizeTreeLabelText(metadata.prefix);
-    const fallbackName = treePath.split("/").pop() || "";
-    const fallbackTitle = prefix && fallbackName.startsWith(`${prefix} `)
-      ? fallbackName.slice(prefix.length).trimStart()
-      : fallbackName;
-    const title = normalizeTreeLabelText(metadata.title, fallbackTitle);
-    const labelKey = JSON.stringify([prefix, title]);
-    const content = row.querySelector("[data-item-section='content']");
-    if (!(content instanceof HTMLElement) || content.dataset.eiamTreeLabel === labelKey) {
-      continue;
-    }
-
-    content.dataset.eiamTreeLabel = labelKey;
-    content.textContent = "";
-
-    const label = document.createElement("span");
-    label.className = "tree-item-label";
-
-    if (prefix) {
-      const prefixBadge = document.createElement("span");
-      prefixBadge.className = "tree-item-prefix-badge";
-      prefixBadge.textContent = prefix;
-      label.appendChild(prefixBadge);
-    }
-
-    const titleText = document.createElement("span");
-    titleText.className = "tree-item-title";
-    titleText.textContent = title;
-    label.appendChild(titleText);
-
-    content.appendChild(label);
-    row.setAttribute("title", prefix ? `${prefix} ${title}` : title);
-  }
-}
-
-function queueTreeLabelDecoration(host) {
-  if (!(host instanceof HTMLElement)) {
-    return;
-  }
-
-  if (host.__eiamTreeLabelFrame) {
-    window.cancelAnimationFrame(host.__eiamTreeLabelFrame);
-  }
-
-  host.__eiamTreeLabelFrame = window.requestAnimationFrame(() => {
-    host.__eiamTreeLabelFrame = 0;
-    decorateTreeLabels(host);
-  });
-}
-
-function setupTreeLabelDecorations(treeRoot, metadataByTreePath) {
-  const host = treeRoot?.querySelector("file-tree-container");
-  if (!(host instanceof HTMLElement)) {
-    return;
-  }
-
-  host.__eiamMetadataByTreePath = metadataByTreePath;
-
-  const renderRoot = getTreeLabelRenderRoot(host);
-  if (!renderRoot) {
-    return;
-  }
-
-  if (host.__eiamTreeLabelObservedRoot !== renderRoot) {
-    host.__eiamTreeLabelObserver?.disconnect();
-    host.__eiamTreeLabelObservedRoot = renderRoot;
-    host.__eiamTreeLabelObserver = new MutationObserver(() => {
-      queueTreeLabelDecoration(host);
-    });
-    host.__eiamTreeLabelObserver.observe(renderRoot, {
-      childList: true,
-      subtree: true,
-    });
-  }
-
-  queueTreeLabelDecoration(host);
 }
 
 function renderBreadcrumb(route) {
@@ -849,50 +77,44 @@ function renderBreadcrumb(route) {
 
 function renderMeta(doc) {
   const items = [];
-
   if (typeof doc.prefix === "string" && doc.prefix.trim().length > 0) {
     items.push(`<span class="meta-item meta-prefix">${escapeHtmlAttr(doc.prefix)}</span>`);
   }
-
   const createdAt = formatMetaDateTime(doc.date);
   if (createdAt) {
     items.push(
       `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeHtmlAttr(createdAt)}</span>`,
     );
   }
-
   const tags = normalizeTags(doc.tags);
   if (tags.length > 0) {
     const tagsStr = tags.map((tag) => `#${escapeHtmlAttr(tag)}`).join(" ");
     items.push(`<span class="meta-item meta-tags">${tagsStr}</span>`);
   }
-
   return items.join("");
 }
 
-function renderNav(docs, docIndexById, currentId, pathBase) {
-  const currentIndex = docIndexById.get(currentId) ?? -1;
-  if (currentIndex === -1) return "";
-
-  const prev = currentIndex > 0 ? docs[currentIndex - 1] : null;
-  const next = currentIndex < docs.length - 1 ? docs[currentIndex + 1] : null;
-
+function renderNav(currentView, currentId, pathBase) {
+  const currentIndex = currentView.docIndexById.get(currentId) ?? -1;
+  if (currentIndex === -1) {
+    return "";
+  }
+  const previous = currentIndex > 0 ? currentView.docs[currentIndex - 1] : null;
+  const next =
+    currentIndex < currentView.docs.length - 1 ? currentView.docs[currentIndex + 1] : null;
   let html = "";
-
-  if (prev) {
-    html += `<a href="${toPathWithBase(prev.route, pathBase)}" class="nav-link nav-link-prev" data-route="${escapeHtmlAttr(prev.route)}">
+  if (previous) {
+    html += `<a href="${toPathWithBase(previous.route, pathBase)}" class="nav-link nav-link-prev" data-route="${escapeHtmlAttr(previous.route)}">
       <div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div>
-      <div class="nav-link-title">${escapeHtmlAttr(prev.title)}</div>
+      <div class="nav-link-title">${escapeHtmlAttr(previous.title)}</div>
     </a>`;
   }
-
   if (next) {
     html += `<a href="${toPathWithBase(next.route, pathBase)}" class="nav-link nav-link-next" data-route="${escapeHtmlAttr(next.route)}">
       <div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div>
       <div class="nav-link-title">${escapeHtmlAttr(next.title)}</div>
     </a>`;
   }
-
   return html;
 }
 
@@ -901,1132 +123,188 @@ function renderBacklinks(doc, pathBase) {
   if (backlinks.length === 0) {
     return "";
   }
-
   let html = '<h2 class="backlinks-title">Backlinks</h2><ul class="backlinks-list">';
   for (const backlink of backlinks) {
-    const prefix = typeof backlink.prefix === "string" && backlink.prefix.trim().length > 0
-      ? `<span class="backlink-prefix">${escapeHtmlAttr(backlink.prefix.trim())}</span>`
-      : "";
+    const prefix =
+      typeof backlink.prefix === "string" && backlink.prefix.trim().length > 0
+        ? `<span class="backlink-prefix">${escapeHtmlAttr(backlink.prefix.trim())}</span>`
+        : "";
     const route = typeof backlink.route === "string" ? normalizeRoute(backlink.route) : "/";
-    const title = typeof backlink.title === "string" && backlink.title.trim().length > 0 ? backlink.title : route;
+    const title =
+      typeof backlink.title === "string" && backlink.title.trim().length > 0
+        ? backlink.title
+        : route;
     html += `<li class="backlinks-item"><a href="${toPathWithBase(route, pathBase)}" class="backlink-link" data-route="${escapeHtmlAttr(route)}">${prefix}<span class="backlink-text">${escapeHtmlAttr(title)}</span></a></li>`;
   }
-  html += "</ul>";
-  return html;
+  return `${html}</ul>`;
 }
 
-function setAppReadyState(state) {
-  if (!(document.documentElement instanceof HTMLElement)) {
-    return;
-  }
-  document.documentElement.setAttribute(APP_READY_STATE_ATTR, state);
+function setRuntimeState(attribute, state) {
+  document.documentElement?.setAttribute(attribute, state);
 }
 
-function setTreeRuntimeState(state) {
-  if (!(document.documentElement instanceof HTMLElement)) {
-    return;
+function collectViewerElements() {
+  return {
+    breadcrumb: document.getElementById("viewer-breadcrumb"),
+    title: document.getElementById("viewer-title"),
+    meta: document.getElementById("viewer-meta"),
+    content: document.getElementById("viewer-content"),
+    backlinks: document.getElementById("viewer-backlinks"),
+    nav: document.getElementById("viewer-nav"),
+    viewer: document.querySelector(".viewer"),
+  };
+}
+
+function createA11yAnnouncer(element) {
+  let timer = null;
+  return {
+    announce(message) {
+      if (!element) {
+        return;
+      }
+      element.textContent = "";
+      if (timer != null) {
+        window.clearTimeout(timer);
+      }
+      timer = window.setTimeout(() => {
+        timer = null;
+        element.textContent = message;
+      }, 20);
+    },
+    destroy() {
+      if (timer != null) {
+        window.clearTimeout(timer);
+        timer = null;
+      }
+    },
+  };
+}
+
+function installPageLifecycle(controllers, contentController) {
+  window.addEventListener("pagehide", (event) => {
+    if (event.persisted) {
+      contentController.destroy();
+      return;
+    }
+    destroyControllers(controllers);
+  });
+  window.addEventListener("pageshow", (event) => {
+    if (event.persisted) {
+      contentController.setup();
+    }
+  });
+}
+
+function destroyControllers(controllers) {
+  for (const controller of [...controllers].reverse()) {
+    controller.destroy?.();
   }
-  document.documentElement.setAttribute(TREE_RUNTIME_STATE_ATTR, state);
 }
 
 async function start() {
-  setAppReadyState("booting");
-  setTreeRuntimeState("idle");
+  setRuntimeState(APP_READY_STATE_ATTR, "booting");
+  setRuntimeState(TREE_RUNTIME_STATE_ATTR, "idle");
 
-  const treeRoot = document.getElementById("tree-root");
-  const treeSearchInput = document.getElementById("tree-search-input");
-  const treeSearchClear = document.getElementById("tree-search-clear");
-  const treeSearchPrev = document.getElementById("tree-search-prev");
-  const treeSearchNext = document.getElementById("tree-search-next");
-  const treeSearchCount = document.getElementById("tree-search-count");
-  const appRoot = document.querySelector(".app-root");
-  const splitter = document.getElementById("app-splitter");
-  const sidebar = document.getElementById("sidebar-panel");
-  const sidebarToggle = document.getElementById("sidebar-toggle");
-  const sidebarClose = document.getElementById("sidebar-close");
-  const sidebarOverlay = document.getElementById("sidebar-overlay");
-  const sidebarBranchPills = document.getElementById("sidebar-branch-pills");
-  const sidebarBranchInfo = document.getElementById("sidebar-branch-info");
-  const settingsToggle = document.getElementById("settings-toggle");
-  const settingsClose = document.getElementById("settings-close");
-  const settingsPanel = document.getElementById("sidebar-settings");
-  const menuTogglePositionInputs = document.querySelectorAll('input[name="menu-toggle-position"]');
-  const themeModeInputs = document.querySelectorAll('input[name="theme-mode"]');
-  const breadcrumbEl = document.getElementById("viewer-breadcrumb");
-  const titleEl = document.getElementById("viewer-title");
-  const metaEl = document.getElementById("viewer-meta");
-  const contentEl = document.getElementById("viewer-content");
-  const backlinksEl = document.getElementById("viewer-backlinks");
-  const navEl = document.getElementById("viewer-nav");
-  const a11yStatusEl = document.getElementById("a11y-status");
-  const viewerEl = document.querySelector(".viewer");
-  const initialViewData = loadInitialViewData();
-  let contentController = null;
-
-  let desktopSidebarWidth = clampDesktopSidebarWidth(loadDesktopSidebarWidth());
-  let activeResizePointerId = null;
-  let resizeStartX = 0;
-  let resizeStartWidth = desktopSidebarWidth;
-  let fileTree = null;
-  let isSyncingTreeSelection = false;
-  let treePathOrder = new Map();
-  let treeSearchValue = "";
-  let renderedTreeBranch = "";
-  let treeRuntime = null;
-  let treeLoadPromise = null;
-  let treeRetryCount = 0;
-  let treeLoadAllowed = false;
-  let pendingTreeLoadReason = "";
-  let requestTreeLoad = (reason) => {
-    pendingTreeLoadReason = reason;
-    return Promise.resolve(false);
-  };
-
-  const announceA11yStatus = (message) => {
-    if (!(a11yStatusEl instanceof HTMLElement)) {
-      return;
-    }
-    a11yStatusEl.textContent = "";
-    window.setTimeout(() => {
-      a11yStatusEl.textContent = message;
-    }, 20);
-  };
-
-  const compactMediaQuery = window.matchMedia(COMPACT_LAYOUT_QUERY);
-  const darkModeMediaQuery = window.matchMedia(DARK_MODE_QUERY);
-  const savedTogglePosition = loadMenuTogglePosition();
-  let themeMode = loadThemeMode();
-  applyMenuTogglePosition(savedTogglePosition);
-  applyTheme(themeMode, darkModeMediaQuery.matches);
-
-  for (const input of menuTogglePositionInputs) {
-    if (!(input instanceof HTMLInputElement)) {
-      continue;
-    }
-    input.checked = input.value === savedTogglePosition;
-  }
-
-  for (const input of themeModeInputs) {
-    if (!(input instanceof HTMLInputElement)) {
-      continue;
-    }
-    input.checked = input.value === themeMode;
-  }
-
-  const isCompactLayout = () => compactMediaQuery.matches;
-
-  const updateSplitterA11y = () => {
-    if (!(splitter instanceof HTMLElement)) {
-      return;
-    }
-
-    const bounds = getDesktopSidebarBounds();
-    splitter.setAttribute("aria-valuemin", String(Math.round(bounds.min)));
-    splitter.setAttribute("aria-valuemax", String(Math.round(bounds.max)));
-    splitter.setAttribute("aria-valuenow", String(Math.round(desktopSidebarWidth)));
-    splitter.setAttribute("aria-valuetext", `${Math.round(desktopSidebarWidth)}px`);
-    splitter.setAttribute("aria-disabled", String(isCompactLayout()));
-  };
-
-  const syncDesktopSidebarWidth = (persist) => {
-    desktopSidebarWidth = clampDesktopSidebarWidth(desktopSidebarWidth);
-
-    if (appRoot instanceof HTMLElement) {
-      if (isCompactLayout()) {
-        appRoot.style.removeProperty("--sidebar-width");
-      } else {
-        appRoot.style.setProperty("--sidebar-width", `${Math.round(desktopSidebarWidth)}px`);
-      }
-    }
-
-    updateSplitterA11y();
-
-    if (persist) {
-      persistDesktopSidebarWidth(desktopSidebarWidth);
-    }
-  };
-
-  const setSettingsExpanded = (expanded) => {
-    if (settingsToggle) {
-      settingsToggle.setAttribute("aria-expanded", String(expanded));
-    }
-  };
-
-  const closeSettings = () => {
-    if (!settingsPanel || settingsPanel.hidden) {
-      return;
-    }
-    settingsPanel.hidden = true;
-    setSettingsExpanded(false);
-  };
-
-  const openSettings = () => {
-    if (!settingsPanel) {
-      return;
-    }
-    settingsPanel.hidden = false;
-    setSettingsExpanded(true);
-    const checkedInput = settingsPanel.querySelector('input[name="theme-mode"]:checked, input[name="menu-toggle-position"]:checked');
-    if (checkedInput instanceof HTMLElement) {
-      checkedInput.focus();
-    }
-  };
-
-  const toggleSettings = () => {
-    if (!settingsPanel) {
-      return;
-    }
-    if (settingsPanel.hidden) {
-      openSettings();
-      return;
-    }
-    closeSettings();
-  };
-
-  const setViewerInteractiveState = (isInteractive) => {
-    if (!(viewerEl instanceof HTMLElement)) {
-      return;
-    }
-
-    if (isInteractive) {
-      viewerEl.removeAttribute("inert");
-      viewerEl.removeAttribute("aria-hidden");
-      return;
-    }
-
-    viewerEl.setAttribute("inert", "");
-    viewerEl.setAttribute("aria-hidden", "true");
-  };
-
-  const syncSidebarA11y = (isOpen) => {
-    if (sidebarToggle) {
-      sidebarToggle.setAttribute("aria-expanded", String(isOpen));
-    }
-
-    if (sidebarOverlay) {
-      sidebarOverlay.setAttribute("aria-hidden", String(!isOpen));
-    }
-
-    if (!(sidebar instanceof HTMLElement)) {
-      setViewerInteractiveState(true);
-      return;
-    }
-
-    if (!isCompactLayout()) {
-      sidebar.removeAttribute("inert");
-      sidebar.removeAttribute("aria-hidden");
-      sidebar.removeAttribute("aria-modal");
-      sidebar.setAttribute("role", "complementary");
-      setViewerInteractiveState(true);
-      return;
-    }
-
-    if (isOpen) {
-      sidebar.removeAttribute("inert");
-      sidebar.removeAttribute("aria-hidden");
-      sidebar.setAttribute("role", "dialog");
-      sidebar.setAttribute("aria-modal", "true");
-      setViewerInteractiveState(false);
-    } else {
-      sidebar.setAttribute("inert", "");
-      sidebar.setAttribute("aria-hidden", "true");
-      sidebar.removeAttribute("aria-modal");
-      sidebar.setAttribute("role", "complementary");
-      setViewerInteractiveState(true);
-    }
-  };
-
-  const openSidebar = () => {
-    if (!appRoot || !isCompactLayout()) {
-      return;
-    }
-    appRoot.classList.add("sidebar-open");
-    if (sidebarOverlay) {
-      sidebarOverlay.hidden = false;
-    }
-    document.body.classList.add("menu-open");
-    syncSidebarA11y(true);
-    void requestTreeLoad("mobile-sidebar");
-    const focusables = getFocusableElements(sidebar);
-    if (focusables.length > 0) {
-      focusables[0].focus();
-    }
-  };
-
-  const closeSidebar = () => {
-    if (!appRoot) {
-      return;
-    }
-    appRoot.classList.remove("sidebar-open");
-    if (sidebarOverlay) {
-      sidebarOverlay.hidden = true;
-    }
-    closeSettings();
-    document.body.classList.remove("menu-open");
-    syncSidebarA11y(false);
-    if (sidebarToggle instanceof HTMLElement && isCompactLayout()) {
-      sidebarToggle.focus();
-    }
-  };
-
-  const handleLayoutChange = () => {
-    if (!isCompactLayout()) {
-      closeSidebar();
-      if (sidebarOverlay) {
-        sidebarOverlay.hidden = true;
-      }
-      syncSidebarA11y(false);
-      syncDesktopSidebarWidth(false);
-      if (treeLoadAllowed) {
-        void requestTreeLoad("desktop-layout");
-      }
-      return;
-    }
-    closeSidebar();
-    syncDesktopSidebarWidth(false);
-  };
-
-  sidebarToggle?.addEventListener("click", openSidebar);
-  sidebarClose?.addEventListener("click", closeSidebar);
-  sidebarOverlay?.addEventListener("click", closeSidebar);
-  settingsToggle?.addEventListener("click", toggleSettings);
-  settingsClose?.addEventListener("click", closeSettings);
-
-  const beginSplitterResize = (event) => {
-    if (!(splitter instanceof HTMLElement) || !(appRoot instanceof HTMLElement) || isCompactLayout()) {
-      return;
-    }
-
-    if (event.pointerType === "mouse" && event.button !== 0) {
-      return;
-    }
-
-    event.preventDefault();
-    activeResizePointerId = event.pointerId;
-    resizeStartX = event.clientX;
-    resizeStartWidth = desktopSidebarWidth;
-    appRoot.classList.add("is-resizing");
-    splitter.setPointerCapture(event.pointerId);
-  };
-
-  const updateSplitterResize = (event) => {
-    if (event.pointerId !== activeResizePointerId) {
-      return;
-    }
-
-    const deltaX = event.clientX - resizeStartX;
-    desktopSidebarWidth = resizeStartWidth + deltaX;
-    syncDesktopSidebarWidth(false);
-  };
-
-  const endSplitterResize = (event) => {
-    if (event.pointerId !== activeResizePointerId) {
-      return;
-    }
-
-    if (splitter instanceof HTMLElement && splitter.hasPointerCapture(event.pointerId)) {
-      splitter.releasePointerCapture(event.pointerId);
-    }
-
-    if (appRoot instanceof HTMLElement) {
-      appRoot.classList.remove("is-resizing");
-    }
-
-    activeResizePointerId = null;
-    persistDesktopSidebarWidth(desktopSidebarWidth);
-  };
-
-  splitter?.addEventListener("pointerdown", beginSplitterResize);
-  splitter?.addEventListener("pointermove", updateSplitterResize);
-  splitter?.addEventListener("pointerup", endSplitterResize);
-  splitter?.addEventListener("pointercancel", endSplitterResize);
-  splitter?.addEventListener("keydown", (event) => {
-    if (isCompactLayout()) {
-      return;
-    }
-
-    let nextWidth = desktopSidebarWidth;
-    if (event.key === "ArrowLeft") {
-      nextWidth -= DESKTOP_SPLITTER_STEP;
-    } else if (event.key === "ArrowRight") {
-      nextWidth += DESKTOP_SPLITTER_STEP;
-    } else if (event.key === "Home") {
-      nextWidth = getDesktopSidebarBounds().min;
-    } else if (event.key === "End") {
-      nextWidth = getDesktopSidebarBounds().max;
-    } else {
-      return;
-    }
-
-    event.preventDefault();
-    desktopSidebarWidth = nextWidth;
-    syncDesktopSidebarWidth(true);
-  });
-
-  window.addEventListener("resize", () => {
-    syncDesktopSidebarWidth(false);
-  });
-
-  for (const input of menuTogglePositionInputs) {
-    if (!(input instanceof HTMLInputElement)) {
-      continue;
-    }
-    input.addEventListener("change", () => {
-      if (!input.checked) {
-        return;
-      }
-      const nextPosition = input.value === "left" ? "left" : "right";
-      applyMenuTogglePosition(nextPosition);
-      persistMenuTogglePosition(nextPosition);
-    });
-  }
-
-  for (const input of themeModeInputs) {
-    if (!(input instanceof HTMLInputElement)) {
-      continue;
-    }
-    input.addEventListener("change", () => {
-      if (!input.checked) {
-        return;
-      }
-      themeMode = normalizeThemeMode(input.value);
-      applyTheme(themeMode, darkModeMediaQuery.matches);
-      persistThemeMode(themeMode);
-    });
-  }
-
-  darkModeMediaQuery.addEventListener("change", (event) => {
-    if (themeMode !== "system") {
-      return;
-    }
-    applyTheme(themeMode, event.matches);
-  });
-
-  document.addEventListener("click", (event) => {
-    if (!settingsPanel || settingsPanel.hidden) {
-      return;
-    }
-    const target = event.target;
-    if (!(target instanceof Node)) {
-      return;
-    }
-    const clickInPanel = settingsPanel.contains(target);
-    const clickOnToggle = settingsToggle instanceof HTMLElement ? settingsToggle.contains(target) : false;
-    if (!clickInPanel && !clickOnToggle) {
-      closeSettings();
-    }
-  });
-
-  compactMediaQuery.addEventListener("change", handleLayoutChange);
-
-  document.addEventListener("keydown", (event) => {
-    if (event.key === "Escape" && appRoot?.classList.contains("sidebar-open")) {
-      closeSidebar();
-      return;
-    }
-
-    if (event.key !== "Tab" || !isCompactLayout() || !appRoot?.classList.contains("sidebar-open")) {
-      return;
-    }
-
-    const focusables = getFocusableElements(sidebar);
-    if (focusables.length === 0) {
-      event.preventDefault();
-      return;
-    }
-
-    const first = focusables[0];
-    const last = focusables[focusables.length - 1];
-    const activeElement = document.activeElement;
-    const activeInsideSidebar = activeElement instanceof Node && sidebar?.contains(activeElement);
-
-    if (!activeInsideSidebar) {
-      event.preventDefault();
-      first.focus();
-      return;
-    }
-
-    if (event.shiftKey && activeElement === first) {
-      event.preventDefault();
-      last.focus();
-      return;
-    }
-
-    if (!event.shiftKey && activeElement === last) {
-      event.preventDefault();
-      first.focus();
-    }
-  });
-
-  const initialRuntimeData = loadInitialRuntimeData();
-  const initialPathBase = normalizePathBase(initialRuntimeData?.pathBase);
-  const manifestUrl = initialRuntimeData?.manifestUrl ?? toPathWithBase("/manifest.json", initialPathBase);
-  const treeModuleUrl = initialRuntimeData?.treeModuleUrl ?? "";
-  const manifestRes = await fetch(manifestUrl);
-  if (!manifestRes.ok) {
-    throw new Error(`Failed to load manifest: ${manifestRes.status}`);
-  }
-  const manifest = normalizeManifestPayload(await manifestRes.json());
-  if (!manifest) {
-    throw new Error("Failed to load a supported manifest schema");
-  }
-  const mermaidConfig = resolveMermaidConfig(manifest);
-  const pathBase = normalizePathBase(manifest.pathBase);
-  const siteTitle = resolveSiteTitle(manifest);
-  const navigation = createNavigationState(manifest, {
+  const bootstrap = await loadRuntimeBootstrap();
+  const elements = collectViewerElements();
+  const announcer = createA11yAnnouncer(document.getElementById("a11y-status"));
+  const navigation = createNavigationState(bootstrap.manifest, {
     savedBranch: localStorage.getItem(BRANCH_KEY),
-    initialDocId: initialViewData?.docId,
+    initialDocId: bootstrap.initialViewData?.docId,
   });
-  const availableBranches = navigation.availableBranches;
-
-  const renderBranchPills = () => {
-    if (!(sidebarBranchPills instanceof HTMLElement)) {
-      return;
-    }
-
-    sidebarBranchPills.innerHTML = "";
-    for (const branch of availableBranches) {
-      const pill = document.createElement("button");
-      pill.type = "button";
-      pill.className = "branch-pill";
-      pill.dataset.branch = branch;
-      pill.textContent = branch;
-      pill.setAttribute("aria-pressed", "false");
-      pill.addEventListener("click", () => {
-        void setActiveBranch(branch);
-      });
-      sidebarBranchPills.appendChild(pill);
-    }
-  };
-
-  const updateBranchInfo = () => {
-    if (sidebarBranchInfo instanceof HTMLElement) {
-      sidebarBranchInfo.textContent =
-        navigation.activeBranch === navigation.defaultBranch
-          ? `publish: true · ${navigation.activeBranch} + unclassified`
-          : `publish: true · ${navigation.activeBranch} only`;
-    }
-    if (sidebarBranchPills instanceof HTMLElement) {
-      for (const pill of sidebarBranchPills.querySelectorAll(".branch-pill")) {
-        if (!(pill instanceof HTMLButtonElement)) {
-          continue;
-        }
-        const isActive = pill.dataset.branch === navigation.activeBranch;
-        pill.classList.toggle("is-active", isActive);
-        pill.setAttribute("aria-pressed", String(isActive));
-      }
-    }
-  };
-
-  const updateTreeSearchControls = () => {
-    const normalizedSearchValue = fileTree ? fileTree.getSearchValue() : treeSearchValue.trim();
-    const hasSearch = normalizedSearchValue.length > 0;
-    const matchCount = hasSearch && fileTree ? fileTree.getSearchMatchingPaths().length : 0;
-    const canStep = hasSearch && matchCount > 0;
-
-    if (treeSearchClear instanceof HTMLButtonElement) {
-      treeSearchClear.hidden = !hasSearch;
-      treeSearchClear.disabled = !hasSearch;
-    }
-
-    for (const button of [treeSearchPrev, treeSearchNext]) {
-      if (button instanceof HTMLButtonElement) {
-        button.disabled = !canStep;
-      }
-    }
-
-    if (treeSearchCount instanceof HTMLElement) {
-      treeSearchCount.textContent = hasSearch ? `${matchCount}개 일치` : "";
-    }
-  };
-
-  const applyTreeSearch = (value) => {
-    treeSearchValue = value;
-
-    if (treeSearchInput instanceof HTMLInputElement && treeSearchInput.value !== value) {
-      treeSearchInput.value = value;
-    }
-
-    if (fileTree) {
-      const query = value.trim();
-      if (query) {
-        if (fileTree.isSearchOpen()) {
-          fileTree.setSearch(query);
-        } else {
-          fileTree.openSearch(query);
-        }
-      } else {
-        fileTree.closeSearch();
-      }
-    }
-
-    updateTreeSearchControls();
-  };
-
-  const moveTreeSearchFocus = (direction) => {
-    if (!fileTree || !fileTree.isSearchOpen() || fileTree.getSearchMatchingPaths().length === 0) {
-      return;
-    }
-
-    if (direction < 0) {
-      fileTree.focusPreviousSearchMatch();
-    } else {
-      fileTree.focusNextSearchMatch();
-    }
-
-    updateTreeSearchControls();
-  };
-
-  if (treeSearchInput instanceof HTMLInputElement) {
-    treeSearchInput.addEventListener("focus", () => {
-      void requestTreeLoad("tree-search");
-    });
-    treeSearchInput.addEventListener("input", () => {
-      applyTreeSearch(treeSearchInput.value);
-      void requestTreeLoad("tree-search");
-    });
-    treeSearchInput.addEventListener("keydown", (event) => {
-      if (event.key === "Enter") {
-        event.preventDefault();
-        moveTreeSearchFocus(event.shiftKey ? -1 : 1);
-        return;
-      }
-
-      if (event.key === "Escape" && treeSearchInput.value.trim()) {
-        event.preventDefault();
-        event.stopPropagation();
-        applyTreeSearch("");
-      }
-    });
-  }
-
-  treeSearchClear?.addEventListener("click", () => {
-    applyTreeSearch("");
-    if (treeSearchInput instanceof HTMLInputElement) {
-      treeSearchInput.focus();
-    }
+  const settingsController = createSettingsController();
+  let treeController = null;
+  const layoutController = createSidebarLayoutController({
+    closeSettings: () => settingsController.close(),
+    requestTreeLoad: (reason) => treeController?.requestLoad(reason),
+  });
+  const mermaidController = createMermaidController(resolveMermaidConfig(bootstrap.manifest));
+  const enhancementController = createContentEnhancementController({
+    root: elements.content,
+    mermaidController,
   });
 
-  treeSearchPrev?.addEventListener("click", () => {
-    moveTreeSearchFocus(-1);
-  });
-
-  treeSearchNext?.addEventListener("click", () => {
-    moveTreeSearchFocus(1);
-  });
-
-  const syncActiveTreeSelection = (docId, { scroll = true } = {}) => {
-    if (!fileTree || !docId) {
-      return;
-    }
-
-    const treePath = navigation.view.trees.docIdToPrimaryTreePath.get(docId);
-    if (!treePath) {
-      return;
-    }
-
-    const selectedPaths = fileTree.getSelectedPaths();
-    if (selectedPaths.length === 1 && selectedPaths[0] === treePath) {
-      return;
-    }
-
-    const item = fileTree.getItem(treePath);
-    if (!item) {
-      return;
-    }
-
-    isSyncingTreeSelection = true;
-    try {
-      item.select();
-    } finally {
-      isSyncingTreeSelection = false;
-    }
-
-    if (scroll) {
-      fileTree.scrollToPath(treePath, { focus: false, offset: "nearest" });
-    }
-  };
-
-  const clearTreeSelection = () => {
-    if (!fileTree) {
-      return;
-    }
-
-    const selectedPaths = fileTree.getSelectedPaths();
-    if (selectedPaths.length === 0) {
-      return;
-    }
-
-    isSyncingTreeSelection = true;
-    try {
-      for (const selectedPath of selectedPaths) {
-        fileTree.getItem(selectedPath)?.deselect();
-      }
-    } finally {
-      isSyncingTreeSelection = false;
-    }
-  };
-
-  const cleanupTreeLabelDecorations = (host) => {
-    if (!(host instanceof HTMLElement)) {
-      return;
-    }
-
-    if (host.__eiamTreeLabelFrame) {
-      window.cancelAnimationFrame(host.__eiamTreeLabelFrame);
-      host.__eiamTreeLabelFrame = 0;
-    }
-    host.__eiamTreeLabelObserver?.disconnect();
-    delete host.__eiamTreeLabelObserver;
-    delete host.__eiamTreeLabelObservedRoot;
-    delete host.__eiamMetadataByTreePath;
-  };
-
-  const destroyFileTree = () => {
-    const host = treeRoot instanceof HTMLElement ? treeRoot.querySelector("file-tree-container") : null;
-    cleanupTreeLabelDecorations(host);
-    fileTree?.cleanUp?.();
-    fileTree = null;
-    renderedTreeBranch = "";
-    host?.remove();
-  };
-
-  const compareTreesByBranchOrder = (left, right) => {
-    const leftIndex = treePathOrder.get(left.path) ?? Number.MAX_SAFE_INTEGER;
-    const rightIndex = treePathOrder.get(right.path) ?? Number.MAX_SAFE_INTEGER;
-    if (leftIndex !== rightIndex) {
-      return leftIndex - rightIndex;
-    }
-    return left.path.localeCompare(right.path, "ko-KR");
-  };
-
-  const prepareTreesInput = () => {
-    if (!treeRuntime) {
-      throw new Error("Tree runtime is not loaded");
-    }
-    treePathOrder = new Map(navigation.view.trees.paths.map((treePath, index) => [treePath, index]));
-    return treeRuntime.prepareFileTreeInput(navigation.view.trees.paths, { sort: compareTreesByBranchOrder });
-  };
-
-  const renderTreeRowDecoration = ({ item }) => {
-    const metadata = navigation.view.trees.metadataByTreePath.get(item.path);
-    if (metadata?.kind !== "file" || metadata.isNew !== true) {
-      return null;
-    }
-
-    return {
-      text: "NEW",
-      title: "New document",
-    };
-  };
-
-  const renderTreeContextMenu = (item, context) => {
-    const route = navigation.view.trees.treePathToRoute.get(item.path);
-    if (!route) {
-      return null;
-    }
-
-    const menu = document.createElement("div");
-    menu.className = "tree-context-menu";
-    Object.assign(menu.style, {
-      background: "var(--trees-bg-override, canvas)",
-      border: "1px solid var(--trees-border-color-override, color-mix(in srgb, currentColor 18%, transparent))",
-      borderRadius: "6px",
-      boxShadow: "0 10px 24px rgba(0, 0, 0, 0.18)",
-      minWidth: "120px",
-      padding: "4px",
-    });
-
-    const link = document.createElement("a");
-    link.className = "tree-context-link";
-    link.href = toPathWithBase(route, pathBase);
-    link.textContent = "Open";
-    Object.assign(link.style, {
-      borderRadius: "4px",
-      color: "inherit",
-      display: "block",
-      padding: "6px 8px",
-      textDecoration: "none",
-    });
-    link.addEventListener("click", (event) => {
-      if (event.defaultPrevented || event.button !== 0 || event.metaKey || event.ctrlKey || event.shiftKey || event.altKey) {
-        return;
-      }
-      event.preventDefault();
-      context.close();
-      void contentController?.navigate(route, true);
-    });
-
-    menu.appendChild(link);
-    return menu;
-  };
-
-  const renderTree = () => {
-    if (!(treeRoot instanceof HTMLElement) || !treeRuntime) {
-      return;
-    }
-
-    if (fileTree && renderedTreeBranch !== navigation.activeBranch) {
-      destroyFileTree();
-    }
-
-    const preparedInput = prepareTreesInput();
-    const selectedTreePath = navigation.currentDocId
-      ? navigation.view.trees.docIdToPrimaryTreePath.get(navigation.currentDocId)
-      : null;
-
-    if (!fileTree) {
-      treeRoot.replaceChildren();
-      fileTree = new treeRuntime.FileTree({
-        composition: {
-          contextMenu: {
-            enabled: true,
-            render: renderTreeContextMenu,
-            triggerMode: "right-click",
-          },
-        },
-        fileTreeSearchMode: "hide-non-matches",
-        flattenEmptyDirectories: false,
-        icons: "minimal",
-        initialExpansion: 1,
-        initialSelectedPaths: selectedTreePath ? [selectedTreePath] : [],
-        itemHeight: 38,
-        onSelectionChange(selectedPaths) {
-          if (isSyncingTreeSelection) {
-            return;
-          }
-
-          const selectedPath = selectedPaths.at(-1);
-          const route = selectedPath ? navigation.view.trees.treePathToRoute.get(selectedPath) : null;
-          if (!route) {
-            window.queueMicrotask(() => syncActiveTreeSelection(navigation.currentDocId, { scroll: false }));
-            return;
-          }
-
-          void contentController?.navigate(route, true);
-        },
-        preparedInput,
-        renderRowDecoration: renderTreeRowDecoration,
-        sort: compareTreesByBranchOrder,
-        search: true,
-        searchBlurBehavior: "retain",
-        stickyFolders: true,
-        unsafeCSS: treeRuntime.TREE_UNSAFE_CSS,
-      });
-      fileTree.render({ containerWrapper: treeRoot });
-    } else {
-      isSyncingTreeSelection = true;
-      try {
-        fileTree.resetPaths(preparedInput.paths, { preparedInput });
-      } finally {
-        isSyncingTreeSelection = false;
-      }
-    }
-
-    renderedTreeBranch = navigation.activeBranch;
-    syncActiveTreeSelection(navigation.currentDocId || "");
-    applyTreeSearch(treeSearchValue);
-    setupTreeLabelDecorations(treeRoot, navigation.view.trees.metadataByTreePath);
-  };
-
-  const renderTreeLoadingState = () => {
-    if (!(treeRoot instanceof HTMLElement) || fileTree) {
-      return;
-    }
-    const status = document.createElement("p");
-    status.className = "tree-load-status";
-    status.setAttribute("role", "status");
-    status.textContent = "문서 탐색기를 불러오는 중입니다.";
-    treeRoot.replaceChildren(status);
-  };
-
-  const renderTreeFallback = (error) => {
-    if (!(treeRoot instanceof HTMLElement)) {
-      return;
-    }
-
-    const fallback = document.createElement("section");
-    fallback.className = "tree-load-fallback";
-    fallback.setAttribute("aria-label", "간이 문서 탐색기");
-
-    const message = document.createElement("p");
-    message.className = "tree-load-fallback-message";
-    message.setAttribute("role", "alert");
-    message.textContent = "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.";
-
-    const retry = document.createElement("button");
-    retry.className = "tree-load-retry";
-    retry.type = "button";
-    retry.textContent = "탐색기 다시 불러오기";
-    retry.addEventListener("click", () => {
-      void requestTreeLoad("retry", { retry: true });
-    });
-
-    const links = document.createElement("ul");
-    links.className = "tree-load-fallback-links";
-    for (const doc of navigation.view.docs) {
-      const item = document.createElement("li");
-      const link = document.createElement("a");
-      link.href = toPathWithBase(doc.route, pathBase);
-      link.textContent = doc.title;
-      link.addEventListener("click", (event) => {
-        if (
-          event.defaultPrevented ||
-          event.button !== 0 ||
-          event.metaKey ||
-          event.ctrlKey ||
-          event.shiftKey ||
-          event.altKey
-        ) {
-          return;
-        }
-        event.preventDefault();
-        void contentController?.navigate(doc.route, true);
-      });
-      item.appendChild(link);
-      links.appendChild(item);
-    }
-
-    fallback.append(message, retry, links);
-    fallback.dataset.error = error instanceof Error ? error.name : "TreeLoadError";
-    treeRoot.replaceChildren(fallback);
-  };
-
-  const loadTreeRuntime = ({ reason, retry = false }) => {
-    if (treeRuntime) {
-      renderTree();
-      return Promise.resolve(true);
-    }
-    if (treeLoadPromise) {
-      return treeLoadPromise;
-    }
-    if (!treeModuleUrl) {
-      const error = new Error("Tree module URL is unavailable");
-      setTreeRuntimeState("error");
-      renderTreeFallback(error);
-      return Promise.resolve(false);
-    }
-
-    const importUrl = new URL(treeModuleUrl);
-    if (retry) {
-      treeRetryCount += 1;
-      importUrl.searchParams.set("retry", String(treeRetryCount));
-    }
-
-    setTreeRuntimeState("loading");
-    if (treeRoot instanceof HTMLElement) {
-      treeRoot.setAttribute("aria-busy", "true");
-      treeRoot.dataset.treeLoadReason = reason;
-    }
-    renderTreeLoadingState();
-    window.performance?.mark?.("eiam-tree-load-start");
-
-    treeLoadPromise = import(importUrl.href)
-      .then((module) => {
-        if (
-          typeof module.FileTree !== "function" ||
-          typeof module.prepareFileTreeInput !== "function" ||
-          typeof module.TREE_UNSAFE_CSS !== "string"
-        ) {
-          throw new Error("Tree runtime exports are invalid");
-        }
-        treeRuntime = module;
-        renderTree();
-        if (treeRoot instanceof HTMLElement) {
-          treeRoot.setAttribute("aria-busy", "false");
-        }
-        setTreeRuntimeState("ready");
-        window.performance?.mark?.("eiam-tree-ready");
-        return true;
-      })
-      .catch((error) => {
-        destroyFileTree();
-        treeRuntime = null;
-        treeLoadPromise = null;
-        if (treeRoot instanceof HTMLElement) {
-          treeRoot.setAttribute("aria-busy", "false");
-        }
-        setTreeRuntimeState("error");
-        renderTreeFallback(error);
-        announceA11yStatus("문서 트리를 불러오지 못했습니다. 간이 링크 탐색기를 사용할 수 있습니다.");
-        console.error("Tree runtime load failed:", error);
-        return false;
-      });
-
-    return treeLoadPromise;
-  };
-
-  contentController = createContentController({
+  const contentController = createContentController({
     navigation,
-    elements: {
-      breadcrumb: breadcrumbEl,
-      title: titleEl,
-      meta: metaEl,
-      content: contentEl,
-      backlinks: backlinksEl,
-      nav: navEl,
-      viewer: viewerEl,
-    },
-    initialViewData,
-    pathBase,
-    siteTitle,
+    elements,
+    initialViewData: bootstrap.initialViewData,
+    pathBase: bootstrap.pathBase,
+    siteTitle: bootstrap.siteTitle,
     renderers: {
       breadcrumb: renderBreadcrumb,
       meta: renderMeta,
       backlinks: renderBacklinks,
-      nav: (currentView, docId, base) => renderNav(currentView.docs, currentView.docIndexById, docId, base),
+      nav: renderNav,
       documentTitle: composeDocumentTitle,
     },
     lifecycle: {
       beforeNavigate() {
-        if (isCompactLayout()) {
-          closeSidebar();
+        if (layoutController.isCompact()) {
+          layoutController.close();
         }
       },
       onBranchChange(branch) {
-        updateBranchInfo();
-        if (treeRuntime) {
-          renderTree();
-        }
-        localStorage.setItem(BRANCH_KEY, branch);
+        treeController?.handleBranchChange(branch);
       },
       onCurrentDocChange(docId) {
-        syncActiveTreeSelection(docId);
+        treeController?.syncActiveSelection(docId);
       },
-      onMissingSelection: clearTreeSelection,
-      async enhanceContent(target) {
-        enhanceContentImages(target);
-        await renderMermaidBlocks(mermaidConfig);
+      onMissingSelection() {
+        treeController?.clearSelection();
       },
-      announce: announceA11yStatus,
-      resolveLocationRoute(pathname) {
-        return resolveRouteFromLocation(pathBase, pathname);
-      },
+      enhanceContent: (target) => enhancementController.enhance(target),
+      announce: (message) => announcer.announce(message),
+      resolveLocationRoute: (pathname) => resolveRouteFromLocation(bootstrap.pathBase, pathname),
     },
   });
+
+  treeController = createTreeController({
+    navigation,
+    pathBase: bootstrap.pathBase,
+    treeModuleUrl: bootstrap.treeModuleUrl,
+    navigate: (route, push) => contentController.navigate(route, push),
+    announce: (message) => announcer.announce(message),
+    isCompactLayout: () => layoutController.isCompact(),
+  });
+
+  const controllers = [
+    settingsController,
+    layoutController,
+    treeController,
+    enhancementController,
+    contentController,
+    announcer,
+  ];
+  settingsController.setup();
+  enhancementController.setup();
+  treeController.setup();
+  layoutController.setup();
   contentController.setup();
 
-  requestTreeLoad = (reason, options = {}) => {
-    if (!treeLoadAllowed) {
-      pendingTreeLoadReason = reason;
-      return Promise.resolve(false);
-    }
-    pendingTreeLoadReason = "";
-    return loadTreeRuntime({ reason, retry: options.retry === true });
-  };
-
-  const scheduleTreeLoadAfterFirstContentPaint = () => {
-    window.requestAnimationFrame(() => {
-      window.requestAnimationFrame(() => {
-        treeLoadAllowed = true;
-        window.performance?.mark?.("eiam-first-content-paint-opportunity");
-
-        if (pendingTreeLoadReason) {
-          void requestTreeLoad(pendingTreeLoadReason);
-          return;
-        }
-        if (isCompactLayout()) {
-          return;
-        }
-
-        const loadForDesktop = () => {
-          void requestTreeLoad("desktop-idle");
-        };
-        if (typeof window.requestIdleCallback === "function") {
-          window.requestIdleCallback(loadForDesktop, { timeout: 500 });
-        } else {
-          window.setTimeout(loadForDesktop, 0);
-        }
-      });
-    });
-  };
-
-  if (contentEl instanceof HTMLElement) {
-    contentEl.addEventListener("click", async (event) => {
-      const target = event.target;
-      if (!(target instanceof Element)) {
-        return;
-      }
-
-      const button = target.closest(".code-copy");
-      if (!(button instanceof HTMLButtonElement) || !contentEl.contains(button)) {
-        return;
-      }
-
-      const code = button.dataset.code;
-      if (!code) {
-        return;
-      }
-
-      try {
-        await navigator.clipboard.writeText(code);
-        button.classList.add("copied");
-        const icon = button.querySelector(".material-symbols-outlined");
-        if (icon instanceof HTMLElement) {
-          icon.textContent = "check";
-        }
-        setTimeout(() => {
-          button.classList.remove("copied");
-          const nextIcon = button.querySelector(".material-symbols-outlined");
-          if (nextIcon instanceof HTMLElement) {
-            nextIcon.textContent = "content_copy";
-          }
-        }, 2000);
-      } catch (err) {
-        console.error("Copy failed:", err);
-      }
-    });
+  try {
+    const currentRoute = resolveRouteFromLocation(bootstrap.pathBase);
+    const initialRoute = currentRoute === "/" ? pickHomeRoute(navigation.view) : currentRoute;
+    await contentController.navigate(initialRoute, currentRoute === "/" && initialRoute !== "/");
+    setRuntimeState(APP_READY_STATE_ATTR, "ready");
+    window.performance?.mark?.("eiam-app-ready");
+    treeController.scheduleDeferredLoad();
+    installPageLifecycle(controllers, contentController);
+  } catch (error) {
+    destroyControllers(controllers);
+    throw error;
   }
-
-  const setActiveBranch = async (nextBranch) => {
-    if (!navigation.setActiveBranch(nextBranch)) {
-      return;
-    }
-
-    localStorage.setItem(BRANCH_KEY, navigation.activeBranch);
-    updateBranchInfo();
-    void requestTreeLoad("branch");
-
-    const currentRoute = resolveRouteFromLocation(pathBase);
-    if (navigation.view.routeMap[currentRoute]) {
-      await contentController.navigate(currentRoute, false);
-      return;
-    }
-
-    const fallbackRoute = pickHomeRoute(navigation.view);
-    await contentController.navigate(fallbackRoute, true);
-  };
-
-  renderBranchPills();
-  updateBranchInfo();
-
-  const currentRoute = resolveRouteFromLocation(pathBase);
-  const initialRoute = currentRoute === "/" ? pickHomeRoute(navigation.view) : currentRoute;
-  handleLayoutChange();
-  await contentController.navigate(initialRoute, currentRoute === "/" && initialRoute !== "/");
-  setAppReadyState("ready");
-  window.performance?.mark?.("eiam-app-ready");
-  scheduleTreeLoadAfterFirstContentPaint();
-
-  window.addEventListener("pagehide", () => contentController?.destroy());
-  window.addEventListener("pageshow", (event) => {
-    if (event.persisted) {
-      contentController?.setup();
-    }
-  });
 }
 
 start().catch((error) => {
-  setAppReadyState("error");
-
-  const contentEl = document.getElementById("viewer-content");
-  if (contentEl) {
+  setRuntimeState(APP_READY_STATE_ATTR, "error");
+  const content = document.getElementById("viewer-content");
+  if (content) {
     const message = error instanceof Error ? error.message : String(error);
-    contentEl.innerHTML = "";
+    content.replaceChildren();
     const placeholder = document.createElement("p");
     placeholder.className = "placeholder";
     placeholder.textContent = `초기화 실패: ${message}`;
-    contentEl.appendChild(placeholder);
+    content.appendChild(placeholder);
   }
   console.error(error);
 });

--- a/src/runtime/content-enhancement-controller.js
+++ b/src/runtime/content-enhancement-controller.js
@@ -1,0 +1,244 @@
+import { createEventScope } from "./controller-lifecycle.js";
+
+const CONTENT_IMAGE_LANDSCAPE_CLASS = "is-landscape";
+const CONTENT_IMAGE_PORTRAIT_CLASS = "is-portrait";
+const CONTENT_IMAGE_SQUARE_CLASS = "is-square";
+const CONTENT_IMAGE_LANDSCAPE_THRESHOLD = 1.1;
+const CONTENT_IMAGE_PORTRAIT_THRESHOLD = 0.9;
+const contentImageDimensionCache = new Map();
+
+function clearContentImageClasses(target) {
+  target?.classList?.remove(
+    CONTENT_IMAGE_LANDSCAPE_CLASS,
+    CONTENT_IMAGE_PORTRAIT_CLASS,
+    CONTENT_IMAGE_SQUARE_CLASS,
+  );
+}
+
+function syncContentImageClasses(image, className, windowRef) {
+  if (!(image instanceof windowRef.HTMLImageElement)) {
+    return;
+  }
+
+  clearContentImageClasses(image);
+  image.classList.add(className);
+
+  const figure = image.closest("figure");
+  if (
+    figure instanceof windowRef.HTMLElement &&
+    (figure.classList.contains("content-image") || figure.classList.contains("image-frame"))
+  ) {
+    clearContentImageClasses(figure);
+    figure.classList.add(className);
+  }
+}
+
+function readIntrinsicImageDimensions(imageLike, windowRef) {
+  if (!(imageLike instanceof windowRef.HTMLImageElement)) {
+    return null;
+  }
+
+  const width =
+    imageLike.naturalWidth > 0
+      ? imageLike.naturalWidth
+      : Number.parseFloat(imageLike.getAttribute("width") ?? "");
+  const height =
+    imageLike.naturalHeight > 0
+      ? imageLike.naturalHeight
+      : Number.parseFloat(imageLike.getAttribute("height") ?? "");
+
+  if (!(width > 0) || !(height > 0)) {
+    return null;
+  }
+
+  return { width, height };
+}
+
+function classifyContentImageByDimensions(image, dimensions, windowRef) {
+  if (!(image instanceof windowRef.HTMLImageElement) || !dimensions) {
+    return;
+  }
+
+  const aspectRatio = dimensions.width / dimensions.height;
+  if (aspectRatio >= CONTENT_IMAGE_LANDSCAPE_THRESHOLD) {
+    syncContentImageClasses(image, CONTENT_IMAGE_LANDSCAPE_CLASS, windowRef);
+    return;
+  }
+
+  if (aspectRatio <= CONTENT_IMAGE_PORTRAIT_THRESHOLD) {
+    syncContentImageClasses(image, CONTENT_IMAGE_PORTRAIT_CLASS, windowRef);
+    return;
+  }
+
+  syncContentImageClasses(image, CONTENT_IMAGE_SQUARE_CLASS, windowRef);
+}
+
+function resolveContentImageDimensions(image, windowRef) {
+  const immediate = readIntrinsicImageDimensions(image, windowRef);
+  if (immediate) {
+    return Promise.resolve(immediate);
+  }
+
+  const source = image.currentSrc || image.getAttribute("src") || "";
+  if (!source) {
+    return Promise.resolve(null);
+  }
+
+  const cached = contentImageDimensionCache.get(source);
+  if (cached) {
+    return cached;
+  }
+
+  const pending = new Promise((resolve) => {
+    const probe = new windowRef.Image();
+    const finalize = () => {
+      resolve(readIntrinsicImageDimensions(probe, windowRef));
+    };
+
+    probe.addEventListener("load", finalize, { once: true });
+    probe.addEventListener("error", () => resolve(null), { once: true });
+    probe.src = source;
+
+    if (probe.complete) {
+      if (typeof probe.decode === "function") {
+        probe.decode().then(finalize).catch(finalize);
+      } else {
+        finalize();
+      }
+    }
+  });
+
+  contentImageDimensionCache.set(source, pending);
+  return pending;
+}
+
+function prepareContentImage(image, windowRef) {
+  if (!(image instanceof windowRef.HTMLImageElement) || image.closest(".mermaid-block")) {
+    return;
+  }
+
+  const figure = image.closest("figure");
+  if (
+    figure instanceof windowRef.HTMLElement &&
+    (figure.classList.contains("content-image") || figure.classList.contains("image-frame"))
+  ) {
+    clearContentImageClasses(figure);
+  }
+  clearContentImageClasses(image);
+
+  const handleError = () => {
+    clearContentImageClasses(image);
+    if (
+      figure instanceof windowRef.HTMLElement &&
+      (figure.classList.contains("content-image") || figure.classList.contains("image-frame"))
+    ) {
+      clearContentImageClasses(figure);
+    }
+  };
+  const handleLoad = () => {
+    resolveContentImageDimensions(image, windowRef)
+      .then((dimensions) => {
+        if (!dimensions) {
+          handleError();
+          return;
+        }
+        classifyContentImageByDimensions(image, dimensions, windowRef);
+      })
+      .catch(handleError);
+  };
+
+  image.addEventListener("load", handleLoad, { once: true });
+  image.addEventListener("error", handleError, { once: true });
+
+  if (image.complete) {
+    handleLoad();
+  }
+}
+
+export function enhanceContentImages(root, windowRef = globalThis.window) {
+  if (!root?.querySelectorAll) {
+    return;
+  }
+
+  for (const image of root.querySelectorAll("img")) {
+    prepareContentImage(image, windowRef);
+  }
+}
+
+export function createContentEnhancementController(options) {
+  const {
+    root,
+    mermaidController,
+    clipboard = globalThis.navigator?.clipboard,
+    windowRef = globalThis.window,
+  } = options;
+  let events = null;
+  const resetTimers = new Set();
+
+  const handleCopyClick = async (event) => {
+    const target = event.target;
+    if (!(target instanceof windowRef.Element)) {
+      return;
+    }
+
+    const button = target.closest(".code-copy");
+    if (!(button instanceof windowRef.HTMLButtonElement) || !root?.contains(button)) {
+      return;
+    }
+
+    const code = button.dataset.code;
+    if (!code) {
+      return;
+    }
+
+    try {
+      if (typeof clipboard?.writeText !== "function") {
+        throw new Error("Clipboard API is unavailable");
+      }
+      await clipboard.writeText(code);
+      button.classList.add("copied");
+      const icon = button.querySelector(".material-symbols-outlined");
+      if (icon instanceof windowRef.HTMLElement) {
+        icon.textContent = "check";
+      }
+      const timer = windowRef.setTimeout(() => {
+        resetTimers.delete(timer);
+        button.classList.remove("copied");
+        const nextIcon = button.querySelector(".material-symbols-outlined");
+        if (nextIcon instanceof windowRef.HTMLElement) {
+          nextIcon.textContent = "content_copy";
+        }
+      }, 2000);
+      resetTimers.add(timer);
+    } catch (error) {
+      console.error("Copy failed:", error);
+    }
+  };
+
+  return {
+    setup() {
+      if (events) {
+        return;
+      }
+      events = createEventScope();
+      events.listen(root, "click", handleCopyClick);
+      mermaidController.setup();
+    },
+    destroy() {
+      if (!events) {
+        return;
+      }
+      events.cleanup();
+      events = null;
+      for (const timer of resetTimers) {
+        windowRef.clearTimeout(timer);
+      }
+      resetTimers.clear();
+      mermaidController.destroy();
+    },
+    async enhance(target = root) {
+      enhanceContentImages(target, windowRef);
+      await mermaidController.render(target);
+    },
+  };
+}

--- a/src/runtime/controller-lifecycle.js
+++ b/src/runtime/controller-lifecycle.js
@@ -1,0 +1,26 @@
+export function createEventScope() {
+  const subscriptions = [];
+
+  return {
+    listen(target, type, listener, options) {
+      if (!target?.addEventListener || !target?.removeEventListener) {
+        return;
+      }
+      target.addEventListener(type, listener, options);
+      subscriptions.push({ target, type, listener, options });
+    },
+    cleanup() {
+      while (subscriptions.length > 0) {
+        const subscription = subscriptions.pop();
+        subscription.target.removeEventListener(
+          subscription.type,
+          subscription.listener,
+          subscription.options,
+        );
+      }
+    },
+    get size() {
+      return subscriptions.length;
+    },
+  };
+}

--- a/src/runtime/mermaid-controller.js
+++ b/src/runtime/mermaid-controller.js
@@ -1,0 +1,316 @@
+const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
+const MERMAID_DEFAULT_THEME = "default";
+const MERMAID_SELECTOR = "pre.mermaid";
+const MERMAID_ERROR_CLASS = "mermaid-render-error";
+const MERMAID_THEME_VALIDATION_RE = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
+const MERMAID_URL_VALIDATION_RE = /^(https?:\/\/|\/|\.{1,2}\/)[^\s"'<>]+$/;
+const MERMAID_WIDE_RATIO = 2.4;
+const MERMAID_TALL_RATIO = 0.85;
+const MERMAID_BLOCK_WIDE_CLASS = "is-wide";
+const MERMAID_BLOCK_TALL_CLASS = "is-tall";
+
+const mermaidRuntime = {
+  initialized: false,
+  loadingPromise: null,
+  scriptElement: null,
+  lastCdnUrl: "",
+  lastTheme: "",
+};
+
+export function resolveMermaidConfig(manifest) {
+  const mermaid = manifest?.mermaid;
+  return {
+    enabled: mermaid?.enabled !== false,
+    cdnUrl:
+      typeof mermaid?.cdnUrl === "string" && mermaid.cdnUrl.trim()
+        ? mermaid.cdnUrl.trim()
+        : MERMAID_CDN,
+    theme:
+      typeof mermaid?.theme === "string" &&
+      MERMAID_THEME_VALIDATION_RE.test(mermaid.theme.trim())
+        ? mermaid.theme.trim()
+        : MERMAID_DEFAULT_THEME,
+  };
+}
+
+function normalizeMermaidTheme(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized || !MERMAID_THEME_VALIDATION_RE.test(normalized)) {
+    return MERMAID_DEFAULT_THEME;
+  }
+  return normalized;
+}
+
+function normalizeMermaidUrl(value) {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  if (!normalized || !MERMAID_URL_VALIDATION_RE.test(normalized)) {
+    return MERMAID_CDN;
+  }
+  return normalized;
+}
+
+function toAbsoluteUrl(value, windowRef) {
+  try {
+    return new URL(value, windowRef.location.href).href;
+  } catch {
+    return value;
+  }
+}
+
+function createMermaidLoadError(message, documentRef) {
+  const paragraph = documentRef.createElement("p");
+  paragraph.className = MERMAID_ERROR_CLASS;
+  paragraph.textContent = message;
+  return paragraph;
+}
+
+function removeMermaidErrorMessage(container) {
+  if (!container?.querySelectorAll) {
+    return;
+  }
+
+  for (const message of container.querySelectorAll(`.${MERMAID_ERROR_CLASS}`)) {
+    message.remove();
+  }
+}
+
+function showMermaidError(preview, message, documentRef) {
+  const container = preview?.parentElement;
+  if (!container?.appendChild) {
+    return;
+  }
+
+  removeMermaidErrorMessage(container);
+  container.appendChild(createMermaidLoadError(message, documentRef));
+}
+
+function normalizeRenderedMermaidSvg(block, windowRef) {
+  const container = block?.parentElement;
+  const svg = block?.querySelector?.("svg");
+  if (!(svg instanceof windowRef.SVGElement)) {
+    return;
+  }
+
+  container?.classList?.remove(MERMAID_BLOCK_WIDE_CLASS, MERMAID_BLOCK_TALL_CLASS);
+
+  svg.style.display = "block";
+  svg.style.width = "auto";
+  svg.style.height = "auto";
+  svg.style.margin = "0 auto";
+  svg.style.maxWidth = "min(100%, var(--content-visual-max-width, 880px))";
+  svg.style.removeProperty("max-height");
+
+  const viewBox = svg.viewBox?.baseVal;
+  const intrinsicWidth =
+    viewBox && Number.isFinite(viewBox.width) && viewBox.width > 0
+      ? viewBox.width
+      : Number.parseFloat(svg.getAttribute("width") ?? "");
+  const intrinsicHeight =
+    viewBox && Number.isFinite(viewBox.height) && viewBox.height > 0
+      ? viewBox.height
+      : Number.parseFloat(svg.getAttribute("height") ?? "");
+
+  if (!(intrinsicWidth > 0) || !(intrinsicHeight > 0)) {
+    return;
+  }
+
+  const aspectRatio = intrinsicWidth / intrinsicHeight;
+  if (container && aspectRatio >= MERMAID_WIDE_RATIO) {
+    container.classList.add(MERMAID_BLOCK_WIDE_CLASS);
+    svg.style.maxWidth = "min(100%, var(--mermaid-wide-max-width, 820px))";
+  }
+
+  if (container && aspectRatio <= MERMAID_TALL_RATIO) {
+    container.classList.add(MERMAID_BLOCK_TALL_CLASS);
+    svg.style.maxHeight = "min(var(--mermaid-tall-max-height, 560px), 68vh)";
+  }
+}
+
+function resetMermaidNodes(nodes) {
+  for (const node of nodes) {
+    node.removeAttribute("data-mermaid-rendered");
+    if (node.parentElement) {
+      node.parentElement.classList.remove(MERMAID_BLOCK_WIDE_CLASS, MERMAID_BLOCK_TALL_CLASS);
+      removeMermaidErrorMessage(node.parentElement);
+    }
+  }
+}
+
+async function loadMermaidLibrary(config, { documentRef, windowRef }) {
+  if (!config.enabled) {
+    return null;
+  }
+
+  const normalized = {
+    ...config,
+    theme: normalizeMermaidTheme(config.theme),
+    cdnUrl: normalizeMermaidUrl(config.cdnUrl),
+  };
+
+  if (windowRef.mermaid) {
+    if (!mermaidRuntime.initialized || mermaidRuntime.lastTheme !== normalized.theme) {
+      windowRef.mermaid.initialize({
+        startOnLoad: false,
+        theme: normalized.theme,
+      });
+      mermaidRuntime.initialized = true;
+      mermaidRuntime.lastTheme = normalized.theme;
+    }
+    return windowRef.mermaid;
+  }
+
+  if (mermaidRuntime.loadingPromise) {
+    return mermaidRuntime.loadingPromise;
+  }
+
+  const expectedAbsoluteUrl = toAbsoluteUrl(normalized.cdnUrl, windowRef);
+  const existingScript = documentRef.getElementById("mermaid-runtime");
+  if (existingScript instanceof windowRef.HTMLScriptElement) {
+    existingScript.remove();
+    mermaidRuntime.scriptElement = null;
+    mermaidRuntime.initialized = false;
+    mermaidRuntime.lastTheme = "";
+    mermaidRuntime.lastCdnUrl = "";
+  }
+
+  mermaidRuntime.loadingPromise = new Promise((resolve, reject) => {
+    let script = mermaidRuntime.scriptElement;
+    if (!(script instanceof windowRef.HTMLScriptElement)) {
+      script = documentRef.createElement("script");
+      script.id = "mermaid-runtime";
+      script.src = normalized.cdnUrl;
+      script.async = true;
+      script.crossOrigin = "anonymous";
+      mermaidRuntime.scriptElement = script;
+      mermaidRuntime.lastCdnUrl = expectedAbsoluteUrl;
+    }
+
+    const finalize = (error) => {
+      mermaidRuntime.loadingPromise = null;
+      if (error) {
+        if (mermaidRuntime.scriptElement instanceof windowRef.HTMLScriptElement) {
+          mermaidRuntime.scriptElement.remove();
+          mermaidRuntime.scriptElement = null;
+        }
+        mermaidRuntime.initialized = false;
+        mermaidRuntime.lastTheme = "";
+        mermaidRuntime.lastCdnUrl = "";
+        reject(error);
+        return;
+      }
+      resolve(windowRef.mermaid ?? null);
+    };
+
+    script.addEventListener("load", () => {
+      if (
+        windowRef.mermaid &&
+        (!mermaidRuntime.initialized || mermaidRuntime.lastTheme !== normalized.theme)
+      ) {
+        windowRef.mermaid.initialize({
+          startOnLoad: false,
+          theme: normalized.theme,
+        });
+        mermaidRuntime.initialized = true;
+        mermaidRuntime.lastTheme = normalized.theme;
+      }
+      finalize();
+    });
+    script.addEventListener("error", () => {
+      finalize(new Error(`Mermaid 라이브러리 로드 실패: ${normalized.cdnUrl}`));
+    });
+
+    if (!script.isConnected) {
+      documentRef.head.appendChild(script);
+    }
+  });
+
+  return mermaidRuntime.loadingPromise;
+}
+
+export function createMermaidController(config, options = {}) {
+  const documentRef = options.documentRef ?? globalThis.document;
+  const windowRef = options.windowRef ?? globalThis.window;
+  let isSetup = false;
+  let lifecycleGeneration = 0;
+
+  return {
+    setup() {
+      if (isSetup) {
+        return;
+      }
+      isSetup = true;
+      lifecycleGeneration += 1;
+    },
+    destroy() {
+      if (!isSetup) {
+        return;
+      }
+      isSetup = false;
+      lifecycleGeneration += 1;
+    },
+    async render(root) {
+      if (!isSetup || !root?.querySelectorAll) {
+        return;
+      }
+
+      const renderGeneration = lifecycleGeneration;
+      const blocks = Array.from(root.querySelectorAll(MERMAID_SELECTOR));
+      if (blocks.length === 0) {
+        return;
+      }
+
+      resetMermaidNodes(blocks);
+
+      try {
+        const mermaid = await loadMermaidLibrary(config, { documentRef, windowRef });
+        if (!isSetup || renderGeneration !== lifecycleGeneration) {
+          return;
+        }
+        if (!mermaid) {
+          for (const block of blocks) {
+            showMermaidError(
+              block,
+              "Mermaid 렌더링이 비활성화되어 코드 블록을 그대로 표시합니다.",
+              documentRef,
+            );
+          }
+          return;
+        }
+
+        for (const block of blocks) {
+          if (!isSetup || renderGeneration !== lifecycleGeneration) {
+            return;
+          }
+          try {
+            if (typeof mermaid.run === "function") {
+              await mermaid.run({ nodes: [block] });
+              normalizeRenderedMermaidSvg(block, windowRef);
+              continue;
+            }
+            if (typeof mermaid.init === "function") {
+              await mermaid.init({ startOnLoad: false }, [block]);
+              normalizeRenderedMermaidSvg(block, windowRef);
+              continue;
+            }
+            throw new Error("Mermaid 렌더러 API가 존재하지 않습니다.");
+          } catch (error) {
+            const message = `Mermaid 렌더링 실패: ${
+              error instanceof Error ? error.message : String(error)
+            }`;
+            showMermaidError(block, message, documentRef);
+          }
+        }
+      } catch (error) {
+        if (!isSetup || renderGeneration !== lifecycleGeneration) {
+          return;
+        }
+        const message = `Mermaid 렌더링 실패: ${
+          error instanceof Error ? error.message : String(error)
+        }`;
+        for (const block of blocks) {
+          showMermaidError(block, message, documentRef);
+        }
+      }
+    },
+  };
+}

--- a/src/runtime/runtime-bootstrap.js
+++ b/src/runtime/runtime-bootstrap.js
@@ -1,0 +1,102 @@
+import { normalizeManifestPayload } from "./manifest-adapter.js";
+import {
+  normalizePathBase,
+  normalizeRoute,
+  stripPathBase,
+  toPathWithBase,
+} from "./navigation-state.js";
+
+const DEFAULT_SITE_TITLE = "File-System Blog";
+
+export function loadInitialViewData(documentRef = globalThis.document) {
+  const script = documentRef.getElementById("initial-view-data");
+  const raw = script?.textContent;
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    const route = typeof parsed.route === "string" ? normalizeRoute(parsed.route) : null;
+    const docId = typeof parsed.docId === "string" ? parsed.docId : null;
+    const title = typeof parsed.title === "string" ? parsed.title : null;
+    return route && docId && title ? { route, docId, title } : null;
+  } catch {
+    return null;
+  }
+}
+
+export function loadInitialRuntimeData(options = {}) {
+  const documentRef = options.documentRef ?? globalThis.document;
+  const windowRef = options.windowRef ?? globalThis.window;
+  const script = documentRef.getElementById("initial-runtime-data");
+  const raw = script?.textContent;
+  if (!raw) {
+    return null;
+  }
+
+  try {
+    const parsed = JSON.parse(raw);
+    if (!parsed || typeof parsed !== "object") {
+      return null;
+    }
+    const pathBase = normalizePathBase(parsed.pathBase);
+    const manifestUrl = typeof parsed.manifestUrl === "string" ? parsed.manifestUrl : "";
+    const treeModuleUrl = typeof parsed.treeModuleUrl === "string" ? parsed.treeModuleUrl : "";
+    if (!manifestUrl || manifestUrl !== toPathWithBase("/manifest.json", pathBase)) {
+      return null;
+    }
+
+    let resolvedTreeModuleUrl;
+    try {
+      resolvedTreeModuleUrl = new URL(treeModuleUrl, documentRef.baseURI);
+    } catch {
+      return null;
+    }
+    const treeModulePath = stripPathBase(resolvedTreeModuleUrl.pathname, pathBase);
+    if (
+      resolvedTreeModuleUrl.origin !== windowRef.location.origin ||
+      !/^\/assets\/tree\.[a-f0-9]{12}\.js$/.test(treeModulePath)
+    ) {
+      return null;
+    }
+    return { manifestUrl, pathBase, treeModuleUrl: resolvedTreeModuleUrl.href };
+  } catch {
+    return null;
+  }
+}
+
+export function resolveSiteTitle(manifest) {
+  const value = typeof manifest?.siteTitle === "string" ? manifest.siteTitle.trim() : "";
+  return value || DEFAULT_SITE_TITLE;
+}
+
+export async function loadRuntimeBootstrap(options = {}) {
+  const documentRef = options.documentRef ?? globalThis.document;
+  const windowRef = options.windowRef ?? globalThis.window;
+  const fetchManifest = options.fetchManifest ?? ((url) => globalThis.fetch(url));
+  const initialViewData = loadInitialViewData(documentRef);
+  const initialRuntimeData = loadInitialRuntimeData({ documentRef, windowRef });
+  const initialPathBase = normalizePathBase(initialRuntimeData?.pathBase);
+  const manifestUrl =
+    initialRuntimeData?.manifestUrl ?? toPathWithBase("/manifest.json", initialPathBase);
+  const response = await fetchManifest(manifestUrl);
+  if (!response.ok) {
+    throw new Error(`Failed to load manifest: ${response.status}`);
+  }
+  const manifest = normalizeManifestPayload(await response.json());
+  if (!manifest) {
+    throw new Error("Failed to load a supported manifest schema");
+  }
+
+  return {
+    initialViewData,
+    manifest,
+    pathBase: normalizePathBase(manifest.pathBase),
+    siteTitle: resolveSiteTitle(manifest),
+    treeModuleUrl: initialRuntimeData?.treeModuleUrl ?? "",
+  };
+}

--- a/src/runtime/settings-controller.js
+++ b/src/runtime/settings-controller.js
@@ -1,0 +1,168 @@
+import { createEventScope } from "./controller-lifecycle.js";
+
+const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
+const THEME_MODE_KEY = "fsblog.themeMode";
+const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
+
+export function normalizeThemeMode(mode) {
+  if (mode === "light" || mode === "dark" || mode === "system") {
+    return mode;
+  }
+  return "system";
+}
+
+export function resolveAppliedTheme(mode, prefersDark) {
+  if (mode === "system") {
+    return prefersDark ? "dark" : "light";
+  }
+  return mode;
+}
+
+export function createSettingsController(options = {}) {
+  const documentRef = options.documentRef ?? globalThis.document;
+  const windowRef = options.windowRef ?? globalThis.window;
+  const storage = options.storage ?? globalThis.localStorage;
+  const settingsToggle = documentRef.getElementById("settings-toggle");
+  const settingsClose = documentRef.getElementById("settings-close");
+  const settingsPanel = documentRef.getElementById("sidebar-settings");
+  const menuTogglePositionInputs = Array.from(
+    documentRef.querySelectorAll('input[name="menu-toggle-position"]'),
+  );
+  const themeModeInputs = Array.from(documentRef.querySelectorAll('input[name="theme-mode"]'));
+  const darkModeMediaQuery = windowRef.matchMedia(DARK_MODE_QUERY);
+  let events = null;
+  let themeMode = "system";
+
+  const setSettingsExpanded = (expanded) => {
+    settingsToggle?.setAttribute("aria-expanded", String(expanded));
+  };
+
+  const close = () => {
+    if (!settingsPanel || settingsPanel.hidden) {
+      return;
+    }
+    settingsPanel.hidden = true;
+    setSettingsExpanded(false);
+  };
+
+  const open = () => {
+    if (!settingsPanel) {
+      return;
+    }
+    settingsPanel.hidden = false;
+    setSettingsExpanded(true);
+    const checkedInput = settingsPanel.querySelector(
+      'input[name="theme-mode"]:checked, input[name="menu-toggle-position"]:checked',
+    );
+    checkedInput?.focus?.();
+  };
+
+  const toggle = () => {
+    if (!settingsPanel) {
+      return;
+    }
+    if (settingsPanel.hidden) {
+      open();
+    } else {
+      close();
+    }
+  };
+
+  const applyMenuTogglePosition = (position) => {
+    documentRef.body?.classList.toggle("mobile-toggle-left", position === "left");
+  };
+
+  const applyTheme = () => {
+    const appliedTheme = resolveAppliedTheme(themeMode, darkModeMediaQuery.matches);
+    documentRef.documentElement.dataset.theme = appliedTheme;
+    documentRef.documentElement.style.colorScheme = appliedTheme;
+  };
+
+  const handleMenuTogglePositionChange = (event) => {
+    const input = event.currentTarget;
+    if (!(input instanceof windowRef.HTMLInputElement) || !input.checked) {
+      return;
+    }
+    const nextPosition = input.value === "left" ? "left" : "right";
+    applyMenuTogglePosition(nextPosition);
+    storage.setItem(MENU_TOGGLE_POSITION_KEY, nextPosition);
+  };
+
+  const handleThemeModeChange = (event) => {
+    const input = event.currentTarget;
+    if (!(input instanceof windowRef.HTMLInputElement) || !input.checked) {
+      return;
+    }
+    themeMode = normalizeThemeMode(input.value);
+    applyTheme();
+    storage.setItem(THEME_MODE_KEY, themeMode);
+  };
+
+  const handleDarkModeChange = () => {
+    if (themeMode === "system") {
+      applyTheme();
+    }
+  };
+
+  const handleOutsideClick = (event) => {
+    if (!settingsPanel || settingsPanel.hidden) {
+      return;
+    }
+    const target = event.target;
+    if (!(target instanceof windowRef.Node)) {
+      return;
+    }
+    const clickInPanel = settingsPanel.contains(target);
+    const clickOnToggle = settingsToggle?.contains?.(target) ?? false;
+    if (!clickInPanel && !clickOnToggle) {
+      close();
+    }
+  };
+
+  return {
+    close,
+    destroy() {
+      if (!events) {
+        return;
+      }
+      close();
+      events.cleanup();
+      events = null;
+    },
+    setup() {
+      if (events) {
+        return;
+      }
+
+      const savedTogglePosition = storage.getItem(MENU_TOGGLE_POSITION_KEY) === "left"
+        ? "left"
+        : "right";
+      themeMode = normalizeThemeMode(storage.getItem(THEME_MODE_KEY));
+      applyMenuTogglePosition(savedTogglePosition);
+      applyTheme();
+
+      for (const input of menuTogglePositionInputs) {
+        if (input instanceof windowRef.HTMLInputElement) {
+          input.checked = input.value === savedTogglePosition;
+        }
+      }
+      for (const input of themeModeInputs) {
+        if (input instanceof windowRef.HTMLInputElement) {
+          input.checked = input.value === themeMode;
+        }
+      }
+
+      events = createEventScope();
+      events.listen(settingsToggle, "click", toggle);
+      events.listen(settingsClose, "click", close);
+      events.listen(documentRef, "click", handleOutsideClick);
+      events.listen(darkModeMediaQuery, "change", handleDarkModeChange);
+      for (const input of menuTogglePositionInputs) {
+        events.listen(input, "change", handleMenuTogglePositionChange);
+      }
+      for (const input of themeModeInputs) {
+        events.listen(input, "change", handleThemeModeChange);
+      }
+    },
+  };
+}

--- a/src/runtime/sidebar-layout-controller.js
+++ b/src/runtime/sidebar-layout-controller.js
@@ -1,0 +1,342 @@
+import { createEventScope } from "./controller-lifecycle.js";
+
+const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
+const SIDEBAR_WIDTH_KEY = "fsblog.desktopSidebarWidth";
+const DESKTOP_SIDEBAR_DEFAULT = 420;
+const DESKTOP_SIDEBAR_MIN = 320;
+const DESKTOP_VIEWER_MIN = 680;
+const DESKTOP_SPLITTER_WIDTH = 10;
+const DESKTOP_SPLITTER_STEP = 24;
+const FOCUSABLE_SELECTOR =
+  'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
+
+function getFocusableElements(container, windowRef) {
+  if (!container) {
+    return [];
+  }
+
+  const candidates = [];
+  const collect = (root) => {
+    for (const element of root.querySelectorAll("*")) {
+      if (!(element instanceof windowRef.HTMLElement)) {
+        continue;
+      }
+      if (element.matches(FOCUSABLE_SELECTOR)) {
+        candidates.push(element);
+      }
+      if (element.shadowRoot) {
+        collect(element.shadowRoot);
+      }
+    }
+  };
+  collect(container);
+
+  return candidates.filter((element) => {
+    if (element.hasAttribute("hidden") || element.getAttribute("aria-hidden") === "true") {
+      return false;
+    }
+    if (element.closest("[hidden], [inert], [aria-hidden='true']")) {
+      return false;
+    }
+    if (element instanceof windowRef.HTMLInputElement && element.type === "hidden") {
+      return false;
+    }
+    const style = windowRef.getComputedStyle(element);
+    if (style.display === "none" || style.visibility === "hidden") {
+      return false;
+    }
+    return element.getClientRects().length > 0;
+  });
+}
+
+export function clampDesktopSidebarWidth(width, viewportWidth) {
+  const max = Math.max(
+    DESKTOP_SIDEBAR_MIN,
+    viewportWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
+  );
+  return Math.min(Math.max(width, DESKTOP_SIDEBAR_MIN), max);
+}
+
+export function createSidebarLayoutController(options = {}) {
+  const documentRef = options.documentRef ?? globalThis.document;
+  const windowRef = options.windowRef ?? globalThis.window;
+  const storage = options.storage ?? globalThis.localStorage;
+  const requestTreeLoad = options.requestTreeLoad ?? (() => Promise.resolve(false));
+  const closeSettings = options.closeSettings ?? (() => {});
+  const appRoot = documentRef.querySelector(".app-root");
+  const splitter = documentRef.getElementById("app-splitter");
+  const sidebar = documentRef.getElementById("sidebar-panel");
+  const sidebarToggle = documentRef.getElementById("sidebar-toggle");
+  const sidebarClose = documentRef.getElementById("sidebar-close");
+  const sidebarOverlay = documentRef.getElementById("sidebar-overlay");
+  const viewer = documentRef.querySelector(".viewer");
+  const compactMediaQuery = windowRef.matchMedia(COMPACT_LAYOUT_QUERY);
+  let events = null;
+  let desktopSidebarWidth = DESKTOP_SIDEBAR_DEFAULT;
+  let activeResizePointerId = null;
+  let resizeStartX = 0;
+  let resizeStartWidth = desktopSidebarWidth;
+
+  const isCompact = () => compactMediaQuery.matches;
+
+  const updateSplitterA11y = () => {
+    if (!(splitter instanceof windowRef.HTMLElement)) {
+      return;
+    }
+    const max = Math.max(
+      DESKTOP_SIDEBAR_MIN,
+      windowRef.innerWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
+    );
+    splitter.setAttribute("aria-valuemin", String(DESKTOP_SIDEBAR_MIN));
+    splitter.setAttribute("aria-valuemax", String(Math.round(max)));
+    splitter.setAttribute("aria-valuenow", String(Math.round(desktopSidebarWidth)));
+    splitter.setAttribute("aria-valuetext", `${Math.round(desktopSidebarWidth)}px`);
+    splitter.setAttribute("aria-disabled", String(isCompact()));
+  };
+
+  const syncDesktopSidebarWidth = (persist) => {
+    desktopSidebarWidth = clampDesktopSidebarWidth(desktopSidebarWidth, windowRef.innerWidth);
+    if (appRoot instanceof windowRef.HTMLElement) {
+      if (isCompact()) {
+        appRoot.style.removeProperty("--sidebar-width");
+      } else {
+        appRoot.style.setProperty("--sidebar-width", `${Math.round(desktopSidebarWidth)}px`);
+      }
+    }
+    updateSplitterA11y();
+    if (persist) {
+      storage.setItem(SIDEBAR_WIDTH_KEY, String(Math.round(desktopSidebarWidth)));
+    }
+  };
+
+  const setViewerInteractiveState = (isInteractive) => {
+    if (!(viewer instanceof windowRef.HTMLElement)) {
+      return;
+    }
+    if (isInteractive) {
+      viewer.removeAttribute("inert");
+      viewer.removeAttribute("aria-hidden");
+    } else {
+      viewer.setAttribute("inert", "");
+      viewer.setAttribute("aria-hidden", "true");
+    }
+  };
+
+  const syncSidebarA11y = (isOpen) => {
+    sidebarToggle?.setAttribute("aria-expanded", String(isOpen));
+    sidebarOverlay?.setAttribute("aria-hidden", String(!isOpen));
+
+    if (!(sidebar instanceof windowRef.HTMLElement)) {
+      setViewerInteractiveState(true);
+      return;
+    }
+    if (!isCompact()) {
+      sidebar.removeAttribute("inert");
+      sidebar.removeAttribute("aria-hidden");
+      sidebar.removeAttribute("aria-modal");
+      sidebar.setAttribute("role", "complementary");
+      setViewerInteractiveState(true);
+      return;
+    }
+    if (isOpen) {
+      sidebar.removeAttribute("inert");
+      sidebar.removeAttribute("aria-hidden");
+      sidebar.setAttribute("role", "dialog");
+      sidebar.setAttribute("aria-modal", "true");
+      setViewerInteractiveState(false);
+    } else {
+      sidebar.setAttribute("inert", "");
+      sidebar.setAttribute("aria-hidden", "true");
+      sidebar.removeAttribute("aria-modal");
+      sidebar.setAttribute("role", "complementary");
+      setViewerInteractiveState(true);
+    }
+  };
+
+  const open = () => {
+    if (!(appRoot instanceof windowRef.HTMLElement) || !isCompact()) {
+      return;
+    }
+    appRoot.classList.add("sidebar-open");
+    if (sidebarOverlay) {
+      sidebarOverlay.hidden = false;
+    }
+    documentRef.body.classList.add("menu-open");
+    syncSidebarA11y(true);
+    void requestTreeLoad("mobile-sidebar");
+    getFocusableElements(sidebar, windowRef)[0]?.focus();
+  };
+
+  const close = () => {
+    if (!(appRoot instanceof windowRef.HTMLElement)) {
+      return;
+    }
+    appRoot.classList.remove("sidebar-open");
+    if (sidebarOverlay) {
+      sidebarOverlay.hidden = true;
+    }
+    closeSettings();
+    documentRef.body.classList.remove("menu-open");
+    syncSidebarA11y(false);
+    if (sidebarToggle?.focus && isCompact()) {
+      sidebarToggle.focus();
+    }
+  };
+
+  const syncLayout = (requestDesktopTreeLoad) => {
+    close();
+    if (!isCompact()) {
+      if (sidebarOverlay) {
+        sidebarOverlay.hidden = true;
+      }
+      syncSidebarA11y(false);
+      syncDesktopSidebarWidth(false);
+      if (requestDesktopTreeLoad) {
+        void requestTreeLoad("desktop-layout");
+      }
+      return;
+    }
+    syncDesktopSidebarWidth(false);
+  };
+
+  const handleLayoutChange = () => {
+    syncLayout(true);
+  };
+
+  const beginSplitterResize = (event) => {
+    if (
+      !(splitter instanceof windowRef.HTMLElement) ||
+      !(appRoot instanceof windowRef.HTMLElement) ||
+      isCompact()
+    ) {
+      return;
+    }
+    if (event.pointerType === "mouse" && event.button !== 0) {
+      return;
+    }
+    event.preventDefault();
+    activeResizePointerId = event.pointerId;
+    resizeStartX = event.clientX;
+    resizeStartWidth = desktopSidebarWidth;
+    appRoot.classList.add("is-resizing");
+    splitter.setPointerCapture(event.pointerId);
+  };
+
+  const updateSplitterResize = (event) => {
+    if (event.pointerId !== activeResizePointerId) {
+      return;
+    }
+    desktopSidebarWidth = resizeStartWidth + event.clientX - resizeStartX;
+    syncDesktopSidebarWidth(false);
+  };
+
+  const endSplitterResize = (event) => {
+    if (event.pointerId !== activeResizePointerId) {
+      return;
+    }
+    if (splitter?.hasPointerCapture?.(event.pointerId)) {
+      splitter.releasePointerCapture(event.pointerId);
+    }
+    appRoot?.classList?.remove("is-resizing");
+    activeResizePointerId = null;
+    syncDesktopSidebarWidth(true);
+  };
+
+  const handleSplitterKeydown = (event) => {
+    if (isCompact()) {
+      return;
+    }
+    const max = Math.max(
+      DESKTOP_SIDEBAR_MIN,
+      windowRef.innerWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
+    );
+    let nextWidth = desktopSidebarWidth;
+    if (event.key === "ArrowLeft") {
+      nextWidth -= DESKTOP_SPLITTER_STEP;
+    } else if (event.key === "ArrowRight") {
+      nextWidth += DESKTOP_SPLITTER_STEP;
+    } else if (event.key === "Home") {
+      nextWidth = DESKTOP_SIDEBAR_MIN;
+    } else if (event.key === "End") {
+      nextWidth = max;
+    } else {
+      return;
+    }
+    event.preventDefault();
+    desktopSidebarWidth = nextWidth;
+    syncDesktopSidebarWidth(true);
+  };
+
+  const handleDocumentKeydown = (event) => {
+    if (event.key === "Escape" && appRoot?.classList?.contains("sidebar-open")) {
+      close();
+      return;
+    }
+    if (
+      event.key !== "Tab" ||
+      !isCompact() ||
+      !appRoot?.classList?.contains("sidebar-open")
+    ) {
+      return;
+    }
+
+    const focusables = getFocusableElements(sidebar, windowRef);
+    if (focusables.length === 0) {
+      event.preventDefault();
+      return;
+    }
+    const first = focusables[0];
+    const last = focusables[focusables.length - 1];
+    const activeElement = documentRef.activeElement;
+    const activeInsideSidebar = activeElement instanceof windowRef.Node && sidebar?.contains(activeElement);
+    if (!activeInsideSidebar) {
+      event.preventDefault();
+      first.focus();
+    } else if (event.shiftKey && activeElement === first) {
+      event.preventDefault();
+      last.focus();
+    } else if (!event.shiftKey && activeElement === last) {
+      event.preventDefault();
+      first.focus();
+    }
+  };
+
+  return {
+    close,
+    destroy() {
+      if (!events) {
+        return;
+      }
+      close();
+      events.cleanup();
+      events = null;
+      if (activeResizePointerId != null && splitter?.hasPointerCapture?.(activeResizePointerId)) {
+        splitter.releasePointerCapture(activeResizePointerId);
+      }
+      appRoot?.classList?.remove("is-resizing");
+      activeResizePointerId = null;
+    },
+    isCompact,
+    open,
+    setup() {
+      if (events) {
+        return;
+      }
+      const storedWidth = Number.parseInt(storage.getItem(SIDEBAR_WIDTH_KEY) ?? "", 10);
+      desktopSidebarWidth = Number.isFinite(storedWidth) ? storedWidth : DESKTOP_SIDEBAR_DEFAULT;
+      events = createEventScope();
+      events.listen(sidebarToggle, "click", open);
+      events.listen(sidebarClose, "click", close);
+      events.listen(sidebarOverlay, "click", close);
+      events.listen(splitter, "pointerdown", beginSplitterResize);
+      events.listen(splitter, "pointermove", updateSplitterResize);
+      events.listen(splitter, "pointerup", endSplitterResize);
+      events.listen(splitter, "pointercancel", endSplitterResize);
+      events.listen(splitter, "keydown", handleSplitterKeydown);
+      events.listen(windowRef, "resize", () => syncDesktopSidebarWidth(false));
+      events.listen(compactMediaQuery, "change", handleLayoutChange);
+      events.listen(documentRef, "keydown", handleDocumentKeydown);
+      syncLayout(false);
+    },
+  };
+}

--- a/src/runtime/tree-controller.js
+++ b/src/runtime/tree-controller.js
@@ -1,0 +1,724 @@
+import { createEventScope } from "./controller-lifecycle.js";
+import { pickHomeRoute, resolveRouteFromLocation, toPathWithBase } from "./navigation-state.js";
+
+const BRANCH_KEY = "fsblog.branch";
+const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
+
+function normalizeTreeLabelText(value, fallback = "") {
+  const normalized = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
+  return normalized || fallback;
+}
+
+function getTreeLabelRenderRoot(host) {
+  return host?.shadowRoot || host || null;
+}
+
+function decorateTreeLabels(host, documentRef) {
+  const metadataByTreePath = host?.__eiamMetadataByTreePath;
+  if (!(metadataByTreePath instanceof Map)) {
+    return;
+  }
+
+  const renderRoot = getTreeLabelRenderRoot(host);
+  if (!renderRoot) {
+    return;
+  }
+
+  const rows = renderRoot.querySelectorAll(
+    "[data-type='item'][data-item-type='file'][data-item-path]",
+  );
+  for (const row of rows) {
+    const treePath = row.getAttribute("data-item-path") || "";
+    const metadata = metadataByTreePath.get(treePath);
+    if (!metadata || metadata.kind !== "file") {
+      continue;
+    }
+
+    const prefix = normalizeTreeLabelText(metadata.prefix);
+    const fallbackName = treePath.split("/").pop() || "";
+    const fallbackTitle =
+      prefix && fallbackName.startsWith(`${prefix} `)
+        ? fallbackName.slice(prefix.length).trimStart()
+        : fallbackName;
+    const title = normalizeTreeLabelText(metadata.title, fallbackTitle);
+    const labelKey = JSON.stringify([prefix, title]);
+    const content = row.querySelector("[data-item-section='content']");
+    if (!content || content.dataset.eiamTreeLabel === labelKey) {
+      continue;
+    }
+
+    content.dataset.eiamTreeLabel = labelKey;
+    content.textContent = "";
+    const label = documentRef.createElement("span");
+    label.className = "tree-item-label";
+    if (prefix) {
+      const prefixBadge = documentRef.createElement("span");
+      prefixBadge.className = "tree-item-prefix-badge";
+      prefixBadge.textContent = prefix;
+      label.appendChild(prefixBadge);
+    }
+    const titleText = documentRef.createElement("span");
+    titleText.className = "tree-item-title";
+    titleText.textContent = title;
+    label.appendChild(titleText);
+    content.appendChild(label);
+    row.setAttribute("title", prefix ? `${prefix} ${title}` : title);
+  }
+}
+
+function queueTreeLabelDecoration(host, documentRef, windowRef) {
+  if (!host) {
+    return;
+  }
+  if (host.__eiamTreeLabelFrame) {
+    windowRef.cancelAnimationFrame(host.__eiamTreeLabelFrame);
+  }
+  host.__eiamTreeLabelFrame = windowRef.requestAnimationFrame(() => {
+    host.__eiamTreeLabelFrame = 0;
+    decorateTreeLabels(host, documentRef);
+  });
+}
+
+function setupTreeLabelDecorations(host, metadataByTreePath, documentRef, windowRef) {
+  if (!host) {
+    return;
+  }
+  host.__eiamMetadataByTreePath = metadataByTreePath;
+  const renderRoot = getTreeLabelRenderRoot(host);
+  if (!renderRoot) {
+    return;
+  }
+  if (host.__eiamTreeLabelObservedRoot !== renderRoot) {
+    host.__eiamTreeLabelObserver?.disconnect();
+    host.__eiamTreeLabelObservedRoot = renderRoot;
+    host.__eiamTreeLabelObserver = new windowRef.MutationObserver(() => {
+      queueTreeLabelDecoration(host, documentRef, windowRef);
+    });
+    host.__eiamTreeLabelObserver.observe(renderRoot, { childList: true, subtree: true });
+  }
+  queueTreeLabelDecoration(host, documentRef, windowRef);
+}
+
+function cleanupTreeLabelDecorations(host, windowRef) {
+  if (!host) {
+    return;
+  }
+  if (host.__eiamTreeLabelFrame) {
+    windowRef.cancelAnimationFrame(host.__eiamTreeLabelFrame);
+    host.__eiamTreeLabelFrame = 0;
+  }
+  host.__eiamTreeLabelObserver?.disconnect();
+  delete host.__eiamTreeLabelObserver;
+  delete host.__eiamTreeLabelObservedRoot;
+  delete host.__eiamMetadataByTreePath;
+}
+
+export function createTreeController(options) {
+  const {
+    navigation,
+    pathBase,
+    treeModuleUrl,
+    navigate,
+    announce = () => {},
+    isCompactLayout = () => false,
+    documentRef = globalThis.document,
+    windowRef = globalThis.window,
+    storage = globalThis.localStorage,
+  } = options;
+  const treeRoot = documentRef.getElementById("tree-root");
+  const treeSearchInput = documentRef.getElementById("tree-search-input");
+  const treeSearchClear = documentRef.getElementById("tree-search-clear");
+  const treeSearchPrev = documentRef.getElementById("tree-search-prev");
+  const treeSearchNext = documentRef.getElementById("tree-search-next");
+  const treeSearchCount = documentRef.getElementById("tree-search-count");
+  const sidebarBranchPills = documentRef.getElementById("sidebar-branch-pills");
+  const sidebarBranchInfo = documentRef.getElementById("sidebar-branch-info");
+  let events = null;
+  let fileTree = null;
+  let isSyncingTreeSelection = false;
+  let treePathOrder = new Map();
+  let treeSearchValue = "";
+  let renderedTreeBranch = "";
+  let treeRuntime = null;
+  let treeLoadPromise = null;
+  let treeRetryCount = 0;
+  let treeLoadAllowed = false;
+  let pendingTreeLoadReason = "";
+  let lifecycleGeneration = 0;
+  let deferredFrame = null;
+  let paintFrame = null;
+  let idleHandle = null;
+  let idleFallbackTimer = null;
+
+  const setTreeRuntimeState = (state) => {
+    documentRef.documentElement?.setAttribute(TREE_RUNTIME_STATE_ATTR, state);
+  };
+
+  const renderBranchPills = () => {
+    if (!sidebarBranchPills) {
+      return;
+    }
+    sidebarBranchPills.replaceChildren();
+    for (const branch of navigation.availableBranches) {
+      const pill = documentRef.createElement("button");
+      pill.type = "button";
+      pill.className = "branch-pill";
+      pill.dataset.branch = branch;
+      pill.textContent = branch;
+      pill.setAttribute("aria-pressed", "false");
+      sidebarBranchPills.appendChild(pill);
+    }
+  };
+
+  const updateBranchInfo = () => {
+    if (sidebarBranchInfo) {
+      sidebarBranchInfo.textContent =
+        navigation.activeBranch === navigation.defaultBranch
+          ? `publish: true · ${navigation.activeBranch} + unclassified`
+          : `publish: true · ${navigation.activeBranch} only`;
+    }
+    for (const pill of sidebarBranchPills?.querySelectorAll(".branch-pill") ?? []) {
+      const isActive = pill.dataset.branch === navigation.activeBranch;
+      pill.classList.toggle("is-active", isActive);
+      pill.setAttribute("aria-pressed", String(isActive));
+    }
+  };
+
+  const updateTreeSearchControls = () => {
+    const normalizedSearchValue = fileTree ? fileTree.getSearchValue() : treeSearchValue.trim();
+    const hasSearch = normalizedSearchValue.length > 0;
+    const matchCount = hasSearch && fileTree ? fileTree.getSearchMatchingPaths().length : 0;
+    const canStep = hasSearch && matchCount > 0;
+    if (treeSearchClear) {
+      treeSearchClear.hidden = !hasSearch;
+      treeSearchClear.disabled = !hasSearch;
+    }
+    for (const button of [treeSearchPrev, treeSearchNext]) {
+      if (button) {
+        button.disabled = !canStep;
+      }
+    }
+    if (treeSearchCount) {
+      treeSearchCount.textContent = hasSearch ? `${matchCount}개 일치` : "";
+    }
+  };
+
+  const applyTreeSearch = (value) => {
+    treeSearchValue = value;
+    if (treeSearchInput && treeSearchInput.value !== value) {
+      treeSearchInput.value = value;
+    }
+    if (fileTree) {
+      const query = value.trim();
+      if (query) {
+        if (fileTree.isSearchOpen()) {
+          fileTree.setSearch(query);
+        } else {
+          fileTree.openSearch(query);
+        }
+      } else {
+        fileTree.closeSearch();
+      }
+    }
+    updateTreeSearchControls();
+  };
+
+  const moveTreeSearchFocus = (direction) => {
+    if (!fileTree || !fileTree.isSearchOpen() || fileTree.getSearchMatchingPaths().length === 0) {
+      return;
+    }
+    if (direction < 0) {
+      fileTree.focusPreviousSearchMatch();
+    } else {
+      fileTree.focusNextSearchMatch();
+    }
+    updateTreeSearchControls();
+  };
+
+  const syncActiveSelection = (docId, { scroll = true } = {}) => {
+    if (!fileTree || !docId) {
+      return;
+    }
+    const treePath = navigation.view.trees.docIdToPrimaryTreePath.get(docId);
+    if (!treePath) {
+      return;
+    }
+    const selectedPaths = fileTree.getSelectedPaths();
+    if (selectedPaths.length === 1 && selectedPaths[0] === treePath) {
+      return;
+    }
+    const item = fileTree.getItem(treePath);
+    if (!item) {
+      return;
+    }
+    isSyncingTreeSelection = true;
+    try {
+      item.select();
+    } finally {
+      isSyncingTreeSelection = false;
+    }
+    if (scroll) {
+      fileTree.scrollToPath(treePath, { focus: false, offset: "nearest" });
+    }
+  };
+
+  const clearSelection = () => {
+    if (!fileTree) {
+      return;
+    }
+    const selectedPaths = fileTree.getSelectedPaths();
+    if (selectedPaths.length === 0) {
+      return;
+    }
+    isSyncingTreeSelection = true;
+    try {
+      for (const selectedPath of selectedPaths) {
+        fileTree.getItem(selectedPath)?.deselect();
+      }
+    } finally {
+      isSyncingTreeSelection = false;
+    }
+  };
+
+  const destroyFileTree = () => {
+    const host = treeRoot?.querySelector("file-tree-container");
+    cleanupTreeLabelDecorations(host, windowRef);
+    fileTree?.cleanUp?.();
+    fileTree = null;
+    renderedTreeBranch = "";
+    host?.remove();
+  };
+
+  const compareTreesByBranchOrder = (left, right) => {
+    const leftIndex = treePathOrder.get(left.path) ?? Number.MAX_SAFE_INTEGER;
+    const rightIndex = treePathOrder.get(right.path) ?? Number.MAX_SAFE_INTEGER;
+    if (leftIndex !== rightIndex) {
+      return leftIndex - rightIndex;
+    }
+    return left.path.localeCompare(right.path, "ko-KR");
+  };
+
+  const prepareTreesInput = () => {
+    if (!treeRuntime) {
+      throw new Error("Tree runtime is not loaded");
+    }
+    treePathOrder = new Map(
+      navigation.view.trees.paths.map((treePath, index) => [treePath, index]),
+    );
+    return treeRuntime.prepareFileTreeInput(navigation.view.trees.paths, {
+      sort: compareTreesByBranchOrder,
+    });
+  };
+
+  const renderTreeRowDecoration = ({ item }) => {
+    const metadata = navigation.view.trees.metadataByTreePath.get(item.path);
+    if (metadata?.kind !== "file" || metadata.isNew !== true) {
+      return null;
+    }
+    return { text: "NEW", title: "New document" };
+  };
+
+  const renderTreeContextMenu = (item, context) => {
+    const route = navigation.view.trees.treePathToRoute.get(item.path);
+    if (!route) {
+      return null;
+    }
+    const menu = documentRef.createElement("div");
+    menu.className = "tree-context-menu";
+    Object.assign(menu.style, {
+      background: "var(--trees-bg-override, canvas)",
+      border:
+        "1px solid var(--trees-border-color-override, color-mix(in srgb, currentColor 18%, transparent))",
+      borderRadius: "6px",
+      boxShadow: "0 10px 24px rgba(0, 0, 0, 0.18)",
+      minWidth: "120px",
+      padding: "4px",
+    });
+    const link = documentRef.createElement("a");
+    link.className = "tree-context-link";
+    link.href = toPathWithBase(route, pathBase);
+    link.textContent = "Open";
+    Object.assign(link.style, {
+      borderRadius: "4px",
+      color: "inherit",
+      display: "block",
+      padding: "6px 8px",
+      textDecoration: "none",
+    });
+    link.addEventListener("click", (event) => {
+      if (
+        event.defaultPrevented ||
+        event.button !== 0 ||
+        event.metaKey ||
+        event.ctrlKey ||
+        event.shiftKey ||
+        event.altKey
+      ) {
+        return;
+      }
+      event.preventDefault();
+      context.close();
+      void navigate(route, true);
+    });
+    menu.appendChild(link);
+    return menu;
+  };
+
+  const renderTree = () => {
+    if (!treeRoot || !treeRuntime) {
+      return;
+    }
+    if (fileTree && renderedTreeBranch !== navigation.activeBranch) {
+      destroyFileTree();
+    }
+    const preparedInput = prepareTreesInput();
+    const selectedTreePath = navigation.currentDocId
+      ? navigation.view.trees.docIdToPrimaryTreePath.get(navigation.currentDocId)
+      : null;
+    if (!fileTree) {
+      treeRoot.replaceChildren();
+      fileTree = new treeRuntime.FileTree({
+        composition: {
+          contextMenu: {
+            enabled: true,
+            render: renderTreeContextMenu,
+            triggerMode: "right-click",
+          },
+        },
+        fileTreeSearchMode: "hide-non-matches",
+        flattenEmptyDirectories: false,
+        icons: "minimal",
+        initialExpansion: 1,
+        initialSelectedPaths: selectedTreePath ? [selectedTreePath] : [],
+        itemHeight: 38,
+        onSelectionChange(selectedPaths) {
+          if (isSyncingTreeSelection) {
+            return;
+          }
+          const selectedPath = selectedPaths.at(-1);
+          const route = selectedPath
+            ? navigation.view.trees.treePathToRoute.get(selectedPath)
+            : null;
+          if (!route) {
+            windowRef.queueMicrotask(() => {
+              syncActiveSelection(navigation.currentDocId, { scroll: false });
+            });
+            return;
+          }
+          void navigate(route, true);
+        },
+        preparedInput,
+        renderRowDecoration: renderTreeRowDecoration,
+        sort: compareTreesByBranchOrder,
+        search: true,
+        searchBlurBehavior: "retain",
+        stickyFolders: true,
+        unsafeCSS: treeRuntime.TREE_UNSAFE_CSS,
+      });
+      fileTree.render({ containerWrapper: treeRoot });
+    } else {
+      isSyncingTreeSelection = true;
+      try {
+        fileTree.resetPaths(preparedInput.paths, { preparedInput });
+      } finally {
+        isSyncingTreeSelection = false;
+      }
+    }
+    renderedTreeBranch = navigation.activeBranch;
+    syncActiveSelection(navigation.currentDocId || "");
+    applyTreeSearch(treeSearchValue);
+    setupTreeLabelDecorations(
+      treeRoot.querySelector("file-tree-container"),
+      navigation.view.trees.metadataByTreePath,
+      documentRef,
+      windowRef,
+    );
+  };
+
+  const renderTreeLoadingState = () => {
+    if (!treeRoot || fileTree) {
+      return;
+    }
+    const status = documentRef.createElement("p");
+    status.className = "tree-load-status";
+    status.setAttribute("role", "status");
+    status.textContent = "문서 탐색기를 불러오는 중입니다.";
+    treeRoot.replaceChildren(status);
+  };
+
+  const renderTreeFallback = (error) => {
+    if (!treeRoot) {
+      return;
+    }
+    const fallback = documentRef.createElement("section");
+    fallback.className = "tree-load-fallback";
+    fallback.setAttribute("aria-label", "간이 문서 탐색기");
+    const message = documentRef.createElement("p");
+    message.className = "tree-load-fallback-message";
+    message.setAttribute("role", "alert");
+    message.textContent =
+      "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.";
+    const retry = documentRef.createElement("button");
+    retry.className = "tree-load-retry";
+    retry.type = "button";
+    retry.textContent = "탐색기 다시 불러오기";
+    retry.addEventListener("click", () => {
+      void requestLoad("retry", { retry: true });
+    });
+    const links = documentRef.createElement("ul");
+    links.className = "tree-load-fallback-links";
+    for (const doc of navigation.view.docs) {
+      const item = documentRef.createElement("li");
+      const link = documentRef.createElement("a");
+      link.href = toPathWithBase(doc.route, pathBase);
+      link.textContent = doc.title;
+      link.addEventListener("click", (event) => {
+        if (
+          event.defaultPrevented ||
+          event.button !== 0 ||
+          event.metaKey ||
+          event.ctrlKey ||
+          event.shiftKey ||
+          event.altKey
+        ) {
+          return;
+        }
+        event.preventDefault();
+        void navigate(doc.route, true);
+      });
+      item.appendChild(link);
+      links.appendChild(item);
+    }
+    fallback.append(message, retry, links);
+    fallback.dataset.error = error instanceof Error ? error.name : "TreeLoadError";
+    treeRoot.replaceChildren(fallback);
+  };
+
+  function loadTreeRuntime({ reason, retry = false }) {
+    if (treeRuntime) {
+      renderTree();
+      return Promise.resolve(true);
+    }
+    if (treeLoadPromise) {
+      return treeLoadPromise;
+    }
+    if (!treeModuleUrl) {
+      const error = new Error("Tree module URL is unavailable");
+      setTreeRuntimeState("error");
+      renderTreeFallback(error);
+      return Promise.resolve(false);
+    }
+
+    const importUrl = new URL(treeModuleUrl);
+    if (retry) {
+      treeRetryCount += 1;
+      importUrl.searchParams.set("retry", String(treeRetryCount));
+    }
+    setTreeRuntimeState("loading");
+    if (treeRoot) {
+      treeRoot.setAttribute("aria-busy", "true");
+      treeRoot.dataset.treeLoadReason = reason;
+    }
+    renderTreeLoadingState();
+    windowRef.performance?.mark?.("eiam-tree-load-start");
+    const generationAtLoad = lifecycleGeneration;
+    const pending = import(importUrl.href)
+      .then((module) => {
+        if (!events || generationAtLoad !== lifecycleGeneration) {
+          return false;
+        }
+        if (
+          typeof module.FileTree !== "function" ||
+          typeof module.prepareFileTreeInput !== "function" ||
+          typeof module.TREE_UNSAFE_CSS !== "string"
+        ) {
+          throw new Error("Tree runtime exports are invalid");
+        }
+        treeRuntime = module;
+        renderTree();
+        treeRoot?.setAttribute("aria-busy", "false");
+        setTreeRuntimeState("ready");
+        windowRef.performance?.mark?.("eiam-tree-ready");
+        return true;
+      })
+      .catch((error) => {
+        if (!events || generationAtLoad !== lifecycleGeneration) {
+          return false;
+        }
+        destroyFileTree();
+        treeRuntime = null;
+        treeRoot?.setAttribute("aria-busy", "false");
+        setTreeRuntimeState("error");
+        renderTreeFallback(error);
+        announce("문서 트리를 불러오지 못했습니다. 간이 링크 탐색기를 사용할 수 있습니다.");
+        console.error("Tree runtime load failed:", error);
+        return false;
+      })
+      .finally(() => {
+        if (treeLoadPromise === pending) {
+          treeLoadPromise = null;
+        }
+      });
+    treeLoadPromise = pending;
+    return pending;
+  }
+
+  function requestLoad(reason, requestOptions = {}) {
+    if (!treeLoadAllowed) {
+      pendingTreeLoadReason = reason;
+      return Promise.resolve(false);
+    }
+    pendingTreeLoadReason = "";
+    return loadTreeRuntime({ reason, retry: requestOptions.retry === true });
+  }
+
+  const handleBranchChange = (branch) => {
+    storage.setItem(BRANCH_KEY, branch);
+    updateBranchInfo();
+    if (treeRuntime) {
+      renderTree();
+    }
+  };
+
+  const setActiveBranch = async (nextBranch) => {
+    if (!navigation.setActiveBranch(nextBranch)) {
+      return false;
+    }
+    handleBranchChange(navigation.activeBranch);
+    void requestLoad("branch");
+    const currentRoute = resolveRouteFromLocation(pathBase, windowRef.location.pathname);
+    if (navigation.view.routeMap[currentRoute]) {
+      await navigate(currentRoute, false);
+      return true;
+    }
+    await navigate(pickHomeRoute(navigation.view), true);
+    return true;
+  };
+
+  const handleBranchPillClick = (event) => {
+    const target = event.target;
+    if (!(target instanceof windowRef.Element)) {
+      return;
+    }
+    const pill = target.closest(".branch-pill");
+    if (!pill || !sidebarBranchPills?.contains(pill)) {
+      return;
+    }
+    void setActiveBranch(pill.dataset.branch);
+  };
+
+  const handleSearchFocus = () => {
+    void requestLoad("tree-search");
+  };
+  const handleSearchInput = () => {
+    applyTreeSearch(treeSearchInput.value);
+    void requestLoad("tree-search");
+  };
+  const handleSearchKeydown = (event) => {
+    if (event.key === "Enter") {
+      event.preventDefault();
+      moveTreeSearchFocus(event.shiftKey ? -1 : 1);
+    } else if (event.key === "Escape" && treeSearchInput.value.trim()) {
+      event.preventDefault();
+      event.stopPropagation();
+      applyTreeSearch("");
+    }
+  };
+
+  const cancelDeferredLoad = () => {
+    if (deferredFrame != null) {
+      windowRef.cancelAnimationFrame(deferredFrame);
+      deferredFrame = null;
+    }
+    if (paintFrame != null) {
+      windowRef.cancelAnimationFrame(paintFrame);
+      paintFrame = null;
+    }
+    if (idleHandle != null && typeof windowRef.cancelIdleCallback === "function") {
+      windowRef.cancelIdleCallback(idleHandle);
+      idleHandle = null;
+    }
+    if (idleFallbackTimer != null) {
+      windowRef.clearTimeout(idleFallbackTimer);
+      idleFallbackTimer = null;
+    }
+  };
+
+  const scheduleDeferredLoad = () => {
+    cancelDeferredLoad();
+    deferredFrame = windowRef.requestAnimationFrame(() => {
+      deferredFrame = null;
+      paintFrame = windowRef.requestAnimationFrame(() => {
+        paintFrame = null;
+        if (!events) {
+          return;
+        }
+        treeLoadAllowed = true;
+        windowRef.performance?.mark?.("eiam-first-content-paint-opportunity");
+        if (pendingTreeLoadReason) {
+          void requestLoad(pendingTreeLoadReason);
+          return;
+        }
+        if (isCompactLayout()) {
+          return;
+        }
+        const loadForDesktop = () => {
+          idleHandle = null;
+          idleFallbackTimer = null;
+          void requestLoad("desktop-idle");
+        };
+        if (typeof windowRef.requestIdleCallback === "function") {
+          idleHandle = windowRef.requestIdleCallback(loadForDesktop, { timeout: 500 });
+        } else {
+          idleFallbackTimer = windowRef.setTimeout(loadForDesktop, 0);
+        }
+      });
+    });
+  };
+
+  return {
+    clearSelection,
+    destroy() {
+      if (!events) {
+        return;
+      }
+      events.cleanup();
+      events = null;
+      lifecycleGeneration += 1;
+      cancelDeferredLoad();
+      destroyFileTree();
+      treeRoot?.replaceChildren();
+      treeRoot?.removeAttribute("aria-busy");
+      treeLoadPromise = null;
+      treeLoadAllowed = false;
+      pendingTreeLoadReason = "";
+    },
+    handleBranchChange,
+    requestLoad,
+    scheduleDeferredLoad,
+    setActiveBranch,
+    setup() {
+      if (events) {
+        return;
+      }
+      events = createEventScope();
+      events.listen(sidebarBranchPills, "click", handleBranchPillClick);
+      events.listen(treeSearchInput, "focus", handleSearchFocus);
+      events.listen(treeSearchInput, "input", handleSearchInput);
+      events.listen(treeSearchInput, "keydown", handleSearchKeydown);
+      events.listen(treeSearchClear, "click", () => {
+        applyTreeSearch("");
+        treeSearchInput?.focus?.();
+      });
+      events.listen(treeSearchPrev, "click", () => moveTreeSearchFocus(-1));
+      events.listen(treeSearchNext, "click", () => moveTreeSearchFocus(1));
+      renderBranchPills();
+      updateBranchInfo();
+      updateTreeSearchControls();
+      if (treeRuntime) {
+        renderTree();
+      }
+    },
+    syncActiveSelection,
+  };
+}

--- a/tests/e2e/runtime-controller-lifecycle.spec.ts
+++ b/tests/e2e/runtime-controller-lifecycle.spec.ts
@@ -1,0 +1,441 @@
+import { expect, test } from "@playwright/test";
+import { createContentEnhancementController } from "../../src/runtime/content-enhancement-controller.js";
+import { createEventScope } from "../../src/runtime/controller-lifecycle.js";
+import { createMermaidController, resolveMermaidConfig } from "../../src/runtime/mermaid-controller.js";
+import { loadInitialViewData } from "../../src/runtime/runtime-bootstrap.js";
+import {
+  createSettingsController,
+  normalizeThemeMode,
+  resolveAppliedTheme,
+} from "../../src/runtime/settings-controller.js";
+import {
+  clampDesktopSidebarWidth,
+  createSidebarLayoutController,
+} from "../../src/runtime/sidebar-layout-controller.js";
+import { createTreeController } from "../../src/runtime/tree-controller.js";
+
+type Listener = (event: Record<string, unknown>) => void;
+
+class FakeTarget {
+  listeners = new Map<string, Set<Listener>>();
+
+  addEventListener(type: string, listener: Listener) {
+    const listeners = this.listeners.get(type) ?? new Set<Listener>();
+    listeners.add(listener);
+    this.listeners.set(type, listeners);
+  }
+
+  removeEventListener(type: string, listener: Listener) {
+    this.listeners.get(type)?.delete(listener);
+  }
+
+  emit(type: string, init: Record<string, unknown> = {}) {
+    const event = {
+      target: this,
+      currentTarget: this,
+      preventDefault() {},
+      stopPropagation() {},
+      ...init,
+    };
+    for (const listener of this.listeners.get(type) ?? []) {
+      listener(event);
+    }
+  }
+
+  listenerCount(type: string) {
+    return this.listeners.get(type)?.size ?? 0;
+  }
+}
+
+class FakeClassList {
+  values = new Set<string>();
+
+  add(...values: string[]) {
+    for (const value of values) this.values.add(value);
+  }
+
+  remove(...values: string[]) {
+    for (const value of values) this.values.delete(value);
+  }
+
+  contains(value: string) {
+    return this.values.has(value);
+  }
+
+  toggle(value: string, force?: boolean) {
+    const enabled = force ?? !this.values.has(value);
+    if (enabled) this.values.add(value);
+    else this.values.delete(value);
+    return enabled;
+  }
+}
+
+class FakeElement extends FakeTarget {
+  attributes = new Map<string, string>();
+  children: FakeElement[] = [];
+  classList = new FakeClassList();
+  className = "";
+  dataset: Record<string, string> = {};
+  hidden = false;
+  parentElement: FakeElement | null = null;
+  shadowRoot = null;
+  style: Record<string, unknown> & {
+    setProperty(name: string, value: string): void;
+    removeProperty(name: string): void;
+  } = Object.assign(Object.create(null), {
+    setProperty(name: string, value: string) {
+      this[name] = value;
+    },
+    removeProperty(name: string) {
+      delete this[name];
+    },
+  });
+  textContent = "";
+  type = "";
+  value = "";
+  checked = false;
+  disabled = false;
+
+  appendChild(child: FakeElement) {
+    child.parentElement = this;
+    this.children.push(child);
+    return child;
+  }
+
+  append(...children: FakeElement[]) {
+    for (const child of children) this.appendChild(child);
+  }
+
+  replaceChildren(...children: FakeElement[]) {
+    this.children = [];
+    this.append(...children);
+  }
+
+  querySelectorAll(selector: string): FakeElement[] {
+    const descendants = this.children.flatMap((child) => [child, ...child.querySelectorAll("*")]);
+    if (selector === "*") return descendants;
+    if (selector === ".branch-pill") {
+      return descendants.filter((child) => child.className.split(/\s+/).includes("branch-pill"));
+    }
+    return [];
+  }
+
+  querySelector(selector: string) {
+    return this.querySelectorAll(selector)[0] ?? null;
+  }
+
+  contains(target: unknown): boolean {
+    return target === this || this.children.some((child) => child.contains(target));
+  }
+
+  setAttribute(name: string, value: string) {
+    this.attributes.set(name, value);
+  }
+
+  getAttribute(name: string) {
+    return this.attributes.get(name) ?? null;
+  }
+
+  removeAttribute(name: string) {
+    this.attributes.delete(name);
+  }
+
+  hasAttribute(name: string) {
+    return this.attributes.has(name);
+  }
+
+  closest() {
+    return null;
+  }
+
+  focus() {}
+
+  matches() {
+    return false;
+  }
+
+  getClientRects() {
+    return [{}];
+  }
+
+  remove() {
+    if (this.parentElement) {
+      this.parentElement.children = this.parentElement.children.filter((child) => child !== this);
+      this.parentElement = null;
+    }
+  }
+}
+
+class FakeInput extends FakeElement {}
+
+class FakeMediaQuery extends FakeTarget {
+  constructor(public matches: boolean) {
+    super();
+  }
+}
+
+class FakeStorage {
+  values = new Map<string, string>();
+
+  getItem(key: string) {
+    return this.values.get(key) ?? null;
+  }
+
+  setItem(key: string, value: string) {
+    this.values.set(key, value);
+  }
+}
+
+function createFakeWindow(mediaQueries = new Map<string, FakeMediaQuery>()) {
+  const target = new FakeTarget();
+  return Object.assign(target, {
+    Element: FakeElement,
+    HTMLElement: FakeElement,
+    HTMLButtonElement: FakeElement,
+    HTMLImageElement: FakeElement,
+    HTMLInputElement: FakeInput,
+    HTMLScriptElement: FakeElement,
+    Node: FakeElement,
+    SVGElement: FakeElement,
+    MutationObserver: class {
+      observe() {}
+      disconnect() {}
+    },
+    clearTimeout,
+    getComputedStyle: () => ({ display: "block", visibility: "visible" }),
+    innerWidth: 1440,
+    location: { href: "https://example.test/", origin: "https://example.test", pathname: "/" },
+    matchMedia: (query: string) => {
+      const mediaQuery = mediaQueries.get(query) ?? new FakeMediaQuery(false);
+      mediaQueries.set(query, mediaQuery);
+      return mediaQuery;
+    },
+    performance: { mark() {} },
+    queueMicrotask,
+    requestAnimationFrame: () => 1,
+    cancelAnimationFrame() {},
+    setTimeout,
+  });
+}
+
+function createFakeDocument() {
+  const target = new FakeTarget();
+  const elements = new Map<string, FakeElement>();
+  const body = new FakeElement();
+  const documentElement = new FakeElement();
+  const appRoot = new FakeElement();
+  const viewer = new FakeElement();
+  const inputs = {
+    menu: [Object.assign(new FakeInput(), { value: "left" }), Object.assign(new FakeInput(), { value: "right" })],
+    theme: [
+      Object.assign(new FakeInput(), { value: "system" }),
+      Object.assign(new FakeInput(), { value: "light" }),
+      Object.assign(new FakeInput(), { value: "dark" }),
+    ],
+  };
+  return Object.assign(target, {
+    activeElement: null,
+    baseURI: "https://example.test/",
+    body,
+    documentElement,
+    elements,
+    inputs,
+    register(id: string, element = new FakeElement()) {
+      elements.set(id, element);
+      return element;
+    },
+    createElement() {
+      return new FakeElement();
+    },
+    getElementById(id: string) {
+      return elements.get(id) ?? null;
+    },
+    querySelector(selector: string) {
+      if (selector === ".app-root") return appRoot;
+      if (selector === ".viewer") return viewer;
+      return null;
+    },
+    querySelectorAll(selector: string) {
+      if (selector === 'input[name="menu-toggle-position"]') return inputs.menu;
+      if (selector === 'input[name="theme-mode"]') return inputs.theme;
+      return [];
+    },
+  });
+}
+
+test.describe("runtime controller module contracts", () => {
+  test("event scope는 등록한 listener를 한 번에 정리한다", () => {
+    const target = new FakeTarget();
+    const listener = () => {};
+    const events = createEventScope();
+    events.listen(target, "click", listener);
+    events.listen(target, "keydown", listener);
+    expect(events.size).toBe(2);
+    expect(target.listenerCount("click")).toBe(1);
+
+    events.cleanup();
+    events.cleanup();
+    expect(events.size).toBe(0);
+    expect(target.listenerCount("click")).toBe(0);
+    expect(target.listenerCount("keydown")).toBe(0);
+  });
+
+  test("content enhancement controller setup/destroy는 중복 listener를 만들지 않는다", async () => {
+    const root = new FakeElement();
+    const calls = { setup: 0, destroy: 0, render: 0 };
+    const controller = createContentEnhancementController({
+      root,
+      windowRef: createFakeWindow(),
+      clipboard: { async writeText() {} },
+      mermaidController: {
+        setup() { calls.setup += 1; },
+        destroy() { calls.destroy += 1; },
+        async render() { calls.render += 1; },
+      },
+    });
+
+    controller.setup();
+    controller.setup();
+    expect(root.listenerCount("click")).toBe(1);
+    expect(calls.setup).toBe(1);
+    await controller.enhance(root);
+    expect(calls.render).toBe(1);
+
+    controller.destroy();
+    controller.destroy();
+    expect(root.listenerCount("click")).toBe(0);
+    expect(calls.destroy).toBe(1);
+  });
+
+  test("settings와 layout controller는 setup/destroy를 독립적으로 반복할 수 있다", () => {
+    const documentRef = createFakeDocument();
+    const mediaQueries = new Map<string, FakeMediaQuery>([
+      ["(prefers-color-scheme: dark)", new FakeMediaQuery(false)],
+      ["(max-width: 1024px)", new FakeMediaQuery(false)],
+    ]);
+    const windowRef = createFakeWindow(mediaQueries);
+    const storage = new FakeStorage();
+    const settingsToggle = documentRef.register("settings-toggle");
+    documentRef.register("settings-close");
+    const settingsPanel = documentRef.register("sidebar-settings");
+    settingsPanel.hidden = true;
+    documentRef.register("app-splitter");
+    documentRef.register("sidebar-panel");
+    documentRef.register("sidebar-toggle");
+    documentRef.register("sidebar-close");
+    documentRef.register("sidebar-overlay");
+
+    const settings = createSettingsController({ documentRef, windowRef, storage });
+    const treeLoadReasons: string[] = [];
+    const layout = createSidebarLayoutController({
+      documentRef,
+      windowRef,
+      storage,
+      closeSettings: settings.close,
+      requestTreeLoad(reason: string) {
+        treeLoadReasons.push(reason);
+        return Promise.resolve(true);
+      },
+    });
+
+    settings.setup();
+    settings.setup();
+    layout.setup();
+    layout.setup();
+    expect(settingsToggle.listenerCount("click")).toBe(1);
+    expect(windowRef.listenerCount("resize")).toBe(1);
+    expect(treeLoadReasons).toEqual([]);
+    expect(documentRef.documentElement.dataset.theme).toBe("light");
+
+    mediaQueries.get("(max-width: 1024px)")?.emit("change");
+    expect(treeLoadReasons).toEqual(["desktop-layout"]);
+
+    settingsToggle.emit("click");
+    expect(settingsPanel.hidden).toBe(false);
+    settings.close();
+    expect(settingsPanel.hidden).toBe(true);
+
+    layout.destroy();
+    layout.destroy();
+    settings.destroy();
+    settings.destroy();
+    expect(settingsToggle.listenerCount("click")).toBe(0);
+    expect(windowRef.listenerCount("resize")).toBe(0);
+  });
+
+  test("tree controller lifecycle은 branch UI와 search listener를 소유한다", () => {
+    const documentRef = createFakeDocument();
+    const windowRef = createFakeWindow();
+    const pills = documentRef.register("sidebar-branch-pills");
+    const branchInfo = documentRef.register("sidebar-branch-info");
+    documentRef.register("tree-root");
+    const search = documentRef.register("tree-search-input");
+    documentRef.register("tree-search-clear");
+    documentRef.register("tree-search-prev");
+    documentRef.register("tree-search-next");
+    documentRef.register("tree-search-count");
+    const navigation = {
+      activeBranch: "dev",
+      availableBranches: ["dev", "main"],
+      currentDocId: "",
+      defaultBranch: "dev",
+      view: {
+        docs: [],
+        routeMap: {},
+        trees: {
+          docIdToPrimaryTreePath: new Map(),
+          metadataByTreePath: new Map(),
+          paths: [],
+          treePathToRoute: new Map(),
+        },
+      },
+      setActiveBranch() { return true; },
+    };
+    const controller = createTreeController({
+      navigation,
+      pathBase: "",
+      treeModuleUrl: "",
+      navigate: async () => true,
+      documentRef,
+      windowRef,
+      storage: new FakeStorage(),
+    });
+
+    controller.setup();
+    controller.setup();
+    expect(pills.children).toHaveLength(2);
+    expect(pills.listenerCount("click")).toBe(1);
+    expect(search.listenerCount("input")).toBe(1);
+    expect(branchInfo.textContent).toContain("dev + unclassified");
+
+    controller.destroy();
+    controller.destroy();
+    expect(pills.listenerCount("click")).toBe(0);
+    expect(search.listenerCount("input")).toBe(0);
+  });
+
+  test("controller pure contracts와 bootstrap parser는 독립 import로 검증된다", () => {
+    expect(normalizeThemeMode("unexpected")).toBe("system");
+    expect(resolveAppliedTheme("system", true)).toBe("dark");
+    expect(clampDesktopSidebarWidth(900, 1200)).toBe(510);
+    expect(resolveMermaidConfig({ mermaid: { cdnUrl: "", theme: "bad theme" } }))
+      .toMatchObject({
+        enabled: true,
+        cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
+        theme: "default",
+      });
+    const mermaid = createMermaidController({ enabled: false, cdnUrl: "/mermaid.js", theme: "default" }, {
+      documentRef: {},
+      windowRef: {},
+    });
+    expect(typeof mermaid.setup).toBe("function");
+    expect(typeof mermaid.destroy).toBe("function");
+
+    const initialView = loadInitialViewData({
+      getElementById: () => ({
+        textContent: JSON.stringify({ route: "guide", docId: "guide", title: "Guide" }),
+      }),
+    });
+    expect(initialView).toEqual({ route: "/guide/", docId: "guide", title: "Guide" });
+  });
+});


### PR DESCRIPTION
Part of #29. Depends on #71. Detailed context: #30.

## Goal

Turn browser startup into a short composition root and give tree/search, sidebar/layout, settings/theme, Mermaid, and content enhancement explicit controller ownership.

## Scope

- Add lifecycle-aware tree/search, sidebar/layout, settings/theme, Mermaid, and content enhancement controllers
- Add a shared event scope for idempotent listener setup and reverse cleanup
- Move SSR bootstrap parsing and manifest loading into an independently loadable module
- Keep navigation-state.js as the single source of truth for branch, route, projection, and current document
- Reduce app.js from 2,032 lines to roughly 300 lines, with start() limited to controller composition and initial navigation
- Add independent controller lifecycle tests and document module boundaries

## Excluded

- Shared SSR/client breadcrumb, metadata, nav, and backlink presentation contracts
- Final mother-to-main merge

## DnD

- [x] start() is a short composition root
- [x] Controllers expose idempotent setup() and destroy() behavior
- [x] Branch and current-document state remain owned by navigation-state.js
- [x] Mobile modal/focus trap, tree search, history, pathBase, accessibility, Mermaid, image, and deferred loading behavior remain covered
- [x] Controller modules and pure contracts can be imported and tested independently
- [x] Initial desktop tree loading remains deferred until the post-paint idle path

## Verification

- bunx tsc --noEmit
- bun run build -- --vault ./test-vault --out ./dist
- bunx playwright test tests/e2e/runtime-controller-lifecycle.spec.ts (5 passed)
- targeted controller/navigation/mobile/deferred/Mermaid integration suites (17+ passed)
- bun run check:size
- bun run check:reproducible (18 files stable)
- bunx playwright test --reporter=dot (74 passed)

## Size

- app JS: 40,201 / 45,000 raw bytes; 13,906 / 15,000 gzip bytes

Issue: #29