### PR TITLE
refactor: share SSR and client view contracts

### DIFF
--- a/docs/solutions/20260719-shared-view-contract.md
+++ b/docs/solutions/20260719-shared-view-contract.md
@@ -1,0 +1,39 @@
+# Shared SSR/client view contract
+
+## 문제
+
+build output과 browser runtime이 breadcrumb, metadata, previous/next, backlinks를 서로 다른 함수로 렌더링했다. 날짜와 tag 정규화, pathBase 인코딩, branch별 nav 대상, HTML escaping도 각각 구현되어 direct-load의 SSR markup과 client navigation 결과가 달라질 수 있었다.
+
+초기 client navigation은 SSR markup이 이미 같아도 `innerHTML`을 다시 대입했다. 이 동작은 불필요한 DOM mutation을 만들고, 두 renderer의 drift를 가렸다.
+
+## 계약
+
+`src/view-contract.ts`는 Node/Bun build와 browser bundle 양쪽에서 import할 수 있는 순수 모듈이다.
+
+- route/pathBase를 정규화하고 각 path segment를 한 번만 encode한다.
+- branch 이름과 branch별 visible docs projection을 정규화한다.
+- home route 선택을 date와 route 기준으로 결정한다.
+- metadata date를 UTC `YYYY-MM-DD HH:mm`으로 렌더링해 server/browser timezone 차이를 제거한다.
+- prefix, tag, backlink를 presentation model로 정규화한다.
+- model의 모든 text와 attribute 값을 동일한 escaping 함수로 렌더링한다.
+- breadcrumb, metadata, nav, backlinks HTML을 `RenderedViewChrome` 한 객체로 반환한다.
+- document title 조합도 같은 contract를 사용한다.
+
+build는 각 문서의 branch를 기준으로 visible docs를 만든 뒤 shared renderer 결과를 `AppShellInitialView`에 넣는다. runtime navigation state도 같은 branch/path/home helper를 사용하고, content controller는 현재 navigation projection을 shared renderer에 전달한다.
+
+## Hydration
+
+content controller는 SSR chrome과 다음 render 결과를 비교한다. `innerHTML`, `textContent`, `hidden` 값이 동일하면 setter를 호출하지 않는다. branch projection이나 route가 달라 실제 markup 변경이 필요할 때만 DOM을 갱신한다.
+
+이 방식은 초기 markup을 무조건 신뢰하지 않으면서도 동일한 SSR markup을 덮어쓰지 않는다.
+
+## 회귀 검증
+
+`view-contract.spec.ts`는 다음을 고정한다.
+
+- date/tag/pathBase/escaping model contract
+- default와 non-default branch projection 및 home route
+- default/unclassified 문서와 non-default branch 문서의 hydration chrome write 0회
+- direct-load와 client-navigation의 breadcrumb/meta/backlinks/nav snapshot 동등성
+
+기존 pathBase, branch 자동 전환, XSS, history 테스트도 shared contract를 통과한 상태로 유지한다.

--- a/docs/solutions/20260719-shared-view-contract.md
+++ b/docs/solutions/20260719-shared-view-contract.md
@@ -13,7 +13,7 @@ build output과 browser runtime이 breadcrumb, metadata, previous/next, backlink
 - route/pathBase를 정규화하고 각 path segment를 한 번만 encode한다.
 - branch 이름과 branch별 visible docs projection을 정규화한다.
 - home route 선택을 date와 route 기준으로 결정한다.
-- metadata date를 UTC `YYYY-MM-DD HH:mm`으로 렌더링해 server/browser timezone 차이를 제거한다.
+- metadata date를 UTC `YYYY-MM-DD HH:mm`으로 렌더링하고 offset 없는 ISO datetime도 UTC로 고정해 server/browser timezone 차이를 제거한다.
 - prefix, tag, backlink를 presentation model로 정규화한다.
 - model의 모든 text와 attribute 값을 동일한 escaping 함수로 렌더링한다.
 - breadcrumb, metadata, nav, backlinks HTML을 `RenderedViewChrome` 한 객체로 반환한다.
@@ -33,6 +33,7 @@ content controller는 SSR chrome과 다음 render 결과를 비교한다. `inner
 
 - date/tag/pathBase/escaping model contract
 - default와 non-default branch projection 및 home route
+- default branch projection이 비었을 때 build/runtime의 non-empty branch fallback
 - default/unclassified 문서와 non-default branch 문서의 hydration chrome write 0회
 - direct-load와 client-navigation의 breadcrumb/meta/backlinks/nav snapshot 동등성
 

--- a/src/build/graph.ts
+++ b/src/build/graph.ts
@@ -1,5 +1,6 @@
 import path from "node:path";
 import type { BuildOptions, DocRecord, FileNode, FolderNode, Manifest, TreeNode } from "../types";
+import { filterViewDocsByBranch, pickViewHomeRoute } from "../view-contract";
 import type { DocumentGraphResult, WikiLookup } from "./contracts";
 import { buildBacklinksByDocId, createWikiLookup } from "./source";
 import { resolveSiteTitle } from "./shared";
@@ -67,14 +68,10 @@ function matchesPathPrefix(value: string, prefix: string): boolean {
 }
 
 export function pickHomeDoc(docs: DocRecord[]): DocRecord | null {
-  const inDefaultBranch = docs.filter((doc) => doc.branch == null || doc.branch === DEFAULT_BRANCH);
-  const candidates = inDefaultBranch.length > 0 ? inDefaultBranch : docs;
-  const byRoute = candidates.find((doc) => doc.route === "/index/");
-  if (byRoute) {
-    return byRoute;
-  }
-
-  return [...candidates].sort(compareByRecentDateThenPath)[0] ?? null;
+  const defaultCandidates = filterViewDocsByBranch(docs, DEFAULT_BRANCH, DEFAULT_BRANCH);
+  const candidates = defaultCandidates.length > 0 ? defaultCandidates : docs;
+  const route = pickViewHomeRoute(candidates);
+  return candidates.find((doc) => doc.route === route) ?? null;
 }
 
 function buildPinnedMenuFolder(docs: DocRecord[], options: BuildOptions): FolderNode | null {

--- a/src/build/output.ts
+++ b/src/build/output.ts
@@ -1,29 +1,24 @@
 import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { BuildOptions, DocRecord, Manifest, ManifestDoc } from "../types";
+import type { BuildOptions, DocRecord, Manifest } from "../types";
 import { buildCanonicalUrl, escapeHtmlAttribute } from "../seo";
 import { render404Html, renderAppShellHtml } from "../template";
 import type { AppShellAssets, AppShellInitialView, AppShellMeta } from "../template";
 import { ensureDir, makeHash, removeEmptyParents, removeFileIfExists, toPosixPath } from "../utils";
+import {
+  composeViewDocumentTitle,
+  filterViewDocsByBranch,
+  normalizeViewBranch,
+  pickViewHomeRoute,
+  renderViewChrome,
+  toViewPathWithBase,
+} from "../view-contract";
 import type { OutputPhaseState, OutputWriteContext, RuntimeAssets } from "./contracts";
-import { pickHomeDoc } from "./graph";
 import { OUTPUT_MARKER_FILE_NAME, resolveSiteTitle } from "./shared";
 
 const DEFAULT_SITE_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 const DEFAULT_SITE_TITLE = "File-System Blog";
-
-function composeDocumentTitle(pageTitle: string, siteTitle: string): string {
-  const left = pageTitle.trim();
-  const right = siteTitle.trim();
-  if (!left) {
-    return right || DEFAULT_SITE_TITLE;
-  }
-  if (!right || left === right) {
-    return left;
-  }
-  return `${left} - ${right}`;
-}
 
 function pickSeoImageDefaults(
   seo: BuildOptions["seo"],
@@ -362,7 +357,7 @@ function buildShellMeta(route: string, doc: DocRecord | null, options: BuildOpti
   const description = typeof doc?.description === "string" && doc.description.trim().length > 0 ? doc.description.trim() : undefined;
   const canonicalUrl = options.seo ? buildCanonicalUrl(route, options.seo) : undefined;
   const baseTitle = doc?.title ?? defaultTitle;
-  const title = composeDocumentTitle(baseTitle, siteTitle);
+  const title = composeViewDocumentTitle(baseTitle, siteTitle);
   const imageDefaults = pickSeoImageDefaults(options.seo);
   const ogImage = imageDefaults.og ?? imageDefaults.social ?? undefined;
   const twitterImage = imageDefaults.twitter ?? imageDefaults.social ?? undefined;
@@ -388,135 +383,29 @@ function buildShellMeta(route: string, doc: DocRecord | null, options: BuildOpti
   };
 }
 
-function renderInitialBreadcrumb(route: string): string {
-  const parts = route.split("/").filter(Boolean);
-  const allItems = ["~", ...parts];
-  return allItems
-    .map((part, index) => {
-      const isCurrent = index === allItems.length - 1 && allItems.length > 1;
-      const escapedPart = escapeHtmlAttribute(part);
-      if (isCurrent) {
-        return `<span class="breadcrumb-current" aria-current="page">${escapedPart}</span>`;
-      }
-      return `<span class="breadcrumb-item">${escapedPart}</span>`;
-    })
-    .join('<span class="material-symbols-outlined breadcrumb-sep">chevron_right</span>');
-}
-
-function formatMetaDateTime(value: string | undefined): string | null {
-  if (!value) {
-    return null;
-  }
-
-  const parsed = new Date(value);
-  if (!Number.isFinite(parsed.getTime())) {
-    return null;
-  }
-
-  const yyyy = parsed.getFullYear();
-  const mm = String(parsed.getMonth() + 1).padStart(2, "0");
-  const dd = String(parsed.getDate()).padStart(2, "0");
-  const hh = String(parsed.getHours()).padStart(2, "0");
-  const mi = String(parsed.getMinutes()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
-}
-
-function normalizeTags(tags: string[]): string[] {
-  return tags.map((tag) => String(tag).trim().replace(/^#+/, "")).filter(Boolean);
-}
-
-function renderInitialMeta(doc: DocRecord): string {
-  const items: string[] = [];
-
-  if (doc.prefix) {
-    items.push(`<span class="meta-item meta-prefix">${escapeHtmlAttribute(doc.prefix)}</span>`);
-  }
-
-  const createdAt = formatMetaDateTime(doc.date);
-  if (createdAt) {
-    items.push(
-      `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeHtmlAttribute(createdAt)}</span>`,
-    );
-  }
-
-  const tags = normalizeTags(doc.tags);
-  if (tags.length > 0) {
-    const tagsStr = tags.map((tag) => `#${escapeHtmlAttribute(tag)}`).join(" ");
-    items.push(`<span class="meta-item meta-tags">${tagsStr}</span>`);
-  }
-
-  return items.join("");
-}
-
-function toPathWithBase(pathname: string, pathBase: string): string {
-  const cleanBase = pathBase.trim().replace(/\\/g, "/");
-  const normalizedBase = !cleanBase || cleanBase === "/"
-    ? ""
-    : `/${cleanBase.replace(/^\/+/, "").replace(/\/+$/, "")}`;
-  if (!normalizedBase) {
-    return pathname;
-  }
-
-  if (pathname === "/") {
-    return `${normalizedBase}/`;
-  }
-  const normalizedPathname = pathname.startsWith("/") ? pathname : `/${pathname}`;
-  return `${normalizedBase}${normalizedPathname}`;
-}
-
-function renderInitialNav(docs: DocRecord[], currentId: string, pathBase: string): string {
-  const currentIndex = docs.findIndex((doc) => doc.id === currentId);
-  if (currentIndex === -1) {
-    return "";
-  }
-
-  const prev = currentIndex > 0 ? docs[currentIndex - 1] : null;
-  const next = currentIndex < docs.length - 1 ? docs[currentIndex + 1] : null;
-
-  let html = "";
-  if (prev) {
-    html += `<a href="${escapeHtmlAttribute(toPathWithBase(prev.route, pathBase))}" class="nav-link nav-link-prev" data-route="${escapeHtmlAttribute(prev.route)}"><div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div><div class="nav-link-title">${escapeHtmlAttribute(prev.title)}</div></a>`;
-  }
-  if (next) {
-    html += `<a href="${escapeHtmlAttribute(toPathWithBase(next.route, pathBase))}" class="nav-link nav-link-next" data-route="${escapeHtmlAttribute(next.route)}"><div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div><div class="nav-link-title">${escapeHtmlAttribute(next.title)}</div></a>`;
-  }
-
-  return html;
-}
-
-function renderInitialBacklinks(backlinks: ManifestDoc["backlinks"], pathBase: string): string {
-  if (backlinks.length === 0) {
-    return "";
-  }
-
-  let html = '<h2 class="backlinks-title">Backlinks</h2><ul class="backlinks-list">';
-  for (const backlink of backlinks) {
-    const prefixHtml = backlink.prefix
-      ? `<span class="backlink-prefix">${escapeHtmlAttribute(backlink.prefix)}</span>`
-      : "";
-    html += `<li class="backlinks-item"><a href="${escapeHtmlAttribute(toPathWithBase(backlink.route, pathBase))}" class="backlink-link" data-route="${escapeHtmlAttribute(backlink.route)}">${prefixHtml}<span class="backlink-text">${escapeHtmlAttribute(backlink.title)}</span></a></li>`;
-  }
-  html += "</ul>";
-  return html;
-}
-
 function buildInitialView(
   doc: DocRecord,
   docs: DocRecord[],
   contentHtml: string,
   manifestDocById: Map<string, Manifest["docsById"][string]>,
   pathBase: string,
+  defaultBranch: string,
 ): AppShellInitialView {
   const manifestDoc = manifestDocById.get(doc.id);
+  const activeBranch = normalizeViewBranch(doc.branch) ?? normalizeViewBranch(defaultBranch) ?? "dev";
+  const visibleDocs = filterViewDocsByBranch(docs, activeBranch, defaultBranch);
+  const chrome = renderViewChrome({
+    route: doc.route,
+    doc: { ...doc, backlinks: manifestDoc?.backlinks ?? [] },
+    docs: visibleDocs,
+    pathBase,
+  });
   return {
     route: doc.route,
     docId: doc.id,
     title: doc.title,
-    breadcrumbHtml: renderInitialBreadcrumb(doc.route),
-    metaHtml: renderInitialMeta(doc),
     contentHtml,
-    backlinksHtml: renderInitialBacklinks(manifestDoc?.backlinks ?? [], pathBase),
-    navHtml: renderInitialNav(docs, doc.id, pathBase),
+    ...chrome,
   };
 }
 
@@ -530,10 +419,23 @@ async function writeShellPages(
 ): Promise<void> {
   const manifestDocById = new Map(Object.entries(manifest.docsById));
   const pathBase = options.seo?.pathBase ?? "";
-  const indexDoc = pickHomeDoc(docs);
+  const defaultViewDocs = filterViewDocsByBranch(
+    docs,
+    manifest.defaultBranch,
+    manifest.defaultBranch,
+  );
+  const indexRoute = pickViewHomeRoute(defaultViewDocs);
+  const indexDoc = docs.find((doc) => doc.route === indexRoute) ?? null;
   const indexOutputPath = "index.html";
   const indexInitialView = indexDoc
-    ? buildInitialView(indexDoc, docs, contentByDocId.get(indexDoc.id) ?? "", manifestDocById, pathBase)
+    ? buildInitialView(
+        indexDoc,
+        docs,
+        contentByDocId.get(indexDoc.id) ?? "",
+        manifestDocById,
+        pathBase,
+        manifest.defaultBranch,
+      )
     : null;
   const shell = renderAppShellHtml(
     buildShellMeta("/", null, options),
@@ -546,12 +448,22 @@ async function writeShellPages(
   await writeOutputIfChanged(
     context,
     "404.html",
-    render404Html(buildAppShellAssetsForOutput("404.html", runtimeAssets), toPathWithBase("/", pathBase)),
+    render404Html(
+      buildAppShellAssetsForOutput("404.html", runtimeAssets),
+      toViewPathWithBase("/", pathBase),
+    ),
   );
 
   for (const doc of docs) {
     const routeOutputPath = toRouteOutputPath(doc.route);
-    const initialView = buildInitialView(doc, docs, contentByDocId.get(doc.id) ?? "", manifestDocById, pathBase);
+    const initialView = buildInitialView(
+      doc,
+      docs,
+      contentByDocId.get(doc.id) ?? "",
+      manifestDocById,
+      pathBase,
+      manifest.defaultBranch,
+    );
     await writeOutputIfChanged(
       context,
       routeOutputPath,

--- a/src/build/output.ts
+++ b/src/build/output.ts
@@ -419,12 +419,13 @@ async function writeShellPages(
 ): Promise<void> {
   const manifestDocById = new Map(Object.entries(manifest.docsById));
   const pathBase = options.seo?.pathBase ?? "";
-  const defaultViewDocs = filterViewDocsByBranch(
+  const defaultBranchDocs = filterViewDocsByBranch(
     docs,
     manifest.defaultBranch,
     manifest.defaultBranch,
   );
-  const indexRoute = pickViewHomeRoute(defaultViewDocs);
+  const homeCandidates = defaultBranchDocs.length > 0 ? defaultBranchDocs : docs;
+  const indexRoute = pickViewHomeRoute(homeCandidates);
   const indexDoc = docs.find((doc) => doc.route === indexRoute) ?? null;
   const indexOutputPath = "index.html";
   const indexInitialView = indexDoc

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -3,141 +3,22 @@ import { createContentEnhancementController } from "./content-enhancement-contro
 import { createMermaidController, resolveMermaidConfig } from "./mermaid-controller.js";
 import {
   createNavigationState,
-  normalizeRoute,
   pickHomeRoute,
   resolveRouteFromLocation,
-  toPathWithBase,
 } from "./navigation-state.js";
 import { loadRuntimeBootstrap } from "./runtime-bootstrap.js";
 import { createSettingsController } from "./settings-controller.js";
 import { createSidebarLayoutController } from "./sidebar-layout-controller.js";
 import { createTreeController } from "./tree-controller.js";
+import {
+  composeViewDocumentTitle,
+  renderViewBreadcrumb,
+  renderViewChrome,
+} from "../view-contract.ts";
 
 const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
 const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
-const DEFAULT_SITE_TITLE = "File-System Blog";
-
-function escapeHtmlAttr(input) {
-  return String(input)
-    .replace(/&/g, "&amp;")
-    .replace(/"/g, "&quot;")
-    .replace(/</g, "&lt;")
-    .replace(/>/g, "&gt;");
-}
-
-function composeDocumentTitle(pageTitle, siteTitle) {
-  const left = String(pageTitle ?? "").trim();
-  const right = String(siteTitle ?? "").trim();
-  if (!left) {
-    return right || DEFAULT_SITE_TITLE;
-  }
-  if (!right || left === right) {
-    return left;
-  }
-  return `${left} - ${right}`;
-}
-
-function formatMetaDateTime(value) {
-  const parsed = new Date(value);
-  if (!Number.isFinite(parsed.getTime())) {
-    return null;
-  }
-  const yyyy = parsed.getFullYear();
-  const mm = String(parsed.getMonth() + 1).padStart(2, "0");
-  const dd = String(parsed.getDate()).padStart(2, "0");
-  const hh = String(parsed.getHours()).padStart(2, "0");
-  const mi = String(parsed.getMinutes()).padStart(2, "0");
-  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
-}
-
-function normalizeTags(tags) {
-  if (!Array.isArray(tags)) {
-    return [];
-  }
-  return tags
-    .map((tag) => String(tag).trim().replace(/^#+/, ""))
-    .filter(Boolean);
-}
-
-function renderBreadcrumb(route) {
-  const parts = route.split("/").filter(Boolean);
-  const allItems = ["~", ...parts];
-  return allItems
-    .map((part, index) => {
-      const isCurrent = index === allItems.length - 1 && allItems.length > 1;
-      const escapedPart = escapeHtmlAttr(part);
-      if (isCurrent) {
-        return `<span class="breadcrumb-current" aria-current="page">${escapedPart}</span>`;
-      }
-      return `<span class="breadcrumb-item">${escapedPart}</span>`;
-    })
-    .join('<span class="material-symbols-outlined breadcrumb-sep">chevron_right</span>');
-}
-
-function renderMeta(doc) {
-  const items = [];
-  if (typeof doc.prefix === "string" && doc.prefix.trim().length > 0) {
-    items.push(`<span class="meta-item meta-prefix">${escapeHtmlAttr(doc.prefix)}</span>`);
-  }
-  const createdAt = formatMetaDateTime(doc.date);
-  if (createdAt) {
-    items.push(
-      `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeHtmlAttr(createdAt)}</span>`,
-    );
-  }
-  const tags = normalizeTags(doc.tags);
-  if (tags.length > 0) {
-    const tagsStr = tags.map((tag) => `#${escapeHtmlAttr(tag)}`).join(" ");
-    items.push(`<span class="meta-item meta-tags">${tagsStr}</span>`);
-  }
-  return items.join("");
-}
-
-function renderNav(currentView, currentId, pathBase) {
-  const currentIndex = currentView.docIndexById.get(currentId) ?? -1;
-  if (currentIndex === -1) {
-    return "";
-  }
-  const previous = currentIndex > 0 ? currentView.docs[currentIndex - 1] : null;
-  const next =
-    currentIndex < currentView.docs.length - 1 ? currentView.docs[currentIndex + 1] : null;
-  let html = "";
-  if (previous) {
-    html += `<a href="${toPathWithBase(previous.route, pathBase)}" class="nav-link nav-link-prev" data-route="${escapeHtmlAttr(previous.route)}">
-      <div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div>
-      <div class="nav-link-title">${escapeHtmlAttr(previous.title)}</div>
-    </a>`;
-  }
-  if (next) {
-    html += `<a href="${toPathWithBase(next.route, pathBase)}" class="nav-link nav-link-next" data-route="${escapeHtmlAttr(next.route)}">
-      <div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div>
-      <div class="nav-link-title">${escapeHtmlAttr(next.title)}</div>
-    </a>`;
-  }
-  return html;
-}
-
-function renderBacklinks(doc, pathBase) {
-  const backlinks = Array.isArray(doc.backlinks) ? doc.backlinks : [];
-  if (backlinks.length === 0) {
-    return "";
-  }
-  let html = '<h2 class="backlinks-title">Backlinks</h2><ul class="backlinks-list">';
-  for (const backlink of backlinks) {
-    const prefix =
-      typeof backlink.prefix === "string" && backlink.prefix.trim().length > 0
-        ? `<span class="backlink-prefix">${escapeHtmlAttr(backlink.prefix.trim())}</span>`
-        : "";
-    const route = typeof backlink.route === "string" ? normalizeRoute(backlink.route) : "/";
-    const title =
-      typeof backlink.title === "string" && backlink.title.trim().length > 0
-        ? backlink.title
-        : route;
-    html += `<li class="backlinks-item"><a href="${toPathWithBase(route, pathBase)}" class="backlink-link" data-route="${escapeHtmlAttr(route)}">${prefix}<span class="backlink-text">${escapeHtmlAttr(title)}</span></a></li>`;
-  }
-  return `${html}</ul>`;
-}
 
 function setRuntimeState(attribute, state) {
   document.documentElement?.setAttribute(attribute, state);
@@ -231,11 +112,9 @@ async function start() {
     pathBase: bootstrap.pathBase,
     siteTitle: bootstrap.siteTitle,
     renderers: {
-      breadcrumb: renderBreadcrumb,
-      meta: renderMeta,
-      backlinks: renderBacklinks,
-      nav: renderNav,
-      documentTitle: composeDocumentTitle,
+      breadcrumb: renderViewBreadcrumb,
+      chrome: renderViewChrome,
+      documentTitle: composeViewDocumentTitle,
     },
     lifecycle: {
       beforeNavigate() {

--- a/src/runtime/content-controller.js
+++ b/src/runtime/content-controller.js
@@ -1,13 +1,13 @@
 import { toPathWithBase } from "./navigation-state.js";
 
 function setHtml(element, value) {
-  if (element) {
+  if (element && element.innerHTML !== value) {
     element.innerHTML = value;
   }
 }
 
 function setText(element, value) {
-  if (element) {
+  if (element && element.textContent !== value) {
     element.textContent = value;
   }
 }
@@ -31,21 +31,29 @@ export function createContentController(options) {
   let hasHydratedInitialView = false;
   let isSetup = false;
 
-  const updateBacklinks = (doc) => {
+  const updateBacklinks = (html) => {
     if (!elements.backlinks) {
       return;
     }
-    const html = doc ? renderers.backlinks(doc, pathBase) : "";
-    elements.backlinks.innerHTML = html;
-    elements.backlinks.hidden = html.length === 0;
+    setHtml(elements.backlinks, html);
+    const shouldHide = html.length === 0;
+    if (elements.backlinks.hidden !== shouldHide) {
+      elements.backlinks.hidden = shouldHide;
+    }
   };
 
   const renderChrome = (route, doc) => {
-    setHtml(elements.breadcrumb, renderers.breadcrumb(route));
+    const chrome = renderers.chrome({
+      route,
+      doc,
+      docs: navigation.view.docs,
+      pathBase,
+    });
+    setHtml(elements.breadcrumb, chrome.breadcrumbHtml);
     setText(elements.title, doc.title);
-    setHtml(elements.meta, renderers.meta(doc));
-    updateBacklinks(doc);
-    setHtml(elements.nav, renderers.nav(navigation.view, doc.id, pathBase));
+    setHtml(elements.meta, chrome.metaHtml);
+    updateBacklinks(chrome.backlinksHtml);
+    setHtml(elements.nav, chrome.navHtml);
   };
 
   const finishNavigation = async (doc) => {
@@ -62,7 +70,7 @@ export function createContentController(options) {
     setText(elements.title, "문서를 찾을 수 없습니다");
     setHtml(elements.meta, "");
     setHtml(elements.content, '<p class="placeholder">요청한 경로에 해당하는 문서가 없습니다.</p>');
-    updateBacklinks(null);
+    updateBacklinks("");
     setHtml(elements.nav, "");
     lifecycle.announce?.("탐색 실패: 요청한 문서를 찾을 수 없습니다.");
     if (push) {
@@ -105,7 +113,7 @@ export function createContentController(options) {
     const response = await fetchContent(toPathWithBase(resolved.doc.contentUrl, pathBase));
     if (!response.ok) {
       setHtml(elements.content, '<p class="placeholder">본문을 불러오지 못했습니다.</p>');
-      updateBacklinks(null);
+      updateBacklinks("");
       setHtml(elements.nav, "");
       lifecycle.announce?.(`탐색 실패: ${resolved.doc.title} 문서를 불러오지 못했습니다.`);
       return false;

--- a/src/runtime/navigation-state.js
+++ b/src/runtime/navigation-state.js
@@ -115,6 +115,15 @@ export function createNavigationState(manifest, options = {}) {
   };
 
   let view = getBranchView(activeBranch);
+  if (view.docs.length === 0 && docs.length > 0) {
+    const fallbackRoute = pickViewHomeRoute(docs);
+    const fallbackDoc = docs.find((doc) => doc.route === fallbackRoute);
+    const fallbackBranch = normalizeBranch(fallbackDoc?.branch) ?? defaultBranch;
+    if (availableBranchSet.has(fallbackBranch)) {
+      activeBranch = fallbackBranch;
+      view = getBranchView(activeBranch);
+    }
+  }
 
   const setActiveBranch = (value) => {
     const branch = normalizeBranch(value);

--- a/src/runtime/navigation-state.js
+++ b/src/runtime/navigation-state.js
@@ -1,123 +1,29 @@
 import { getRuntimeManifestDocs } from "./manifest-adapter.js";
 import { buildTreesAdapterInput } from "./tree-adapter.js";
+import {
+  filterViewDocsByBranch,
+  normalizeViewBranch as normalizeBranch,
+  normalizeViewPathBase as normalizePathBase,
+  normalizeViewPathname as normalizePathname,
+  normalizeViewRoute as normalizeRoute,
+  pickViewHomeRoute,
+  stripViewPathBase as stripPathBase,
+  toViewPathWithBase as toPathWithBase,
+} from "../view-contract.ts";
 
 const DEFAULT_BRANCH = "dev";
 
-function toSafeUrlPath(input) {
-  return String(input)
-    .split("/")
-    .map((segment, index) => {
-      if (index === 0 && segment === "") {
-        return "";
-      }
-      return encodeURIComponent(segment);
-    })
-    .join("/");
-}
-
-export function normalizePathname(pathname) {
-  let normalized = "/";
-  try {
-    normalized = decodeURIComponent(pathname || "/");
-  } catch {
-    normalized = String(pathname || "/");
-  }
-  if (!normalized.startsWith("/")) {
-    normalized = `/${normalized}`;
-  }
-  return normalized.replace(/\/+/g, "/") || "/";
-}
-
-export function normalizeRoute(pathname) {
-  const normalized = normalizePathname(pathname);
-  return normalized.endsWith("/") ? normalized : `${normalized}/`;
-}
-
-export function normalizePathBase(pathBase) {
-  if (typeof pathBase !== "string") {
-    return "";
-  }
-
-  const cleaned = pathBase.trim().replace(/\\/g, "/");
-  if (!cleaned || cleaned === "/") {
-    return "";
-  }
-
-  return `/${cleaned.replace(/^\/+/, "").replace(/\/+$/, "")}`;
-}
-
-export function stripPathBase(pathname, pathBase) {
-  const normalizedPath = normalizePathname(pathname);
-  if (!pathBase) {
-    return normalizedPath;
-  }
-  if (normalizedPath === pathBase) {
-    return "/";
-  }
-  if (normalizedPath.startsWith(`${pathBase}/`)) {
-    return normalizedPath.slice(pathBase.length) || "/";
-  }
-  return normalizedPath;
-}
-
-export function toPathWithBase(pathname, pathBase) {
-  const normalizedPath = normalizePathname(pathname);
-  if (!pathBase) {
-    return toSafeUrlPath(normalizedPath);
-  }
-  if (normalizedPath === "/") {
-    return toSafeUrlPath(`${pathBase}/`);
-  }
-  return toSafeUrlPath(`${pathBase}${normalizedPath}`);
-}
+export {
+  normalizeBranch,
+  normalizePathBase,
+  normalizePathname,
+  normalizeRoute,
+  stripPathBase,
+  toPathWithBase,
+};
 
 export function resolveRouteFromLocation(pathBase, pathname = globalThis.location?.pathname ?? "/") {
   return normalizeRoute(stripPathBase(pathname, pathBase));
-}
-
-export function normalizeBranch(value) {
-  if (typeof value !== "string") {
-    return null;
-  }
-
-  const normalized = value.trim().toLowerCase();
-  return normalized.length > 0 ? normalized : null;
-}
-
-function isDocVisibleInBranch(doc, branch, defaultBranch) {
-  const docBranch = normalizeBranch(doc.branch);
-  return docBranch ? docBranch === branch : branch === defaultBranch;
-}
-
-function parseDateToEpochMs(value) {
-  if (typeof value !== "string" || value.trim().length === 0) {
-    return null;
-  }
-
-  const parsed = Date.parse(value);
-  return Number.isFinite(parsed) ? parsed : null;
-}
-
-function getRecentSortEpochMs(doc) {
-  return parseDateToEpochMs(doc.updatedDate) ?? parseDateToEpochMs(doc.date);
-}
-
-function compareDocsByRecentDateThenRoute(left, right) {
-  const leftEpoch = getRecentSortEpochMs(left);
-  const rightEpoch = getRecentSortEpochMs(right);
-
-  if (leftEpoch != null && rightEpoch != null) {
-    const byDate = rightEpoch - leftEpoch;
-    if (byDate !== 0) {
-      return byDate;
-    }
-  } else if (leftEpoch != null) {
-    return -1;
-  } else if (rightEpoch != null) {
-    return 1;
-  }
-
-  return left.route.localeCompare(right.route, "ko-KR");
 }
 
 function cloneFilteredTree(nodes, visibleDocIds) {
@@ -143,7 +49,7 @@ function cloneFilteredTree(nodes, visibleDocIds) {
 }
 
 function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
-  const docs = manifestDocs.filter((doc) => isDocVisibleInBranch(doc, branch, defaultBranch));
+  const docs = filterViewDocsByBranch(manifestDocs, branch, defaultBranch);
   const visibleDocIds = new Set(docs.map((doc) => doc.id));
   const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
   const trees = buildTreesAdapterInput(tree, docs);
@@ -160,10 +66,7 @@ function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
 }
 
 export function pickHomeRoute(view) {
-  if (view.routeMap["/index/"]) {
-    return "/index/";
-  }
-  return [...view.docs].sort(compareDocsByRecentDateThenRoute)[0]?.route || "/";
+  return pickViewHomeRoute(view.docs);
 }
 
 function collectAvailableBranches(manifest, manifestDocs, defaultBranch) {

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,5 +1,6 @@
 import { escapeHtmlAttribute } from "./seo";
 import type { Manifest } from "./types";
+import { toViewPathWithBase } from "./view-contract";
 
 const DEFAULT_TITLE = "File-System Blog";
 const DEFAULT_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
@@ -168,16 +169,6 @@ function renderInitialViewScript(initialView: AppShellInitialView | null): strin
   return `\n    <script id="initial-view-data" type="application/json">${payload}</script>`;
 }
 
-function toPublicUrl(pathBase: string, pathname: string): string {
-  const normalizedBase = pathBase.trim().replace(/^\/+|\/+$/g, "");
-  const normalizedPath = pathname.trim().replace(/^\/+/g, "");
-  const rawPath = `/${[normalizedBase, normalizedPath].filter(Boolean).join("/")}`;
-  return rawPath
-    .split("/")
-    .map((segment, index) => (index === 0 && segment === "" ? "" : encodeURIComponent(segment)))
-    .join("/");
-}
-
 function renderRuntimeBootstrapScript(
   manifest: AppShellManifestPayload | null,
   assets: AppShellAssets,
@@ -187,9 +178,9 @@ function renderRuntimeBootstrapScript(
   }
 
   const payloadData: AppShellRuntimePayload = {
-    manifestUrl: toPublicUrl(manifest.pathBase, "/manifest.json"),
+    manifestUrl: toViewPathWithBase("/manifest.json", manifest.pathBase),
     pathBase: manifest.pathBase,
-    treeModuleUrl: toPublicUrl(manifest.pathBase, assets.treeModulePath),
+    treeModuleUrl: toViewPathWithBase(assets.treeModulePath, manifest.pathBase),
   };
   const payload = JSON.stringify(payloadData)
     .replaceAll("<", "\\u003c")

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -1,0 +1,344 @@
+const DEFAULT_BRANCH = "dev";
+const DEFAULT_SITE_TITLE = "File-System Blog";
+
+export interface ViewBacklinkContract {
+  route?: unknown;
+  title?: unknown;
+  prefix?: unknown;
+}
+
+export interface ViewDocContract {
+  id: string;
+  route: string;
+  title: string;
+  prefix?: unknown;
+  date?: unknown;
+  updatedDate?: unknown;
+  tags?: unknown;
+  branch?: unknown;
+  backlinks?: readonly ViewBacklinkContract[];
+}
+
+export interface ViewChromeModel {
+  breadcrumb: {
+    items: Array<{ label: string; current: boolean }>;
+  };
+  meta: {
+    prefix: string | null;
+    createdAt: string | null;
+    tags: string[];
+  };
+  navigation: {
+    previous: ViewLinkModel | null;
+    next: ViewLinkModel | null;
+  };
+  backlinks: Array<ViewLinkModel & { prefix: string | null }>;
+}
+
+interface ViewLinkModel {
+  route: string;
+  href: string;
+  title: string;
+}
+
+export interface RenderedViewChrome {
+  breadcrumbHtml: string;
+  metaHtml: string;
+  backlinksHtml: string;
+  navHtml: string;
+}
+
+function toSafeUrlPath(input: string): string {
+  return input
+    .split("/")
+    .map((segment, index) => (index === 0 && segment === "" ? "" : encodeURIComponent(segment)))
+    .join("/");
+}
+
+export function normalizeViewPathname(pathname: unknown): string {
+  let normalized = "/";
+  try {
+    normalized = decodeURIComponent(String(pathname || "/"));
+  } catch {
+    normalized = String(pathname || "/");
+  }
+  if (!normalized.startsWith("/")) {
+    normalized = `/${normalized}`;
+  }
+  return normalized.replace(/\/+/g, "/") || "/";
+}
+
+export function normalizeViewRoute(pathname: unknown): string {
+  const normalized = normalizeViewPathname(pathname);
+  return normalized.endsWith("/") ? normalized : `${normalized}/`;
+}
+
+export function normalizeViewPathBase(pathBase: unknown): string {
+  if (typeof pathBase !== "string") {
+    return "";
+  }
+  const cleaned = pathBase.trim().replace(/\\/g, "/");
+  if (!cleaned || cleaned === "/") {
+    return "";
+  }
+  return `/${cleaned.replace(/^\/+/, "").replace(/\/+$/, "")}`;
+}
+
+export function stripViewPathBase(pathname: unknown, pathBase: unknown): string {
+  const normalizedPath = normalizeViewPathname(pathname);
+  const normalizedBase = normalizeViewPathBase(pathBase);
+  if (!normalizedBase) {
+    return normalizedPath;
+  }
+  if (normalizedPath === normalizedBase) {
+    return "/";
+  }
+  if (normalizedPath.startsWith(`${normalizedBase}/`)) {
+    return normalizedPath.slice(normalizedBase.length) || "/";
+  }
+  return normalizedPath;
+}
+
+export function toViewPathWithBase(pathname: unknown, pathBase: unknown): string {
+  const normalizedPath = normalizeViewPathname(pathname);
+  const normalizedBase = normalizeViewPathBase(pathBase);
+  if (!normalizedBase) {
+    return toSafeUrlPath(normalizedPath);
+  }
+  if (normalizedPath === "/") {
+    return toSafeUrlPath(`${normalizedBase}/`);
+  }
+  return toSafeUrlPath(`${normalizedBase}${normalizedPath}`);
+}
+
+export function normalizeViewBranch(value: unknown): string | null {
+  if (typeof value !== "string") {
+    return null;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized || null;
+}
+
+export function filterViewDocsByBranch<T extends { branch?: unknown }>(
+  docs: readonly T[],
+  branch: unknown,
+  defaultBranch: unknown,
+): T[] {
+  const normalizedDefault = normalizeViewBranch(defaultBranch) ?? DEFAULT_BRANCH;
+  const normalizedBranch = normalizeViewBranch(branch) ?? normalizedDefault;
+  return docs.filter((doc) => {
+    const docBranch = normalizeViewBranch(doc.branch);
+    return docBranch ? docBranch === normalizedBranch : normalizedBranch === normalizedDefault;
+  });
+}
+
+function parseDateToEpochMs(value: unknown): number | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  const parsed = Date.parse(value);
+  return Number.isFinite(parsed) ? parsed : null;
+}
+
+export function pickViewHomeRoute(
+  docs: readonly Pick<ViewDocContract, "route" | "date" | "updatedDate">[],
+): string {
+  const indexDoc = docs.find((doc) => normalizeViewRoute(doc.route) === "/index/");
+  if (indexDoc) {
+    return "/index/";
+  }
+  const selected = [...docs].sort((left, right) => {
+    const leftEpoch = parseDateToEpochMs(left.updatedDate) ?? parseDateToEpochMs(left.date);
+    const rightEpoch = parseDateToEpochMs(right.updatedDate) ?? parseDateToEpochMs(right.date);
+    if (leftEpoch != null && rightEpoch != null && leftEpoch !== rightEpoch) {
+      return rightEpoch - leftEpoch;
+    }
+    if (leftEpoch != null && rightEpoch == null) return -1;
+    if (leftEpoch == null && rightEpoch != null) return 1;
+    return normalizeViewRoute(left.route).localeCompare(normalizeViewRoute(right.route), "ko-KR");
+  })[0];
+  return selected ? normalizeViewRoute(selected.route) : "/";
+}
+
+export function escapeViewHtml(value: unknown): string {
+  return String(value ?? "")
+    .replaceAll("&", "&amp;")
+    .replaceAll("<", "&lt;")
+    .replaceAll(">", "&gt;")
+    .replaceAll('"', "&quot;")
+    .replaceAll("'", "&#39;");
+}
+
+export function formatViewDateTime(value: unknown): string | null {
+  if (typeof value !== "string" || !value.trim()) {
+    return null;
+  }
+  const parsed = new Date(value);
+  if (!Number.isFinite(parsed.getTime())) {
+    return null;
+  }
+  const yyyy = parsed.getUTCFullYear();
+  const mm = String(parsed.getUTCMonth() + 1).padStart(2, "0");
+  const dd = String(parsed.getUTCDate()).padStart(2, "0");
+  const hh = String(parsed.getUTCHours()).padStart(2, "0");
+  const mi = String(parsed.getUTCMinutes()).padStart(2, "0");
+  return `${yyyy}-${mm}-${dd} ${hh}:${mi}`;
+}
+
+export function normalizeViewTags(tags: unknown): string[] {
+  if (!Array.isArray(tags)) {
+    return [];
+  }
+  return tags
+    .map((tag) => String(tag).trim().replace(/^#+/, ""))
+    .filter(Boolean);
+}
+
+function normalizeText(value: unknown, fallback = ""): string {
+  const normalized = typeof value === "string" ? value.trim() : "";
+  return normalized || fallback;
+}
+
+function createLinkModel(doc: Pick<ViewDocContract, "route" | "title">, pathBase: unknown): ViewLinkModel {
+  const route = normalizeViewRoute(doc.route);
+  return {
+    route,
+    href: toViewPathWithBase(route, pathBase),
+    title: normalizeText(doc.title, route),
+  };
+}
+
+export function createViewBreadcrumbModel(routeValue: unknown): ViewChromeModel["breadcrumb"] {
+  const route = normalizeViewRoute(routeValue);
+  const labels = ["~", ...route.split("/").filter(Boolean)];
+  return {
+    items: labels.map((label, index) => ({
+      label,
+      current: index === labels.length - 1 && labels.length > 1,
+    })),
+  };
+}
+
+export function createViewChromeModel(options: {
+  route: unknown;
+  doc: ViewDocContract;
+  docs: readonly ViewDocContract[];
+  pathBase: unknown;
+}): ViewChromeModel {
+  const currentIndex = options.docs.findIndex((doc) => doc.id === options.doc.id);
+  const previous = currentIndex > 0 ? options.docs[currentIndex - 1] : null;
+  const next =
+    currentIndex >= 0 && currentIndex < options.docs.length - 1
+      ? options.docs[currentIndex + 1]
+      : null;
+  const backlinks = Array.isArray(options.doc.backlinks) ? options.doc.backlinks : [];
+
+  return {
+    breadcrumb: createViewBreadcrumbModel(options.route),
+    meta: {
+      prefix: normalizeText(options.doc.prefix) || null,
+      createdAt: formatViewDateTime(options.doc.date),
+      tags: normalizeViewTags(options.doc.tags),
+    },
+    navigation: {
+      previous: previous ? createLinkModel(previous, options.pathBase) : null,
+      next: next ? createLinkModel(next, options.pathBase) : null,
+    },
+    backlinks: backlinks.map((backlink) => {
+      const route = normalizeViewRoute(backlink.route);
+      return {
+        route,
+        href: toViewPathWithBase(route, options.pathBase),
+        title: normalizeText(backlink.title, route),
+        prefix: normalizeText(backlink.prefix) || null,
+      };
+    }),
+  };
+}
+
+function renderBreadcrumb(model: ViewChromeModel["breadcrumb"]): string {
+  return model.items
+    .map((item) =>
+      item.current
+        ? `<span class="breadcrumb-current" aria-current="page">${escapeViewHtml(item.label)}</span>`
+        : `<span class="breadcrumb-item">${escapeViewHtml(item.label)}</span>`,
+    )
+    .join('<span class="material-symbols-outlined breadcrumb-sep">chevron_right</span>');
+}
+
+export function renderViewBreadcrumb(route: unknown): string {
+  return renderBreadcrumb(createViewBreadcrumbModel(route));
+}
+
+function renderMeta(model: ViewChromeModel["meta"]): string {
+  const items: string[] = [];
+  if (model.prefix) {
+    items.push(`<span class="meta-item meta-prefix">${escapeViewHtml(model.prefix)}</span>`);
+  }
+  if (model.createdAt) {
+    items.push(
+      `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeViewHtml(model.createdAt)}</span>`,
+    );
+  }
+  if (model.tags.length > 0) {
+    const tags = model.tags.map((tag) => `#${escapeViewHtml(tag)}`).join(" ");
+    items.push(`<span class="meta-item meta-tags">${tags}</span>`);
+  }
+  return items.join("");
+}
+
+function renderNavLink(link: ViewLinkModel, direction: "previous" | "next"): string {
+  if (direction === "previous") {
+    return `<a href="${escapeViewHtml(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewHtml(link.route)}"><div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div><div class="nav-link-title">${escapeViewHtml(link.title)}</div></a>`;
+  }
+  return `<a href="${escapeViewHtml(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewHtml(link.route)}"><div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div><div class="nav-link-title">${escapeViewHtml(link.title)}</div></a>`;
+}
+
+function renderNavigation(model: ViewChromeModel["navigation"]): string {
+  return [
+    model.previous ? renderNavLink(model.previous, "previous") : "",
+    model.next ? renderNavLink(model.next, "next") : "",
+  ].join("");
+}
+
+function renderBacklinks(model: ViewChromeModel["backlinks"]): string {
+  if (model.length === 0) {
+    return "";
+  }
+  const items = model
+    .map((backlink) => {
+      const prefix = backlink.prefix
+        ? `<span class="backlink-prefix">${escapeViewHtml(backlink.prefix)}</span>`
+        : "";
+      return `<li class="backlinks-item"><a href="${escapeViewHtml(backlink.href)}" class="backlink-link" data-route="${escapeViewHtml(backlink.route)}">${prefix}<span class="backlink-text">${escapeViewHtml(backlink.title)}</span></a></li>`;
+    })
+    .join("");
+  return `<h2 class="backlinks-title">Backlinks</h2><ul class="backlinks-list">${items}</ul>`;
+}
+
+export function renderViewChrome(options: {
+  route: unknown;
+  doc: ViewDocContract;
+  docs: readonly ViewDocContract[];
+  pathBase: unknown;
+}): RenderedViewChrome {
+  const model = createViewChromeModel(options);
+  return {
+    breadcrumbHtml: renderBreadcrumb(model.breadcrumb),
+    metaHtml: renderMeta(model.meta),
+    backlinksHtml: renderBacklinks(model.backlinks),
+    navHtml: renderNavigation(model.navigation),
+  };
+}
+
+export function composeViewDocumentTitle(pageTitle: unknown, siteTitle: unknown): string {
+  const left = normalizeText(pageTitle);
+  const right = normalizeText(siteTitle);
+  if (!left) {
+    return right || DEFAULT_SITE_TITLE;
+  }
+  if (!right || left === right) {
+    return left;
+  }
+  return `${left} - ${right}`;
+}

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -173,7 +173,16 @@ export function formatViewDateTime(value: unknown): string | null {
   if (typeof value !== "string" || !value.trim()) {
     return null;
   }
-  const parsed = new Date(value);
+  const normalized = value.trim();
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
+  const offsetlessDateTime =
+    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(normalized);
+  const deterministicInput = dateOnly
+    ? `${normalized}T00:00:00Z`
+    : offsetlessDateTime
+      ? `${normalized.replace(" ", "T")}Z`
+      : normalized;
+  const parsed = new Date(deterministicInput);
   if (!Number.isFinite(parsed.getTime())) {
     return null;
   }

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -176,13 +176,15 @@ export function pickViewHomeRoute(
   return selected ? normalizeViewRoute(selected.route) : "/";
 }
 
-export function escapeViewHtml(value: unknown): string {
+export function escapeViewText(value: unknown): string {
   return String(value ?? "")
     .replaceAll("&", "&amp;")
     .replaceAll("<", "&lt;")
-    .replaceAll(">", "&gt;")
-    .replaceAll('"', "&quot;")
-    .replaceAll("'", "&#39;");
+    .replaceAll(">", "&gt;");
+}
+
+function escapeViewAttribute(value: unknown): string {
+  return escapeViewText(value).replaceAll('"', "&quot;");
 }
 
 export function formatViewDateTime(value: unknown): string | null {
@@ -274,8 +276,8 @@ function renderBreadcrumb(model: ViewChromeModel["breadcrumb"]): string {
   return model.items
     .map((item) =>
       item.current
-        ? `<span class="breadcrumb-current" aria-current="page">${escapeViewHtml(item.label)}</span>`
-        : `<span class="breadcrumb-item">${escapeViewHtml(item.label)}</span>`,
+        ? `<span class="breadcrumb-current" aria-current="page">${escapeViewText(item.label)}</span>`
+        : `<span class="breadcrumb-item">${escapeViewText(item.label)}</span>`,
     )
     .join('<span class="material-symbols-outlined breadcrumb-sep">chevron_right</span>');
 }
@@ -287,15 +289,15 @@ export function renderViewBreadcrumb(route: unknown): string {
 function renderMeta(model: ViewChromeModel["meta"]): string {
   const items: string[] = [];
   if (model.prefix) {
-    items.push(`<span class="meta-item meta-prefix">${escapeViewHtml(model.prefix)}</span>`);
+    items.push(`<span class="meta-item meta-prefix">${escapeViewText(model.prefix)}</span>`);
   }
   if (model.createdAt) {
     items.push(
-      `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeViewHtml(model.createdAt)}</span>`,
+      `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeViewText(model.createdAt)}</span>`,
     );
   }
   if (model.tags.length > 0) {
-    const tags = model.tags.map((tag) => `#${escapeViewHtml(tag)}`).join(" ");
+    const tags = model.tags.map((tag) => `#${escapeViewText(tag)}`).join(" ");
     items.push(`<span class="meta-item meta-tags">${tags}</span>`);
   }
   return items.join("");
@@ -303,9 +305,9 @@ function renderMeta(model: ViewChromeModel["meta"]): string {
 
 function renderNavLink(link: ViewLinkModel, direction: "previous" | "next"): string {
   if (direction === "previous") {
-    return `<a href="${escapeViewHtml(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewHtml(link.route)}"><div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div><div class="nav-link-title">${escapeViewHtml(link.title)}</div></a>`;
+    return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
   }
-  return `<a href="${escapeViewHtml(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewHtml(link.route)}"><div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div><div class="nav-link-title">${escapeViewHtml(link.title)}</div></a>`;
+  return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
 }
 
 function renderNavigation(model: ViewChromeModel["navigation"]): string {
@@ -322,9 +324,9 @@ function renderBacklinks(model: ViewChromeModel["backlinks"]): string {
   const items = model
     .map((backlink) => {
       const prefix = backlink.prefix
-        ? `<span class="backlink-prefix">${escapeViewHtml(backlink.prefix)}</span>`
+        ? `<span class="backlink-prefix">${escapeViewText(backlink.prefix)}</span>`
         : "";
-      return `<li class="backlinks-item"><a href="${escapeViewHtml(backlink.href)}" class="backlink-link" data-route="${escapeViewHtml(backlink.route)}">${prefix}<span class="backlink-text">${escapeViewHtml(backlink.title)}</span></a></li>`;
+      return `<li class="backlinks-item"><a href="${escapeViewAttribute(backlink.href)}" class="backlink-link" data-route="${escapeViewAttribute(backlink.route)}">${prefix}<span class="backlink-text">${escapeViewText(backlink.title)}</span></a></li>`;
     })
     .join("");
   return `<h2 class="backlinks-title">Backlinks</h2><ul class="backlinks-list">${items}</ul>`;

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -132,11 +132,27 @@ export function filterViewDocsByBranch<T extends { branch?: unknown }>(
   });
 }
 
-function parseDateToEpochMs(value: unknown): number | null {
+function normalizeViewDateInput(value: unknown): string | null {
   if (typeof value !== "string" || !value.trim()) {
     return null;
   }
-  const parsed = Date.parse(value);
+  const normalized = value.trim();
+  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
+  const offsetlessDateTime =
+    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(normalized);
+  return dateOnly
+    ? `${normalized}T00:00:00Z`
+    : offsetlessDateTime
+      ? `${normalized.replace(" ", "T")}Z`
+      : normalized;
+}
+
+function parseDateToEpochMs(value: unknown): number | null {
+  const normalized = normalizeViewDateInput(value);
+  if (normalized == null) {
+    return null;
+  }
+  const parsed = Date.parse(normalized);
   return Number.isFinite(parsed) ? parsed : null;
 }
 
@@ -170,22 +186,11 @@ export function escapeViewHtml(value: unknown): string {
 }
 
 export function formatViewDateTime(value: unknown): string | null {
-  if (typeof value !== "string" || !value.trim()) {
+  const epoch = parseDateToEpochMs(value);
+  if (epoch == null) {
     return null;
   }
-  const normalized = value.trim();
-  const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
-  const offsetlessDateTime =
-    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(normalized);
-  const deterministicInput = dateOnly
-    ? `${normalized}T00:00:00Z`
-    : offsetlessDateTime
-      ? `${normalized.replace(" ", "T")}Z`
-      : normalized;
-  const parsed = new Date(deterministicInput);
-  if (!Number.isFinite(parsed.getTime())) {
-    return null;
-  }
+  const parsed = new Date(epoch);
   const yyyy = parsed.getUTCFullYear();
   const mm = String(parsed.getUTCMonth() + 1).padStart(2, "0");
   const dd = String(parsed.getUTCDate()).padStart(2, "0");

--- a/tests/e2e/runtime-navigation-controller.spec.ts
+++ b/tests/e2e/runtime-navigation-controller.spec.ts
@@ -129,10 +129,13 @@ test.describe("runtime navigation contracts", () => {
       pathBase: "/blog",
       siteTitle: "Site",
       renderers: {
+        chrome: ({ route, doc }: { route: string; doc: { id: string } }) => ({
+          breadcrumbHtml: `crumb:${route}`,
+          metaHtml: `meta:${doc.id}`,
+          backlinksHtml: `backlinks:${doc.id}`,
+          navHtml: `nav:${doc.id}`,
+        }),
         breadcrumb: (route: string) => `crumb:${route}`,
-        meta: (doc: { id: string }) => `meta:${doc.id}`,
-        backlinks: (doc: { id: string }) => `backlinks:${doc.id}`,
-        nav: (_view: unknown, docId: string) => `nav:${docId}`,
         documentTitle: (title: string, siteTitle: string) => `${title} - ${siteTitle}`,
       },
       lifecycle: {

--- a/tests/e2e/view-contract.spec.ts
+++ b/tests/e2e/view-contract.spec.ts
@@ -1,0 +1,167 @@
+import { expect, test, type Page } from "@playwright/test";
+import {
+  composeViewDocumentTitle,
+  createViewChromeModel,
+  filterViewDocsByBranch,
+  formatViewDateTime,
+  normalizeViewTags,
+  pickViewHomeRoute,
+  renderViewChrome,
+  toViewPathWithBase,
+} from "../../src/view-contract";
+import { waitForAppReady } from "./utils/app-ready";
+
+const CHROME_IDS = ["viewer-breadcrumb", "viewer-meta", "viewer-backlinks", "viewer-nav"];
+
+async function readChromeSnapshot(page: Page) {
+  return page.evaluate((ids) => {
+    const read = (id: string) => document.getElementById(id)?.innerHTML ?? null;
+    const backlinks = document.getElementById("viewer-backlinks");
+    return {
+      breadcrumbHtml: read(ids[0]),
+      metaHtml: read(ids[1]),
+      backlinksHtml: read(ids[2]),
+      navHtml: read(ids[3]),
+      backlinksHidden: backlinks?.hidden ?? null,
+      title: document.getElementById("viewer-title")?.textContent ?? null,
+    };
+  }, CHROME_IDS);
+}
+
+test.describe("shared SSR/client view contract", () => {
+  test("presentation model은 date, tag, pathBase와 escaping 규칙을 한 번 적용한다", () => {
+    const docs = [
+      {
+        id: "previous",
+        route: "/Previous/",
+        title: "Previous & safe",
+        branch: "dev",
+      },
+      {
+        id: "current",
+        route: "/Unsafe <route>/",
+        title: "Current",
+        prefix: "  P<1>  ",
+        date: "2026-07-19T10:30:00+09:00",
+        tags: [" #alpha ", "<beta>", ""],
+        branch: "dev",
+        backlinks: [
+          {
+            route: "/Back link/",
+            title: '<img src=x onerror="alert(1)">',
+            prefix: " B&1 ",
+          },
+        ],
+      },
+    ];
+
+    const model = createViewChromeModel({
+      route: docs[1].route,
+      doc: docs[1],
+      docs,
+      pathBase: "/docs 한글",
+    });
+    const rendered = renderViewChrome({
+      route: docs[1].route,
+      doc: docs[1],
+      docs,
+      pathBase: "/docs 한글",
+    });
+
+    expect(model.meta).toEqual({
+      prefix: "P<1>",
+      createdAt: "2026-07-19 01:30",
+      tags: ["alpha", "<beta>"],
+    });
+    expect(model.navigation.previous?.href).toBe(
+      "/docs%20%ED%95%9C%EA%B8%80/Previous/",
+    );
+    expect(model.backlinks[0].href).toBe(
+      "/docs%20%ED%95%9C%EA%B8%80/Back%20link/",
+    );
+    expect(rendered.breadcrumbHtml).toContain("Unsafe &lt;route&gt;");
+    expect(rendered.metaHtml).toContain("P&lt;1&gt;");
+    expect(rendered.backlinksHtml).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+    expect(rendered.backlinksHtml).not.toContain("<img");
+    expect(formatViewDateTime("invalid")).toBeNull();
+    expect(normalizeViewTags("not-an-array")).toEqual([]);
+    expect(toViewPathWithBase("/A B/", "/docs 한글")).toBe(
+      "/docs%20%ED%95%9C%EA%B8%80/A%20B/",
+    );
+    expect(composeViewDocumentTitle("Current", "Site")).toBe("Current - Site");
+  });
+
+  test("SSR nav와 client navigation은 같은 branch projection과 home 선택을 사용한다", () => {
+    const docs = [
+      { id: "base", route: "/BASE/", title: "Base", date: "2026-07-17", branch: null },
+      { id: "dev", route: "/DEV/", title: "Dev", date: "2026-07-19", branch: "dev" },
+      { id: "main", route: "/MAIN/", title: "Main", date: "2026-07-20", branch: "main" },
+    ];
+
+    expect(filterViewDocsByBranch(docs, "dev", "dev").map((doc) => doc.id)).toEqual([
+      "base",
+      "dev",
+    ]);
+    expect(filterViewDocsByBranch(docs, "main", "dev").map((doc) => doc.id)).toEqual([
+      "main",
+    ]);
+    expect(pickViewHomeRoute(filterViewDocsByBranch(docs, "dev", "dev"))).toBe("/DEV/");
+  });
+
+  test("동일한 SSR chrome은 초기 hydration에서 다시 쓰지 않는다", async ({ page }) => {
+    await page.addInitScript((ids) => {
+      const descriptor = Object.getOwnPropertyDescriptor(Element.prototype, "innerHTML");
+      const hydrationWindow = window as Window & { __eiamChromeWrites?: string[] };
+      hydrationWindow.__eiamChromeWrites = [];
+      if (!descriptor?.get || !descriptor.set) {
+        hydrationWindow.__eiamChromeWrites.push("unsupported-innerHTML-descriptor");
+        return;
+      }
+      const trackedIds = new Set(ids);
+      Object.defineProperty(Element.prototype, "innerHTML", {
+        configurable: descriptor.configurable,
+        enumerable: descriptor.enumerable,
+        get: descriptor.get,
+        set(this: Element, value: string) {
+          if (trackedIds.has(this.id)) {
+            hydrationWindow.__eiamChromeWrites?.push(this.id);
+          }
+          descriptor.set?.call(this, value);
+        },
+      });
+    }, CHROME_IDS);
+
+    for (const route of ["/BC-VO-00/", "/BC-VO-01/"]) {
+      await page.goto(route);
+      await waitForAppReady(page);
+      const writes = await page.evaluate(
+        () => (window as Window & { __eiamChromeWrites?: string[] }).__eiamChromeWrites ?? [],
+      );
+      expect(writes, route).toEqual([]);
+    }
+  });
+
+  test("direct-load와 client-navigation의 chrome snapshot이 동일하다", async ({ page, context }) => {
+    await page.goto("/BC-VO-00/");
+    await waitForAppReady(page);
+
+    const link = page.locator("#viewer-nav .nav-link-next, #viewer-nav .nav-link-prev").first();
+    const targetRoute = await link.getAttribute("data-route");
+    if (!targetRoute) {
+      throw new Error("snapshot 비교 대상 nav route를 찾지 못했습니다.");
+    }
+
+    const directPage = await context.newPage();
+    await directPage.goto(targetRoute);
+    await waitForAppReady(directPage);
+    const directSnapshot = await readChromeSnapshot(directPage);
+
+    await link.click();
+    await expect(page).toHaveURL(new RegExp(`${targetRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+    await expect(page.locator("#viewer-title")).toHaveText(directSnapshot.title ?? "");
+    const clientSnapshot = await readChromeSnapshot(page);
+
+    expect(clientSnapshot).toEqual(directSnapshot);
+    await directPage.close();
+  });
+});

--- a/tests/e2e/view-contract.spec.ts
+++ b/tests/e2e/view-contract.spec.ts
@@ -1,3 +1,7 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
 import { expect, test, type Page } from "@playwright/test";
 import {
   composeViewDocumentTitle,
@@ -9,6 +13,7 @@ import {
   renderViewChrome,
   toViewPathWithBase,
 } from "../../src/view-contract";
+import { createNavigationState, pickHomeRoute } from "../../src/runtime/navigation-state.js";
 import { waitForAppReady } from "./utils/app-ready";
 
 const CHROME_IDS = ["viewer-breadcrumb", "viewer-meta", "viewer-backlinks", "viewer-nav"];
@@ -84,6 +89,7 @@ test.describe("shared SSR/client view contract", () => {
     expect(rendered.backlinksHtml).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
     expect(rendered.backlinksHtml).not.toContain("<img");
     expect(formatViewDateTime("invalid")).toBeNull();
+    expect(formatViewDateTime("2024-09-20T09:30:00")).toBe("2024-09-20 09:30");
     expect(normalizeViewTags("not-an-array")).toEqual([]);
     expect(toViewPathWithBase("/A B/", "/docs 한글")).toBe(
       "/docs%20%ED%95%9C%EA%B8%80/A%20B/",
@@ -106,6 +112,78 @@ test.describe("shared SSR/client view contract", () => {
       "main",
     ]);
     expect(pickViewHomeRoute(filterViewDocsByBranch(docs, "dev", "dev"))).toBe("/DEV/");
+
+    const mainDoc = {
+      id: "main",
+      route: "/MAIN/",
+      title: "Main",
+      contentUrl: "/content/main.html",
+      date: "2026-07-20",
+      tags: [],
+      branch: "main",
+      backlinks: [],
+    };
+    const navigation = createNavigationState({
+      defaultBranch: "dev",
+      branches: ["dev", "main"],
+      ui: { newWithinDays: 0 },
+      docIds: [mainDoc.id],
+      docsById: { [mainDoc.id]: mainDoc },
+      routeMap: { [mainDoc.route]: mainDoc.id },
+      tree: [{ type: "file", name: "main.md", id: mainDoc.id }],
+    });
+    expect(navigation.activeBranch).toBe("main");
+    expect(pickHomeRoute(navigation.view)).toBe("/MAIN/");
+  });
+
+  test("default branch에 문서가 없어도 root SSR은 non-empty branch home을 사용한다", () => {
+    test.setTimeout(60_000);
+    const repoRoot = process.cwd();
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-view-fallback-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    fs.mkdirSync(vaultDir, { recursive: true });
+    fs.writeFileSync(
+      path.join(vaultDir, "main-only.md"),
+      `---
+publish: true
+prefix: MAIN-ONLY
+category_path: fallback
+branch: main
+title: Main Only
+date: "2026-07-19"
+tags: []
+---
+
+Main-only content.
+`,
+      "utf8",
+    );
+
+    try {
+      const result = spawnSync(
+        "bun",
+        [path.join(repoRoot, "src/cli.ts"), "build", "--vault", vaultDir, "--out", outDir],
+        { cwd: workDir, encoding: "utf8" },
+      );
+      const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+      expect(result.status, output).toBe(0);
+      const indexHtml = fs.readFileSync(path.join(outDir, "index.html"), "utf8");
+      const initialViewPayload = indexHtml.match(
+        /<script id="initial-view-data" type="application\/json">([^<]+)<\/script>/,
+      )?.[1];
+      expect(initialViewPayload).toBeTruthy();
+      expect(JSON.parse(initialViewPayload ?? "null")).toEqual({
+        route: "/MAIN-ONLY/",
+        docId: "main-only",
+        title: "Main Only",
+      });
+      expect(indexHtml).toContain(
+        '<h1 id="viewer-title" class="viewer-title">Main Only</h1>',
+      );
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
   });
 
   test("동일한 SSR chrome은 초기 hydration에서 다시 쓰지 않는다", async ({ page }) => {

--- a/tests/e2e/view-contract.spec.ts
+++ b/tests/e2e/view-contract.spec.ts
@@ -136,6 +136,37 @@ test.describe("shared SSR/client view contract", () => {
     expect(pickHomeRoute(navigation.view)).toBe("/MAIN/");
   });
 
+  test("offset 없는 datetime도 실행 timezone과 무관하게 같은 home을 선택한다", () => {
+    const originalTimezone = process.env.TZ;
+    const docs = [
+      {
+        id: "offsetless",
+        route: "/OFFSETLESS/",
+        title: "Offsetless",
+        updatedDate: "2024-09-20T00:30:00",
+      },
+      {
+        id: "qualified",
+        route: "/QUALIFIED/",
+        title: "Qualified",
+        updatedDate: "2024-09-20T05:00:00Z",
+      },
+    ];
+
+    try {
+      for (const timezone of ["UTC", "America/Los_Angeles", "Asia/Seoul"]) {
+        process.env.TZ = timezone;
+        expect(pickViewHomeRoute(docs), timezone).toBe("/QUALIFIED/");
+      }
+    } finally {
+      if (originalTimezone == null) {
+        delete process.env.TZ;
+      } else {
+        process.env.TZ = originalTimezone;
+      }
+    }
+  });
+
   test("default branch에 문서가 없어도 root SSR은 non-empty branch home을 사용한다", () => {
     test.setTimeout(60_000);
     const repoRoot = process.cwd();

--- a/tests/e2e/view-contract.spec.ts
+++ b/tests/e2e/view-contract.spec.ts
@@ -86,7 +86,7 @@ test.describe("shared SSR/client view contract", () => {
     );
     expect(rendered.breadcrumbHtml).toContain("Unsafe &lt;route&gt;");
     expect(rendered.metaHtml).toContain("P&lt;1&gt;");
-    expect(rendered.backlinksHtml).toContain("&lt;img src=x onerror=&quot;alert(1)&quot;&gt;");
+    expect(rendered.backlinksHtml).toContain('&lt;img src=x onerror="alert(1)"&gt;');
     expect(rendered.backlinksHtml).not.toContain("<img");
     expect(formatViewDateTime("invalid")).toBeNull();
     expect(formatViewDateTime("2024-09-20T09:30:00")).toBe("2024-09-20 09:30");
@@ -95,6 +95,54 @@ test.describe("shared SSR/client view contract", () => {
       "/docs%20%ED%95%9C%EA%B8%80/A%20B/",
     );
     expect(composeViewDocumentTitle("Current", "Site")).toBe("Current - Site");
+  });
+
+  test("따옴표가 있는 chrome도 browser innerHTML과 byte-identical하다", async ({ page }) => {
+    const docs = [
+      {
+        id: "previous",
+        route: `/Alice's "Notes"/`,
+        title: `Alice's "Notes"`,
+      },
+      {
+        id: "current",
+        route: "/Current/",
+        title: "Current",
+        prefix: `P's "Q"`,
+        tags: [`tag's`, `"quoted"`],
+        backlinks: [
+          {
+            route: `/Backlink's "Route"/`,
+            title: `Backlink's "Title"`,
+            prefix: `B's "P"`,
+          },
+        ],
+      },
+    ];
+    const rendered = renderViewChrome({
+      route: docs[1].route,
+      doc: docs[1],
+      docs,
+      pathBase: "",
+    });
+
+    await page.setContent(
+      `<div id="viewer-breadcrumb">${rendered.breadcrumbHtml}</div>` +
+        `<div id="viewer-meta">${rendered.metaHtml}</div>` +
+        `<div id="viewer-backlinks">${rendered.backlinksHtml}</div>` +
+        `<div id="viewer-nav">${rendered.navHtml}</div>`,
+    );
+
+    const canonical = await page.evaluate((ids) => {
+      const read = (id: string) => document.getElementById(id)?.innerHTML ?? "";
+      return {
+        breadcrumbHtml: read(ids[0]),
+        metaHtml: read(ids[1]),
+        backlinksHtml: read(ids[2]),
+        navHtml: read(ids[3]),
+      };
+    }, CHROME_IDS);
+    expect(canonical).toEqual(rendered);
   });
 
   test("SSR nav와 client navigation은 같은 branch projection과 home 선택을 사용한다", () => {


### PR DESCRIPTION
Part of #29. Depends on #72. Detailed context: #32.

## Goal

Make direct-load SSR and client navigation derive viewer chrome from one browser-safe presentation model and avoid rewriting identical hydrated markup.

## Scope

- Add view-contract.ts for canonical pathBase/route, branch projection, home route, UTC date, tag, title, and escaping rules
- Build breadcrumb, metadata, previous/next, and backlinks models once and render the same HTML in build output and browser runtime
- Filter SSR previous/next documents with the same active/default branch projection as navigation-state.js
- Use a deterministic non-empty branch fallback when the configured default branch has no documents
- Treat offset-less ISO date-times as UTC for both rendering and home selection so server and browser cannot drift by timezone
- Separate browser-canonical text-node and attribute escaping so quoted chrome does not trigger hydration rewrites
- Reuse the shared path contract for runtime bootstrap and 404 links
- Apply viewer chrome only when innerHTML/text/hidden values actually differ
- Add malicious-input contract tests, branch fallback checks, hydration write checks, and direct/client snapshot equivalence
- Document the shared presentation and hydration contract

## Excluded

- Additional visual redesign or content markup changes
- Final mother-to-main merge

## DnD

- [x] SSR and client navigation render equivalent breadcrumb/meta/backlinks/nav structures
- [x] Date, tag, route/pathBase, branch projection, title, and escaping rules have one canonical implementation
- [x] Identical initial SSR chrome performs zero tracked innerHTML writes during hydration
- [x] Quoted prefix/tag/backlink/nav/route chrome is byte-identical to browser innerHTML
- [x] Branch-specific direct loads use the same nav projection as client navigation
- [x] Empty default-branch projections select the same non-empty fallback in build and runtime
- [x] Direct-load and client-navigation chrome snapshots are compared in browser tests
- [x] Existing pathBase, history, branch, XSS, mobile, search, and accessibility regressions remain green

## Verification

- bunx tsc --noEmit
- isolated build against ./test-vault
- bunx playwright test tests/e2e/view-contract.spec.ts (7 passed)
- targeted view/navigation/pathBase/branch/XSS suite (15 passed before final regressions)
- bun run check:size
- bun run check:reproducible (18 files stable; digest 300fb9bf88f8)
- bunx playwright test (81 passed)

## Size

- app JS: 41,249 / 45,000 raw bytes; 14,235 / 15,000 gzip bytes

Issue: #29
