### PR TITLE
build: browser runtime strict typecheck

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,6 +24,9 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Typecheck TypeScript and browser runtime
+        run: bun run typecheck
+
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium
 

--- a/README.ko.md
+++ b/README.ko.md
@@ -34,6 +34,7 @@ bun run blog [build|dev|clean] [options]
 - `bun run build`: 정적 파일 빌드
 - `bun run dev`: 로컬 개발 서버 실행 (기본 `http://localhost:3000`)
 - `bun run clean`: EIAM 소유권 마커가 확인된 `dist`와 일치하는 EIAM cache namespace만 삭제
+- `bun run typecheck`: TypeScript와 브라우저 런타임 JavaScript 정적 타입 검사
 
 빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리, cache root를 포함하거나 그 안에 놓인 경로는 출력으로 사용하지 않으며, symlink인 cache path component, namespace, index도 거부합니다. `staticPaths`는 output 밖으로 벗어나거나 예약된 `.eiam-output.json` 마커와 충돌할 수 없습니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output과 예약 static path를 거부하는 경로에서도 이 migration을 수행합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 

--- a/README.md
+++ b/README.md
@@ -602,6 +602,7 @@ Scripts from `package.json`:
 
 ```bash
 bun install
+bun run typecheck
 bun run build -- --vault ./test-vault --out ./dist
 bun run dev -- --vault ./test-vault --out ./dist
 bun run test:e2e

--- a/bun.lock
+++ b/bun.lock
@@ -23,6 +23,7 @@
         "@types/sanitize-html": "2.16.1",
         "bun-types": "^1.3.14",
         "markdownlint": "^0.40.0",
+        "typescript": "7.0.2",
       },
     },
   },
@@ -68,6 +69,46 @@
     "@types/sanitize-html": ["@types/sanitize-html@2.16.1", "", { "dependencies": { "htmlparser2": "^10.1" } }, "sha512-n9wjs8bCOTyN/ynwD8s/nTcTreIHB1vf31vhLMGqUPNHaweKC4/fAl4Dj+hUlCTKYgm4P3k83fmiFfzkZ6sgMA=="],
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
+
+    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+
+    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+
+    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+
+    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+
+    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+
+    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+
+    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+
+    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+
+    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+
+    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
+
+    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
+
+    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
+
+    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
+
+    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
+
+    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
+
+    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
+
+    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
+
+    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
+
+    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
+
+    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
 
@@ -278,6 +319,8 @@
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
+
+    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 

--- a/package.json
+++ b/package.json
@@ -24,6 +24,7 @@
 		"check:size": "bun run scripts/check-output-size.ts --out ./dist",
 		"check:reproducible": "bun run scripts/check-build-reproducibility.ts --vault ./test-vault --out ./dist",
 		"lint:md:publish": "bun run scripts/lint-published-markdown.ts --out-dir dist",
+		"typecheck": "tsc --noEmit",
 		"test:e2e": "playwright test",
 		"test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"
 	},
@@ -45,6 +46,7 @@
 		"@types/picomatch": "^4.0.3",
 		"@types/sanitize-html": "2.16.1",
 		"bun-types": "^1.3.14",
-		"markdownlint": "^0.40.0"
+		"markdownlint": "^0.40.0",
+		"typescript": "7.0.2"
 	}
 }

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -20,10 +20,23 @@ const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
 const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
 
+/**
+ * @typedef {import("./contracts").A11yAnnouncer} A11yAnnouncer
+ * @typedef {import("./contracts").ContentController} ContentController
+ * @typedef {import("./contracts").RuntimeController} RuntimeController
+ * @typedef {import("./contracts").TreeController} TreeController
+ * @typedef {import("./contracts").ViewerElements} ViewerElements
+ */
+
+/**
+ * @param {string} attribute
+ * @param {string} state
+ */
 function setRuntimeState(attribute, state) {
   document.documentElement?.setAttribute(attribute, state);
 }
 
+/** @returns {ViewerElements} */
 function collectViewerElements() {
   return {
     breadcrumb: document.getElementById("viewer-breadcrumb"),
@@ -36,9 +49,15 @@ function collectViewerElements() {
   };
 }
 
+/**
+ * @param {HTMLElement | null} element
+ * @returns {A11yAnnouncer}
+ */
 function createA11yAnnouncer(element) {
+  /** @type {number | null} */
   let timer = null;
   return {
+    /** @param {string} message */
     announce(message) {
       if (!element) {
         return;
@@ -61,6 +80,10 @@ function createA11yAnnouncer(element) {
   };
 }
 
+/**
+ * @param {RuntimeController[]} controllers
+ * @param {ContentController} contentController
+ */
 function installPageLifecycle(controllers, contentController) {
   window.addEventListener("pagehide", (event) => {
     if (event.persisted) {
@@ -76,6 +99,7 @@ function installPageLifecycle(controllers, contentController) {
   });
 }
 
+/** @param {RuntimeController[]} controllers */
 function destroyControllers(controllers) {
   for (const controller of [...controllers].reverse()) {
     controller.destroy?.();
@@ -94,10 +118,11 @@ async function start() {
     initialDocId: bootstrap.initialViewData?.docId,
   });
   const settingsController = createSettingsController();
+  /** @type {TreeController | null} */
   let treeController = null;
   const layoutController = createSidebarLayoutController({
     closeSettings: () => settingsController.close(),
-    requestTreeLoad: (reason) => treeController?.requestLoad(reason),
+    requestTreeLoad: (reason) => treeController?.requestLoad(reason) ?? Promise.resolve(false),
   });
   const mermaidController = createMermaidController(resolveMermaidConfig(bootstrap.manifest));
   const enhancementController = createContentEnhancementController({
@@ -146,6 +171,7 @@ async function start() {
     isCompactLayout: () => layoutController.isCompact(),
   });
 
+  /** @type {RuntimeController[]} */
   const controllers = [
     settingsController,
     layoutController,

--- a/src/runtime/content-controller.js
+++ b/src/runtime/content-controller.js
@@ -1,17 +1,49 @@
 import { toPathWithBase } from "./navigation-state.js";
 
+/** @typedef {import("./contracts").ContentController} ContentController */
+/** @typedef {import("./contracts").ContentLifecycle} ContentLifecycle */
+/** @typedef {import("./contracts").ContentRenderers} ContentRenderers */
+/** @typedef {import("./contracts").InitialViewData} InitialViewData */
+/** @typedef {import("./contracts").NavigationState} NavigationState */
+/** @typedef {import("./contracts").RuntimeManifestDoc} RuntimeManifestDoc */
+/** @typedef {import("./contracts").ViewerElements} ViewerElements */
+
+/**
+ * @param {Element | null | undefined} element
+ * @param {string} value
+ */
 function setHtml(element, value) {
   if (element && element.innerHTML !== value) {
     element.innerHTML = value;
   }
 }
 
+/**
+ * @param {Node | null | undefined} element
+ * @param {string} value
+ */
 function setText(element, value) {
   if (element && element.textContent !== value) {
     element.textContent = value;
   }
 }
 
+/**
+ * @param {{
+ *   navigation: NavigationState;
+ *   elements: ViewerElements;
+ *   initialViewData: InitialViewData | null;
+ *   pathBase: string;
+ *   siteTitle: string;
+ *   renderers: ContentRenderers;
+ *   lifecycle?: ContentLifecycle;
+ *   fetchContent?: (url: string) => Promise<Response>;
+ *   historyApi?: Pick<History, "pushState"> | null;
+ *   locationApi?: Pick<Location, "pathname"> | null;
+ *   setPageTitle?: (value: string) => void;
+ * }} options
+ * @returns {ContentController}
+ */
 export function createContentController(options) {
   const {
     navigation,
@@ -31,6 +63,7 @@ export function createContentController(options) {
   let hasHydratedInitialView = false;
   let isSetup = false;
 
+  /** @param {string} html */
   const updateBacklinks = (html) => {
     if (!elements.backlinks) {
       return;
@@ -42,6 +75,10 @@ export function createContentController(options) {
     }
   };
 
+  /**
+   * @param {string} route
+   * @param {RuntimeManifestDoc} doc
+   */
   const renderChrome = (route, doc) => {
     const chrome = renderers.chrome({
       route,
@@ -56,6 +93,7 @@ export function createContentController(options) {
     setHtml(elements.nav, chrome.navHtml);
   };
 
+  /** @param {RuntimeManifestDoc} doc */
   const finishNavigation = async (doc) => {
     await lifecycle.enhanceContent?.(elements.content);
     setPageTitle(renderers.documentTitle(doc.title, siteTitle));
@@ -63,6 +101,10 @@ export function createContentController(options) {
     lifecycle.announce?.(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
   };
 
+  /**
+   * @param {string} route
+   * @param {boolean} push
+   */
   const renderMissingRoute = (route, push) => {
     navigation.setCurrentDocId("");
     lifecycle.onMissingSelection?.();
@@ -78,6 +120,10 @@ export function createContentController(options) {
     }
   };
 
+  /**
+   * @param {unknown} rawRoute
+   * @param {boolean} push
+   */
   const navigate = async (rawRoute, push) => {
     lifecycle.beforeNavigate?.();
     const resolved = navigation.resolve(rawRoute);
@@ -124,6 +170,7 @@ export function createContentController(options) {
     return true;
   };
 
+  /** @param {Event} event */
   const handleLinkClick = (event) => {
     const target = event.target;
     if (!(target instanceof Element)) {

--- a/src/runtime/content-enhancement-controller.js
+++ b/src/runtime/content-enhancement-controller.js
@@ -5,8 +5,16 @@ const CONTENT_IMAGE_PORTRAIT_CLASS = "is-portrait";
 const CONTENT_IMAGE_SQUARE_CLASS = "is-square";
 const CONTENT_IMAGE_LANDSCAPE_THRESHOLD = 1.1;
 const CONTENT_IMAGE_PORTRAIT_THRESHOLD = 0.9;
+/** @typedef {{ width: number; height: number }} ImageDimensions */
+/** @typedef {import("./contracts").ContentEnhancementController} ContentEnhancementController */
+/** @typedef {import("./contracts").EventScope} EventScope */
+/** @typedef {import("./contracts").MermaidController} MermaidController */
+/** @typedef {import("./contracts").RuntimeWindow} RuntimeWindow */
+
+/** @type {Map<string, Promise<ImageDimensions | null>>} */
 const contentImageDimensionCache = new Map();
 
+/** @param {Element | null | undefined} target */
 function clearContentImageClasses(target) {
   target?.classList?.remove(
     CONTENT_IMAGE_LANDSCAPE_CLASS,
@@ -15,6 +23,11 @@ function clearContentImageClasses(target) {
   );
 }
 
+/**
+ * @param {unknown} image
+ * @param {string} className
+ * @param {RuntimeWindow} windowRef
+ */
 function syncContentImageClasses(image, className, windowRef) {
   if (!(image instanceof windowRef.HTMLImageElement)) {
     return;
@@ -33,6 +46,11 @@ function syncContentImageClasses(image, className, windowRef) {
   }
 }
 
+/**
+ * @param {unknown} imageLike
+ * @param {RuntimeWindow} windowRef
+ * @returns {ImageDimensions | null}
+ */
 function readIntrinsicImageDimensions(imageLike, windowRef) {
   if (!(imageLike instanceof windowRef.HTMLImageElement)) {
     return null;
@@ -54,6 +72,11 @@ function readIntrinsicImageDimensions(imageLike, windowRef) {
   return { width, height };
 }
 
+/**
+ * @param {unknown} image
+ * @param {ImageDimensions | null} dimensions
+ * @param {RuntimeWindow} windowRef
+ */
 function classifyContentImageByDimensions(image, dimensions, windowRef) {
   if (!(image instanceof windowRef.HTMLImageElement) || !dimensions) {
     return;
@@ -73,6 +96,11 @@ function classifyContentImageByDimensions(image, dimensions, windowRef) {
   syncContentImageClasses(image, CONTENT_IMAGE_SQUARE_CLASS, windowRef);
 }
 
+/**
+ * @param {HTMLImageElement} image
+ * @param {RuntimeWindow} windowRef
+ * @returns {Promise<ImageDimensions | null>}
+ */
 function resolveContentImageDimensions(image, windowRef) {
   const immediate = readIntrinsicImageDimensions(image, windowRef);
   if (immediate) {
@@ -89,7 +117,7 @@ function resolveContentImageDimensions(image, windowRef) {
     return cached;
   }
 
-  const pending = new Promise((resolve) => {
+  const pending = new Promise((/** @type {(value: ImageDimensions | null) => void} */ resolve) => {
     const probe = new windowRef.Image();
     const finalize = () => {
       resolve(readIntrinsicImageDimensions(probe, windowRef));
@@ -112,6 +140,10 @@ function resolveContentImageDimensions(image, windowRef) {
   return pending;
 }
 
+/**
+ * @param {Element} image
+ * @param {RuntimeWindow} windowRef
+ */
 function prepareContentImage(image, windowRef) {
   if (!(image instanceof windowRef.HTMLImageElement) || image.closest(".mermaid-block")) {
     return;
@@ -155,6 +187,10 @@ function prepareContentImage(image, windowRef) {
   }
 }
 
+/**
+ * @param {ParentNode | null | undefined} root
+ * @param {RuntimeWindow} [windowRef]
+ */
 export function enhanceContentImages(root, windowRef = globalThis.window) {
   if (!root?.querySelectorAll) {
     return;
@@ -165,6 +201,10 @@ export function enhanceContentImages(root, windowRef = globalThis.window) {
   }
 }
 
+/**
+ * @param {{ root: HTMLElement | null; mermaidController: MermaidController; clipboard?: Pick<Clipboard, "writeText">; windowRef?: RuntimeWindow }} options
+ * @returns {ContentEnhancementController}
+ */
 export function createContentEnhancementController(options) {
   const {
     root,
@@ -172,9 +212,12 @@ export function createContentEnhancementController(options) {
     clipboard = globalThis.navigator?.clipboard,
     windowRef = globalThis.window,
   } = options;
+  /** @type {EventScope | null} */
   let events = null;
+  /** @type {Set<number>} */
   const resetTimers = new Set();
 
+  /** @param {Event} event */
   const handleCopyClick = async (event) => {
     const target = event.target;
     if (!(target instanceof windowRef.Element)) {

--- a/src/runtime/contracts.ts
+++ b/src/runtime/contracts.ts
@@ -1,0 +1,235 @@
+import type { Manifest, ManifestDoc } from "../types";
+import type { RenderedViewChrome } from "../view-contract";
+
+export type RuntimeManifest = Manifest;
+export type RuntimeManifestDoc = ManifestDoc & { isNew: boolean };
+export type RuntimeWindow = Window &
+  typeof globalThis & {
+    mermaid?: MermaidLibrary;
+  };
+
+export interface InitialViewData {
+  route: string;
+  docId: string;
+  title: string;
+}
+
+export interface InitialRuntimeData {
+  manifestUrl: string;
+  pathBase: string;
+  treeModuleUrl: string;
+}
+
+export interface RuntimeBootstrap {
+  initialViewData: InitialViewData | null;
+  manifest: RuntimeManifest;
+  pathBase: string;
+  siteTitle: string;
+  treeModuleUrl: string;
+}
+
+export interface RuntimeTreeFileNode {
+  type: "file";
+  name: string;
+  id: string;
+  title?: string;
+  prefix?: string;
+  route?: string;
+  branch?: string | null;
+  isNew?: boolean;
+}
+
+export interface RuntimeTreeFolderNode {
+  type: "folder";
+  name: string;
+  path: string;
+  virtual?: boolean;
+  children: RuntimeTreeNode[];
+}
+
+export type RuntimeTreeNode = RuntimeTreeFolderNode | RuntimeTreeFileNode;
+
+export interface TreeFolderMetadata {
+  kind: "folder";
+  name: string;
+  sourcePath: string;
+  virtual: boolean;
+}
+
+export interface TreeFileMetadata {
+  kind: "file";
+  branch: string | null;
+  docId: string;
+  isNew: boolean;
+  prefix: string;
+  route: string;
+  title: string;
+}
+
+export type TreePathMetadata = TreeFolderMetadata | TreeFileMetadata;
+
+export interface TreesAdapterInput {
+  docIdToPrimaryTreePath: Map<string, string>;
+  docIdToTreePaths: Map<string, string[]>;
+  metadataByTreePath: Map<string, TreePathMetadata>;
+  paths: string[];
+  treePathToDocId: Map<string, string>;
+  treePathToRoute: Map<string, string>;
+}
+
+export interface BranchView {
+  docs: RuntimeManifestDoc[];
+  visibleDocIds: Set<string>;
+  tree: RuntimeTreeNode[];
+  trees: TreesAdapterInput;
+  routeMap: Record<string, string>;
+  docIndexById: Map<string, number>;
+}
+
+export interface NavigationResolution {
+  route: string;
+  id: string | null;
+  doc: RuntimeManifestDoc | null;
+  branchChanged: boolean;
+}
+
+export interface NavigationState {
+  availableBranches: string[];
+  defaultBranch: string;
+  readonly activeBranch: string;
+  readonly currentDocId: string;
+  readonly view: BranchView;
+  setActiveBranch(value: unknown): boolean;
+  setCurrentDocId(value: unknown): void;
+  resolve(rawRoute: unknown): NavigationResolution;
+}
+
+export interface RuntimeController {
+  setup?: () => void;
+  destroy?: () => void;
+}
+
+export interface A11yAnnouncer extends RuntimeController {
+  announce(message: string): void;
+  destroy(): void;
+}
+
+export interface EventScope {
+  listen(
+    target: EventTarget | null | undefined,
+    type: string,
+    listener: EventListenerOrEventListenerObject,
+    options?: boolean | AddEventListenerOptions,
+  ): void;
+  cleanup(): void;
+  readonly size: number;
+}
+
+export interface ViewerElements {
+  breadcrumb: HTMLElement | null;
+  title: HTMLElement | null;
+  meta: HTMLElement | null;
+  content: HTMLElement | null;
+  backlinks: HTMLElement | null;
+  nav: HTMLElement | null;
+  viewer: Element | null;
+}
+
+export interface ContentRenderers {
+  breadcrumb(route: unknown): string;
+  chrome(options: {
+    route: unknown;
+    doc: RuntimeManifestDoc;
+    docs: readonly RuntimeManifestDoc[];
+    pathBase: unknown;
+  }): RenderedViewChrome;
+  documentTitle(pageTitle: unknown, siteTitle: unknown): string;
+}
+
+export interface ContentLifecycle {
+  beforeNavigate?: () => void;
+  onBranchChange?: (branch: string) => void;
+  onCurrentDocChange?: (docId: string) => void;
+  onMissingSelection?: () => void;
+  enhanceContent?: (target: HTMLElement | null) => void | Promise<void>;
+  announce?: (message: string) => void;
+  resolveLocationRoute?: (pathname: string) => string;
+}
+
+export interface ContentController extends RuntimeController {
+  navigate(rawRoute: unknown, push: boolean): Promise<boolean>;
+  setup(): void;
+  destroy(): void;
+}
+
+export interface MermaidConfig {
+  enabled: boolean;
+  cdnUrl: string;
+  theme: string;
+}
+
+export interface MermaidLibrary {
+  initialize: (options: { startOnLoad: boolean; theme: string }) => void;
+  run?: (options: { nodes: HTMLElement[] }) => Promise<void> | void;
+  init?: (options: { startOnLoad: boolean }, nodes: HTMLElement[]) => Promise<void> | void;
+}
+
+export interface MermaidController extends RuntimeController {
+  setup(): void;
+  destroy(): void;
+  render(root?: ParentNode | null): Promise<void>;
+}
+
+export interface ContentEnhancementController extends RuntimeController {
+  setup(): void;
+  destroy(): void;
+  enhance(target?: HTMLElement | null): Promise<void>;
+}
+
+export interface SettingsController extends RuntimeController {
+  close(): void;
+  setup(): void;
+  destroy(): void;
+}
+
+export interface SidebarLayoutController extends RuntimeController {
+  close(): void;
+  isCompact(): boolean;
+  setup(): void;
+  destroy(): void;
+}
+
+export interface TreeController extends RuntimeController {
+  clearSelection(): void;
+  handleBranchChange(branch: string): void;
+  requestLoad(reason: string, options?: { retry?: boolean }): Promise<boolean>;
+  scheduleDeferredLoad(): void;
+  setActiveBranch(branch: unknown): Promise<boolean>;
+  setup(): void;
+  destroy(): void;
+  syncActiveSelection(docId: string, options?: { scroll?: boolean }): void;
+}
+
+export interface TreeControllerOptions {
+  navigation: NavigationState;
+  pathBase: string;
+  treeModuleUrl: string;
+  navigate: (route: string, push: boolean) => Promise<boolean>;
+  announce?: (message: string) => void;
+  isCompactLayout?: () => boolean;
+  documentRef?: Document;
+  windowRef?: RuntimeWindow;
+  storage?: Pick<Storage, "setItem">;
+}
+
+export type TreeLabelHost = HTMLElement & {
+  __eiamTreeLabelFrame?: number;
+  __eiamTreeLabelObserver?: MutationObserver;
+  __eiamTreeLabelObservedRoot?: ParentNode;
+  __eiamMetadataByTreePath?: Map<string, TreePathMetadata>;
+};
+
+export type TreeRuntimeModule = Pick<
+  typeof import("@pierre/trees"),
+  "FileTree" | "prepareFileTreeInput"
+> & { TREE_UNSAFE_CSS: string };

--- a/src/runtime/controller-lifecycle.js
+++ b/src/runtime/controller-lifecycle.js
@@ -1,4 +1,8 @@
+/** @typedef {import("./contracts").EventScope} EventScope */
+
+/** @returns {EventScope} */
 export function createEventScope() {
+  /** @type {Array<{ target: EventTarget; type: string; listener: EventListenerOrEventListenerObject; options?: boolean | AddEventListenerOptions }>} */
   const subscriptions = [];
 
   return {
@@ -12,6 +16,9 @@ export function createEventScope() {
     cleanup() {
       while (subscriptions.length > 0) {
         const subscription = subscriptions.pop();
+        if (!subscription) {
+          continue;
+        }
         subscription.target.removeEventListener(
           subscription.type,
           subscription.listener,

--- a/src/runtime/manifest-adapter.js
+++ b/src/runtime/manifest-adapter.js
@@ -1,37 +1,62 @@
 const CURRENT_SCHEMA_VERSION = 2;
 
+/** @typedef {import("./contracts").RuntimeManifest} RuntimeManifest */
+/** @typedef {import("./contracts").RuntimeManifestDoc} RuntimeManifestDoc */
+/** @typedef {{ docIds: string[]; docsById: Record<string, Record<string, unknown> & { id: string }> }} NormalizedDocIndex */
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
 function isRecord(value) {
   return !!value && typeof value === "object" && !Array.isArray(value);
 }
 
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown> & { tree: unknown[]; routeMap: Record<string, unknown> }}
+ */
 function hasManifestEnvelope(value) {
   return isRecord(value) && Array.isArray(value.tree) && isRecord(value.routeMap);
 }
 
+/**
+ * @param {unknown} docs
+ * @returns {NormalizedDocIndex | null}
+ */
 function collectLegacyDocs(docs) {
   if (!Array.isArray(docs)) {
     return null;
   }
 
+  /** @type {string[]} */
   const docIds = [];
+  /** @type {Record<string, Record<string, unknown> & { id: string }>} */
   const docsById = Object.create(null);
   for (const doc of docs) {
     if (!isRecord(doc) || typeof doc.id !== "string" || !doc.id || Object.hasOwn(docsById, doc.id)) {
       return null;
     }
     docIds.push(doc.id);
-    docsById[doc.id] = doc;
+    docsById[doc.id] = /** @type {Record<string, unknown> & { id: string }} */ (doc);
   }
 
   return { docIds, docsById };
 }
 
+/**
+ * @param {unknown} docIdsInput
+ * @param {unknown} docsByIdInput
+ * @returns {NormalizedDocIndex | null}
+ */
 function collectCurrentDocs(docIdsInput, docsByIdInput) {
   if (!Array.isArray(docIdsInput) || !isRecord(docsByIdInput)) {
     return null;
   }
 
+  /** @type {string[]} */
   const docIds = [];
+  /** @type {Record<string, Record<string, unknown> & { id: string }>} */
   const docsById = Object.create(null);
   for (const id of docIdsInput) {
     if (
@@ -48,7 +73,7 @@ function collectCurrentDocs(docIdsInput, docsByIdInput) {
       return null;
     }
     docIds.push(id);
-    docsById[id] = doc;
+    docsById[id] = /** @type {Record<string, unknown> & { id: string }} */ (doc);
   }
 
   if (Object.keys(docsByIdInput).length !== docIds.length) {
@@ -58,6 +83,10 @@ function collectCurrentDocs(docIdsInput, docsByIdInput) {
   return { docIds, docsById };
 }
 
+/**
+ * @param {unknown} value
+ * @returns {RuntimeManifest | null}
+ */
 export function normalizeManifestPayload(value) {
   if (!hasManifestEnvelope(value)) {
     return null;
@@ -77,13 +106,19 @@ export function normalizeManifestPayload(value) {
   }
 
   const { docs: _legacyDocs, ...manifest } = value;
-  return {
-    ...manifest,
-    schemaVersion: CURRENT_SCHEMA_VERSION,
-    ...normalizedDocs,
-  };
+  return /** @type {RuntimeManifest} */ (
+    /** @type {unknown} */ ({
+      ...manifest,
+      schemaVersion: CURRENT_SCHEMA_VERSION,
+      ...normalizedDocs,
+    })
+  );
 }
 
+/**
+ * @param {RuntimeManifest | null | undefined} manifest
+ * @returns {import("../types").ManifestDoc[]}
+ */
 export function getManifestDocs(manifest) {
   if (!manifest || !Array.isArray(manifest.docIds) || !isRecord(manifest.docsById)) {
     return [];
@@ -91,9 +126,15 @@ export function getManifestDocs(manifest) {
   return manifest.docIds.map((id) => manifest.docsById[id]).filter(Boolean);
 }
 
+/**
+ * @param {RuntimeManifest | null | undefined} manifest
+ * @param {number} [nowMs]
+ * @returns {RuntimeManifestDoc[]}
+ */
 export function getRuntimeManifestDocs(manifest, nowMs = Date.now()) {
-  const newWithinDays = Number.isFinite(manifest?.ui?.newWithinDays)
-    ? Math.max(0, Number(manifest.ui.newWithinDays))
+  const configuredNewWithinDays = manifest?.ui?.newWithinDays;
+  const newWithinDays = Number.isFinite(configuredNewWithinDays)
+    ? Math.max(0, Number(configuredNewWithinDays))
     : 0;
   const threshold = nowMs - newWithinDays * 24 * 60 * 60 * 1000;
 

--- a/src/runtime/mermaid-controller.js
+++ b/src/runtime/mermaid-controller.js
@@ -9,6 +9,15 @@ const MERMAID_TALL_RATIO = 0.85;
 const MERMAID_BLOCK_WIDE_CLASS = "is-wide";
 const MERMAID_BLOCK_TALL_CLASS = "is-tall";
 
+/**
+ * @typedef {import("./contracts").MermaidConfig} MermaidConfig
+ * @typedef {import("./contracts").MermaidController} MermaidController
+ * @typedef {import("./contracts").MermaidLibrary} MermaidLibrary
+ * @typedef {import("./contracts").RuntimeManifest} RuntimeManifest
+ * @typedef {import("./contracts").RuntimeWindow} RuntimeWindow
+ */
+
+/** @type {{ initialized: boolean; loadingPromise: Promise<MermaidLibrary | null> | null; scriptElement: HTMLScriptElement | null; lastCdnUrl: string; lastTheme: string }} */
 const mermaidRuntime = {
   initialized: false,
   loadingPromise: null,
@@ -17,6 +26,10 @@ const mermaidRuntime = {
   lastTheme: "",
 };
 
+/**
+ * @param {RuntimeManifest | { mermaid?: Partial<MermaidConfig> } | null | undefined} manifest
+ * @returns {MermaidConfig}
+ */
 export function resolveMermaidConfig(manifest) {
   const mermaid = manifest?.mermaid;
   return {
@@ -33,6 +46,7 @@ export function resolveMermaidConfig(manifest) {
   };
 }
 
+/** @param {unknown} value */
 function normalizeMermaidTheme(value) {
   const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized || !MERMAID_THEME_VALIDATION_RE.test(normalized)) {
@@ -41,6 +55,7 @@ function normalizeMermaidTheme(value) {
   return normalized;
 }
 
+/** @param {unknown} value */
 function normalizeMermaidUrl(value) {
   const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized || !MERMAID_URL_VALIDATION_RE.test(normalized)) {
@@ -49,6 +64,10 @@ function normalizeMermaidUrl(value) {
   return normalized;
 }
 
+/**
+ * @param {string} value
+ * @param {RuntimeWindow} windowRef
+ */
 function toAbsoluteUrl(value, windowRef) {
   try {
     return new URL(value, windowRef.location.href).href;
@@ -57,6 +76,10 @@ function toAbsoluteUrl(value, windowRef) {
   }
 }
 
+/**
+ * @param {string} message
+ * @param {Document} documentRef
+ */
 function createMermaidLoadError(message, documentRef) {
   const paragraph = documentRef.createElement("p");
   paragraph.className = MERMAID_ERROR_CLASS;
@@ -64,6 +87,7 @@ function createMermaidLoadError(message, documentRef) {
   return paragraph;
 }
 
+/** @param {ParentNode | null | undefined} container */
 function removeMermaidErrorMessage(container) {
   if (!container?.querySelectorAll) {
     return;
@@ -74,6 +98,11 @@ function removeMermaidErrorMessage(container) {
   }
 }
 
+/**
+ * @param {HTMLElement} preview
+ * @param {string} message
+ * @param {Document} documentRef
+ */
 function showMermaidError(preview, message, documentRef) {
   const container = preview?.parentElement;
   if (!container?.appendChild) {
@@ -84,6 +113,10 @@ function showMermaidError(preview, message, documentRef) {
   container.appendChild(createMermaidLoadError(message, documentRef));
 }
 
+/**
+ * @param {HTMLElement} block
+ * @param {RuntimeWindow} windowRef
+ */
 function normalizeRenderedMermaidSvg(block, windowRef) {
   const container = block?.parentElement;
   const svg = block?.querySelector?.("svg");
@@ -126,6 +159,7 @@ function normalizeRenderedMermaidSvg(block, windowRef) {
   }
 }
 
+/** @param {HTMLElement[]} nodes */
 function resetMermaidNodes(nodes) {
   for (const node of nodes) {
     node.removeAttribute("data-mermaid-rendered");
@@ -136,6 +170,11 @@ function resetMermaidNodes(nodes) {
   }
 }
 
+/**
+ * @param {MermaidConfig} config
+ * @param {{ documentRef: Document; windowRef: RuntimeWindow }} environment
+ * @returns {Promise<MermaidLibrary | null>}
+ */
 async function loadMermaidLibrary(config, { documentRef, windowRef }) {
   if (!config.enabled) {
     return null;
@@ -185,6 +224,7 @@ async function loadMermaidLibrary(config, { documentRef, windowRef }) {
       mermaidRuntime.lastCdnUrl = expectedAbsoluteUrl;
     }
 
+    /** @param {unknown} [error] */
     const finalize = (error) => {
       mermaidRuntime.loadingPromise = null;
       if (error) {
@@ -227,6 +267,11 @@ async function loadMermaidLibrary(config, { documentRef, windowRef }) {
   return mermaidRuntime.loadingPromise;
 }
 
+/**
+ * @param {MermaidConfig} config
+ * @param {{ documentRef?: Document; windowRef?: RuntimeWindow }} [options]
+ * @returns {MermaidController}
+ */
 export function createMermaidController(config, options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
@@ -254,7 +299,10 @@ export function createMermaidController(config, options = {}) {
       }
 
       const renderGeneration = lifecycleGeneration;
-      const blocks = Array.from(root.querySelectorAll(MERMAID_SELECTOR));
+      /** @type {HTMLElement[]} */
+      const blocks = Array.from(root.querySelectorAll(MERMAID_SELECTOR)).filter(
+        (block) => block instanceof windowRef.HTMLElement,
+      );
       if (blocks.length === 0) {
         return;
       }

--- a/src/runtime/navigation-state.js
+++ b/src/runtime/navigation-state.js
@@ -13,6 +13,12 @@ import {
 
 const DEFAULT_BRANCH = "dev";
 
+/** @typedef {import("./contracts").BranchView} BranchView */
+/** @typedef {import("./contracts").NavigationState} NavigationState */
+/** @typedef {import("./contracts").RuntimeManifest} RuntimeManifest */
+/** @typedef {import("./contracts").RuntimeManifestDoc} RuntimeManifestDoc */
+/** @typedef {import("./contracts").RuntimeTreeNode} RuntimeTreeNode */
+
 export {
   normalizeBranch,
   normalizePathBase,
@@ -22,11 +28,21 @@ export {
   toPathWithBase,
 };
 
+/**
+ * @param {unknown} pathBase
+ * @param {unknown} [pathname]
+ */
 export function resolveRouteFromLocation(pathBase, pathname = globalThis.location?.pathname ?? "/") {
   return normalizeRoute(stripPathBase(pathname, pathBase));
 }
 
+/**
+ * @param {RuntimeTreeNode[]} nodes
+ * @param {Set<string>} visibleDocIds
+ * @returns {RuntimeTreeNode[]}
+ */
 function cloneFilteredTree(nodes, visibleDocIds) {
+  /** @type {RuntimeTreeNode[]} */
   const filteredNodes = [];
 
   for (const node of nodes) {
@@ -48,12 +64,21 @@ function cloneFilteredTree(nodes, visibleDocIds) {
   return filteredNodes;
 }
 
+/**
+ * @param {RuntimeManifest} manifest
+ * @param {RuntimeManifestDoc[]} manifestDocs
+ * @param {string} branch
+ * @param {string} defaultBranch
+ * @returns {BranchView}
+ */
 function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
   const docs = filterViewDocsByBranch(manifestDocs, branch, defaultBranch);
   const visibleDocIds = new Set(docs.map((doc) => doc.id));
   const tree = cloneFilteredTree(manifest.tree, visibleDocIds);
   const trees = buildTreesAdapterInput(tree, docs);
+  /** @type {Record<string, string>} */
   const routeMap = {};
+  /** @type {Map<string, number>} */
   const docIndexById = new Map();
 
   for (let index = 0; index < docs.length; index += 1) {
@@ -65,10 +90,17 @@ function buildBranchView(manifest, manifestDocs, branch, defaultBranch) {
   return { docs, visibleDocIds, tree, trees, routeMap, docIndexById };
 }
 
+/** @param {BranchView} view */
 export function pickHomeRoute(view) {
   return pickViewHomeRoute(view.docs);
 }
 
+/**
+ * @param {RuntimeManifest} manifest
+ * @param {RuntimeManifestDoc[]} manifestDocs
+ * @param {string} defaultBranch
+ * @returns {string[]}
+ */
 function collectAvailableBranches(manifest, manifestDocs, defaultBranch) {
   const branchSet = new Set([defaultBranch]);
   for (const doc of manifestDocs) {
@@ -93,6 +125,11 @@ function collectAvailableBranches(manifest, manifestDocs, defaultBranch) {
   });
 }
 
+/**
+ * @param {RuntimeManifest} manifest
+ * @param {{ savedBranch?: unknown; initialDocId?: unknown }} [options]
+ * @returns {NavigationState}
+ */
 export function createNavigationState(manifest, options = {}) {
   const defaultBranch = normalizeBranch(manifest.defaultBranch) || DEFAULT_BRANCH;
   const docs = getRuntimeManifestDocs(manifest);
@@ -100,10 +137,12 @@ export function createNavigationState(manifest, options = {}) {
   const availableBranches = collectAvailableBranches(manifest, docs, defaultBranch);
   const availableBranchSet = new Set(availableBranches);
   const savedBranch = normalizeBranch(options.savedBranch);
+  /** @type {Map<string, BranchView>} */
   const branchViewCache = new Map();
   let activeBranch = savedBranch && availableBranchSet.has(savedBranch) ? savedBranch : defaultBranch;
   let currentDocId = typeof options.initialDocId === "string" ? options.initialDocId : "";
 
+  /** @param {string} branch */
   const getBranchView = (branch) => {
     const cached = branchViewCache.get(branch);
     if (cached) {
@@ -125,6 +164,7 @@ export function createNavigationState(manifest, options = {}) {
     }
   }
 
+  /** @param {unknown} value */
   const setActiveBranch = (value) => {
     const branch = normalizeBranch(value);
     if (!branch || !availableBranchSet.has(branch)) {
@@ -135,6 +175,7 @@ export function createNavigationState(manifest, options = {}) {
     return true;
   };
 
+  /** @param {unknown} rawRoute */
   const resolve = (rawRoute) => {
     const route = normalizeRoute(rawRoute);
     const previousBranch = activeBranch;

--- a/src/runtime/runtime-bootstrap.js
+++ b/src/runtime/runtime-bootstrap.js
@@ -8,6 +8,23 @@ import {
 
 const DEFAULT_SITE_TITLE = "File-System Blog";
 
+/** @typedef {import("./contracts").InitialRuntimeData} InitialRuntimeData */
+/** @typedef {import("./contracts").InitialViewData} InitialViewData */
+/** @typedef {import("./contracts").RuntimeBootstrap} RuntimeBootstrap */
+/** @typedef {import("./contracts").RuntimeManifest} RuntimeManifest */
+
+/**
+ * @param {unknown} value
+ * @returns {value is Record<string, unknown>}
+ */
+function isRecord(value) {
+  return !!value && typeof value === "object" && !Array.isArray(value);
+}
+
+/**
+ * @param {Document} [documentRef]
+ * @returns {InitialViewData | null}
+ */
 export function loadInitialViewData(documentRef = globalThis.document) {
   const script = documentRef.getElementById("initial-view-data");
   const raw = script?.textContent;
@@ -16,8 +33,9 @@ export function loadInitialViewData(documentRef = globalThis.document) {
   }
 
   try {
+    /** @type {unknown} */
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") {
+    if (!isRecord(parsed)) {
       return null;
     }
     const route = typeof parsed.route === "string" ? normalizeRoute(parsed.route) : null;
@@ -29,6 +47,10 @@ export function loadInitialViewData(documentRef = globalThis.document) {
   }
 }
 
+/**
+ * @param {{ documentRef?: Document; windowRef?: Window }} [options]
+ * @returns {InitialRuntimeData | null}
+ */
 export function loadInitialRuntimeData(options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
@@ -39,8 +61,9 @@ export function loadInitialRuntimeData(options = {}) {
   }
 
   try {
+    /** @type {unknown} */
     const parsed = JSON.parse(raw);
-    if (!parsed || typeof parsed !== "object") {
+    if (!isRecord(parsed)) {
       return null;
     }
     const pathBase = normalizePathBase(parsed.pathBase);
@@ -50,6 +73,7 @@ export function loadInitialRuntimeData(options = {}) {
       return null;
     }
 
+    /** @type {URL} */
     let resolvedTreeModuleUrl;
     try {
       resolvedTreeModuleUrl = new URL(treeModuleUrl, documentRef.baseURI);
@@ -69,15 +93,20 @@ export function loadInitialRuntimeData(options = {}) {
   }
 }
 
+/** @param {RuntimeManifest} manifest */
 export function resolveSiteTitle(manifest) {
   const value = typeof manifest?.siteTitle === "string" ? manifest.siteTitle.trim() : "";
   return value || DEFAULT_SITE_TITLE;
 }
 
+/**
+ * @param {{ documentRef?: Document; windowRef?: Window; fetchManifest?: (url: string) => Promise<Response> }} [options]
+ * @returns {Promise<RuntimeBootstrap>}
+ */
 export async function loadRuntimeBootstrap(options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
-  const fetchManifest = options.fetchManifest ?? ((url) => globalThis.fetch(url));
+  const fetchManifest = options.fetchManifest ?? ((/** @type {string} */ url) => globalThis.fetch(url));
   const initialViewData = loadInitialViewData(documentRef);
   const initialRuntimeData = loadInitialRuntimeData({ documentRef, windowRef });
   const initialPathBase = normalizePathBase(initialRuntimeData?.pathBase);

--- a/src/runtime/settings-controller.js
+++ b/src/runtime/settings-controller.js
@@ -4,6 +4,15 @@ const MENU_TOGGLE_POSITION_KEY = "fsblog.menuTogglePosition";
 const THEME_MODE_KEY = "fsblog.themeMode";
 const DARK_MODE_QUERY = "(prefers-color-scheme: dark)";
 
+/** @typedef {import("./contracts").EventScope} EventScope */
+/** @typedef {import("./contracts").RuntimeWindow} RuntimeWindow */
+/** @typedef {import("./contracts").SettingsController} SettingsController */
+/** @typedef {"light" | "dark" | "system"} ThemeMode */
+
+/**
+ * @param {unknown} mode
+ * @returns {ThemeMode}
+ */
 export function normalizeThemeMode(mode) {
   if (mode === "light" || mode === "dark" || mode === "system") {
     return mode;
@@ -11,6 +20,11 @@ export function normalizeThemeMode(mode) {
   return "system";
 }
 
+/**
+ * @param {ThemeMode} mode
+ * @param {boolean} prefersDark
+ * @returns {"light" | "dark"}
+ */
 export function resolveAppliedTheme(mode, prefersDark) {
   if (mode === "system") {
     return prefersDark ? "dark" : "light";
@@ -18,6 +32,10 @@ export function resolveAppliedTheme(mode, prefersDark) {
   return mode;
 }
 
+/**
+ * @param {{ documentRef?: Document; windowRef?: RuntimeWindow; storage?: Storage }} [options]
+ * @returns {SettingsController}
+ */
 export function createSettingsController(options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
@@ -30,9 +48,12 @@ export function createSettingsController(options = {}) {
   );
   const themeModeInputs = Array.from(documentRef.querySelectorAll('input[name="theme-mode"]'));
   const darkModeMediaQuery = windowRef.matchMedia(DARK_MODE_QUERY);
+  /** @type {EventScope | null} */
   let events = null;
+  /** @type {ThemeMode} */
   let themeMode = "system";
 
+  /** @param {boolean} expanded */
   const setSettingsExpanded = (expanded) => {
     settingsToggle?.setAttribute("aria-expanded", String(expanded));
   };
@@ -54,7 +75,9 @@ export function createSettingsController(options = {}) {
     const checkedInput = settingsPanel.querySelector(
       'input[name="theme-mode"]:checked, input[name="menu-toggle-position"]:checked',
     );
-    checkedInput?.focus?.();
+    if (checkedInput instanceof windowRef.HTMLElement) {
+      checkedInput.focus();
+    }
   };
 
   const toggle = () => {
@@ -68,6 +91,7 @@ export function createSettingsController(options = {}) {
     }
   };
 
+  /** @param {"left" | "right"} position */
   const applyMenuTogglePosition = (position) => {
     documentRef.body?.classList.toggle("mobile-toggle-left", position === "left");
   };
@@ -78,6 +102,7 @@ export function createSettingsController(options = {}) {
     documentRef.documentElement.style.colorScheme = appliedTheme;
   };
 
+  /** @param {Event} event */
   const handleMenuTogglePositionChange = (event) => {
     const input = event.currentTarget;
     if (!(input instanceof windowRef.HTMLInputElement) || !input.checked) {
@@ -88,6 +113,7 @@ export function createSettingsController(options = {}) {
     storage.setItem(MENU_TOGGLE_POSITION_KEY, nextPosition);
   };
 
+  /** @param {Event} event */
   const handleThemeModeChange = (event) => {
     const input = event.currentTarget;
     if (!(input instanceof windowRef.HTMLInputElement) || !input.checked) {
@@ -104,6 +130,7 @@ export function createSettingsController(options = {}) {
     }
   };
 
+  /** @param {Event} event */
   const handleOutsideClick = (event) => {
     if (!settingsPanel || settingsPanel.hidden) {
       return;

--- a/src/runtime/sidebar-layout-controller.js
+++ b/src/runtime/sidebar-layout-controller.js
@@ -10,12 +10,23 @@ const DESKTOP_SPLITTER_STEP = 24;
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
+/** @typedef {import("./contracts").EventScope} EventScope */
+/** @typedef {import("./contracts").RuntimeWindow} RuntimeWindow */
+/** @typedef {import("./contracts").SidebarLayoutController} SidebarLayoutController */
+
+/**
+ * @param {ParentNode | null} container
+ * @param {RuntimeWindow} windowRef
+ * @returns {HTMLElement[]}
+ */
 function getFocusableElements(container, windowRef) {
   if (!container) {
     return [];
   }
 
+  /** @type {HTMLElement[]} */
   const candidates = [];
+  /** @param {ParentNode} root */
   const collect = (root) => {
     for (const element of root.querySelectorAll("*")) {
       if (!(element instanceof windowRef.HTMLElement)) {
@@ -49,6 +60,10 @@ function getFocusableElements(container, windowRef) {
   });
 }
 
+/**
+ * @param {number} width
+ * @param {number} viewportWidth
+ */
 export function clampDesktopSidebarWidth(width, viewportWidth) {
   const max = Math.max(
     DESKTOP_SIDEBAR_MIN,
@@ -57,6 +72,16 @@ export function clampDesktopSidebarWidth(width, viewportWidth) {
   return Math.min(Math.max(width, DESKTOP_SIDEBAR_MIN), max);
 }
 
+/**
+ * @param {{
+ *   documentRef?: Document;
+ *   windowRef?: RuntimeWindow;
+ *   storage?: Storage;
+ *   requestTreeLoad?: (reason: string) => Promise<boolean>;
+ *   closeSettings?: () => void;
+ * }} [options]
+ * @returns {SidebarLayoutController & { open(): void }}
+ */
 export function createSidebarLayoutController(options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
@@ -71,8 +96,10 @@ export function createSidebarLayoutController(options = {}) {
   const sidebarOverlay = documentRef.getElementById("sidebar-overlay");
   const viewer = documentRef.querySelector(".viewer");
   const compactMediaQuery = windowRef.matchMedia(COMPACT_LAYOUT_QUERY);
+  /** @type {EventScope | null} */
   let events = null;
   let desktopSidebarWidth = DESKTOP_SIDEBAR_DEFAULT;
+  /** @type {number | null} */
   let activeResizePointerId = null;
   let resizeStartX = 0;
   let resizeStartWidth = desktopSidebarWidth;
@@ -94,6 +121,7 @@ export function createSidebarLayoutController(options = {}) {
     splitter.setAttribute("aria-disabled", String(isCompact()));
   };
 
+  /** @param {boolean} persist */
   const syncDesktopSidebarWidth = (persist) => {
     desktopSidebarWidth = clampDesktopSidebarWidth(desktopSidebarWidth, windowRef.innerWidth);
     if (appRoot instanceof windowRef.HTMLElement) {
@@ -109,6 +137,7 @@ export function createSidebarLayoutController(options = {}) {
     }
   };
 
+  /** @param {boolean} isInteractive */
   const setViewerInteractiveState = (isInteractive) => {
     if (!(viewer instanceof windowRef.HTMLElement)) {
       return;
@@ -122,6 +151,7 @@ export function createSidebarLayoutController(options = {}) {
     }
   };
 
+  /** @param {boolean} isOpen */
   const syncSidebarA11y = (isOpen) => {
     sidebarToggle?.setAttribute("aria-expanded", String(isOpen));
     sidebarOverlay?.setAttribute("aria-hidden", String(!isOpen));
@@ -183,6 +213,7 @@ export function createSidebarLayoutController(options = {}) {
     }
   };
 
+  /** @param {boolean} requestDesktopTreeLoad */
   const syncLayout = (requestDesktopTreeLoad) => {
     close();
     if (!isCompact()) {
@@ -203,7 +234,11 @@ export function createSidebarLayoutController(options = {}) {
     syncLayout(true);
   };
 
+  /** @param {Event} event */
   const beginSplitterResize = (event) => {
+    if (!(event instanceof windowRef.PointerEvent)) {
+      return;
+    }
     if (
       !(splitter instanceof windowRef.HTMLElement) ||
       !(appRoot instanceof windowRef.HTMLElement) ||
@@ -222,7 +257,11 @@ export function createSidebarLayoutController(options = {}) {
     splitter.setPointerCapture(event.pointerId);
   };
 
+  /** @param {Event} event */
   const updateSplitterResize = (event) => {
+    if (!(event instanceof windowRef.PointerEvent)) {
+      return;
+    }
     if (event.pointerId !== activeResizePointerId) {
       return;
     }
@@ -230,7 +269,11 @@ export function createSidebarLayoutController(options = {}) {
     syncDesktopSidebarWidth(false);
   };
 
+  /** @param {Event} event */
   const endSplitterResize = (event) => {
+    if (!(event instanceof windowRef.PointerEvent)) {
+      return;
+    }
     if (event.pointerId !== activeResizePointerId) {
       return;
     }
@@ -242,7 +285,11 @@ export function createSidebarLayoutController(options = {}) {
     syncDesktopSidebarWidth(true);
   };
 
+  /** @param {Event} event */
   const handleSplitterKeydown = (event) => {
+    if (!(event instanceof windowRef.KeyboardEvent)) {
+      return;
+    }
     if (isCompact()) {
       return;
     }
@@ -267,7 +314,11 @@ export function createSidebarLayoutController(options = {}) {
     syncDesktopSidebarWidth(true);
   };
 
+  /** @param {Event} event */
   const handleDocumentKeydown = (event) => {
+    if (!(event instanceof windowRef.KeyboardEvent)) {
+      return;
+    }
     if (event.key === "Escape" && appRoot?.classList?.contains("sidebar-open")) {
       close();
       return;

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -4,6 +4,17 @@ const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f]/g;
 const PATH_SEPARATOR_RE = /[\\/]+/g;
 const WHITESPACE_RE = /\s+/g;
 
+/** @typedef {import("./contracts").RuntimeManifestDoc} RuntimeManifestDoc */
+/** @typedef {import("./contracts").RuntimeTreeFileNode} RuntimeTreeFileNode */
+/** @typedef {import("./contracts").RuntimeTreeNode} RuntimeTreeNode */
+/** @typedef {import("./contracts").TreePathMetadata} TreePathMetadata */
+/** @typedef {import("./contracts").TreesAdapterInput} TreesAdapterInput */
+
+/**
+ * @param {unknown} value
+ * @param {string} fallback
+ * @returns {string}
+ */
 function normalizeTreeSegment(value, fallback) {
   const normalized = String(value ?? "")
     .replace(CONTROL_CHARS_RE, "")
@@ -14,10 +25,16 @@ function normalizeTreeSegment(value, fallback) {
   return normalized || fallback;
 }
 
+/** @param {string} value */
 function trimFileExtension(value) {
   return value.replace(/\.md$/i, "");
 }
 
+/**
+ * @param {string} parentPath
+ * @param {unknown} segment
+ * @param {boolean} isDirectory
+ */
 function joinTreePath(parentPath, segment, isDirectory) {
   const cleanParent = parentPath.replace(/\/+$/, "");
   const cleanSegment = normalizeTreeSegment(segment, "Untitled");
@@ -25,6 +42,10 @@ function joinTreePath(parentPath, segment, isDirectory) {
   return isDirectory ? `${joined}${DIRECTORY_SUFFIX}` : joined;
 }
 
+/**
+ * @param {string} pathValue
+ * @param {number} counter
+ */
 function appendCollisionSuffix(pathValue, counter) {
   const suffix = ` (${counter})`;
   if (pathValue.endsWith(DIRECTORY_SUFFIX)) {
@@ -39,6 +60,10 @@ function appendCollisionSuffix(pathValue, counter) {
   return `${pathValue}${suffix}`;
 }
 
+/**
+ * @param {string} pathValue
+ * @param {Set<string>} usedPaths
+ */
 function makeUniquePath(pathValue, usedPaths) {
   if (!usedPaths.has(pathValue)) {
     return pathValue;
@@ -53,6 +78,10 @@ function makeUniquePath(pathValue, usedPaths) {
   return candidate;
 }
 
+/**
+ * @param {RuntimeTreeFileNode} node
+ * @param {RuntimeManifestDoc | undefined} doc
+ */
 export function formatTreesFileBasename(node, doc) {
   const fallbackTitle = trimFileExtension(node?.name ? String(node.name) : "Untitled");
   const rawTitle = typeof node?.title === "string" && node.title.trim() ? node.title : doc?.title;
@@ -61,7 +90,13 @@ export function formatTreesFileBasename(node, doc) {
   return `${prefix ? `${prefix} ` : ""}${title}`;
 }
 
+/**
+ * @param {RuntimeTreeNode[]} treeNodes
+ * @param {RuntimeManifestDoc[]} [docs]
+ * @returns {TreesAdapterInput}
+ */
 export function buildTreesAdapterInput(treeNodes, docs = []) {
+  /** @type {Map<string, RuntimeManifestDoc>} */
   const docById = new Map();
   for (const doc of Array.isArray(docs) ? docs : []) {
     if (typeof doc?.id === "string" && doc.id) {
@@ -69,14 +104,25 @@ export function buildTreesAdapterInput(treeNodes, docs = []) {
     }
   }
 
+  /** @type {string[]} */
   const paths = [];
+  /** @type {Set<string>} */
   const usedPaths = new Set();
+  /** @type {Map<string, TreePathMetadata>} */
   const metadataByTreePath = new Map();
+  /** @type {Map<string, string>} */
   const treePathToDocId = new Map();
+  /** @type {Map<string, string>} */
   const treePathToRoute = new Map();
+  /** @type {Map<string, string[]>} */
   const docIdToTreePaths = new Map();
+  /** @type {Map<string, string>} */
   const docIdToPrimaryTreePath = new Map();
 
+  /**
+   * @param {string} pathValue
+   * @param {TreePathMetadata} metadata
+   */
   const registerPath = (pathValue, metadata) => {
     const treePath = makeUniquePath(pathValue, usedPaths);
     usedPaths.add(treePath);
@@ -85,6 +131,11 @@ export function buildTreesAdapterInput(treeNodes, docs = []) {
     return treePath;
   };
 
+  /**
+   * @param {string} treePath
+   * @param {RuntimeTreeFileNode} node
+   * @param {RuntimeManifestDoc | undefined} doc
+   */
   const registerDocPath = (treePath, node, doc) => {
     const docId = typeof node?.id === "string" ? node.id : "";
     if (!docId) {
@@ -109,6 +160,10 @@ export function buildTreesAdapterInput(treeNodes, docs = []) {
     }
   };
 
+  /**
+   * @param {RuntimeTreeNode[]} nodes
+   * @param {string} [parentPath]
+   */
   const walk = (nodes, parentPath = "") => {
     if (!Array.isArray(nodes)) {
       return;

--- a/src/runtime/tree-controller.js
+++ b/src/runtime/tree-controller.js
@@ -4,15 +4,42 @@ import { pickHomeRoute, resolveRouteFromLocation, toPathWithBase } from "./navig
 const BRANCH_KEY = "fsblog.branch";
 const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
 
+/**
+ * @typedef {import("@pierre/trees").ContextMenuItem} ContextMenuItem
+ * @typedef {import("@pierre/trees").ContextMenuOpenContext} ContextMenuOpenContext
+ * @typedef {import("@pierre/trees").FileTree} FileTree
+ * @typedef {import("@pierre/trees").FileTreeRowDecorationContext} FileTreeRowDecorationContext
+ * @typedef {import("@pierre/trees").FileTreeSortEntry} FileTreeSortEntry
+ * @typedef {import("./contracts").EventScope} EventScope
+ * @typedef {import("./contracts").TreeController} TreeController
+ * @typedef {import("./contracts").TreeControllerOptions} TreeControllerOptions
+ * @typedef {import("./contracts").TreeLabelHost} TreeLabelHost
+ * @typedef {import("./contracts").TreePathMetadata} TreePathMetadata
+ * @typedef {import("./contracts").TreeRuntimeModule} TreeRuntimeModule
+ * @typedef {import("./contracts").RuntimeWindow} RuntimeWindow
+ */
+
+/**
+ * @param {unknown} value
+ * @param {string} [fallback]
+ */
 function normalizeTreeLabelText(value, fallback = "") {
   const normalized = typeof value === "string" ? value.replace(/\s+/g, " ").trim() : "";
   return normalized || fallback;
 }
 
+/**
+ * @param {TreeLabelHost | null | undefined} host
+ * @returns {ParentNode | null}
+ */
 function getTreeLabelRenderRoot(host) {
   return host?.shadowRoot || host || null;
 }
 
+/**
+ * @param {TreeLabelHost | null | undefined} host
+ * @param {Document} documentRef
+ */
 function decorateTreeLabels(host, documentRef) {
   const metadataByTreePath = host?.__eiamMetadataByTreePath;
   if (!(metadataByTreePath instanceof Map)) {
@@ -42,6 +69,7 @@ function decorateTreeLabels(host, documentRef) {
         : fallbackName;
     const title = normalizeTreeLabelText(metadata.title, fallbackTitle);
     const labelKey = JSON.stringify([prefix, title]);
+    /** @type {HTMLElement | null} */
     const content = row.querySelector("[data-item-section='content']");
     if (!content || content.dataset.eiamTreeLabel === labelKey) {
       continue;
@@ -66,6 +94,11 @@ function decorateTreeLabels(host, documentRef) {
   }
 }
 
+/**
+ * @param {TreeLabelHost | null | undefined} host
+ * @param {Document} documentRef
+ * @param {RuntimeWindow} windowRef
+ */
 function queueTreeLabelDecoration(host, documentRef, windowRef) {
   if (!host) {
     return;
@@ -79,6 +112,12 @@ function queueTreeLabelDecoration(host, documentRef, windowRef) {
   });
 }
 
+/**
+ * @param {TreeLabelHost | null | undefined} host
+ * @param {Map<string, TreePathMetadata>} metadataByTreePath
+ * @param {Document} documentRef
+ * @param {RuntimeWindow} windowRef
+ */
 function setupTreeLabelDecorations(host, metadataByTreePath, documentRef, windowRef) {
   if (!host) {
     return;
@@ -99,6 +138,10 @@ function setupTreeLabelDecorations(host, metadataByTreePath, documentRef, window
   queueTreeLabelDecoration(host, documentRef, windowRef);
 }
 
+/**
+ * @param {TreeLabelHost | null | undefined} host
+ * @param {RuntimeWindow} windowRef
+ */
 function cleanupTreeLabelDecorations(host, windowRef) {
   if (!host) {
     return;
@@ -113,6 +156,26 @@ function cleanupTreeLabelDecorations(host, windowRef) {
   delete host.__eiamMetadataByTreePath;
 }
 
+/**
+ * @param {unknown} value
+ * @returns {value is TreeRuntimeModule}
+ */
+function isTreeRuntimeModule(value) {
+  if (!value || typeof value !== "object") {
+    return false;
+  }
+  const candidate = /** @type {Record<string, unknown>} */ (value);
+  return (
+    typeof candidate.FileTree === "function" &&
+    typeof candidate.prepareFileTreeInput === "function" &&
+    typeof candidate.TREE_UNSAFE_CSS === "string"
+  );
+}
+
+/**
+ * @param {TreeControllerOptions} options
+ * @returns {TreeController}
+ */
 export function createTreeController(options) {
   const {
     navigation,
@@ -126,30 +189,48 @@ export function createTreeController(options) {
     storage = globalThis.localStorage,
   } = options;
   const treeRoot = documentRef.getElementById("tree-root");
-  const treeSearchInput = documentRef.getElementById("tree-search-input");
-  const treeSearchClear = documentRef.getElementById("tree-search-clear");
-  const treeSearchPrev = documentRef.getElementById("tree-search-prev");
-  const treeSearchNext = documentRef.getElementById("tree-search-next");
+  const treeSearchInput = /** @type {HTMLInputElement | null} */ (
+    documentRef.getElementById("tree-search-input")
+  );
+  const treeSearchClear = /** @type {HTMLButtonElement | null} */ (
+    documentRef.getElementById("tree-search-clear")
+  );
+  const treeSearchPrev = /** @type {HTMLButtonElement | null} */ (
+    documentRef.getElementById("tree-search-prev")
+  );
+  const treeSearchNext = /** @type {HTMLButtonElement | null} */ (
+    documentRef.getElementById("tree-search-next")
+  );
   const treeSearchCount = documentRef.getElementById("tree-search-count");
   const sidebarBranchPills = documentRef.getElementById("sidebar-branch-pills");
   const sidebarBranchInfo = documentRef.getElementById("sidebar-branch-info");
+  /** @type {EventScope | null} */
   let events = null;
+  /** @type {FileTree | null} */
   let fileTree = null;
   let isSyncingTreeSelection = false;
+  /** @type {Map<string, number>} */
   let treePathOrder = new Map();
   let treeSearchValue = "";
   let renderedTreeBranch = "";
+  /** @type {TreeRuntimeModule | null} */
   let treeRuntime = null;
+  /** @type {Promise<boolean> | null} */
   let treeLoadPromise = null;
   let treeRetryCount = 0;
   let treeLoadAllowed = false;
   let pendingTreeLoadReason = "";
   let lifecycleGeneration = 0;
+  /** @type {number | null} */
   let deferredFrame = null;
+  /** @type {number | null} */
   let paintFrame = null;
+  /** @type {number | null} */
   let idleHandle = null;
+  /** @type {number | null} */
   let idleFallbackTimer = null;
 
+  /** @param {string} state */
   const setTreeRuntimeState = (state) => {
     documentRef.documentElement?.setAttribute(TREE_RUNTIME_STATE_ATTR, state);
   };
@@ -178,6 +259,9 @@ export function createTreeController(options) {
           : `publish: true · ${navigation.activeBranch} only`;
     }
     for (const pill of sidebarBranchPills?.querySelectorAll(".branch-pill") ?? []) {
+      if (!(pill instanceof windowRef.HTMLElement)) {
+        continue;
+      }
       const isActive = pill.dataset.branch === navigation.activeBranch;
       pill.classList.toggle("is-active", isActive);
       pill.setAttribute("aria-pressed", String(isActive));
@@ -203,6 +287,7 @@ export function createTreeController(options) {
     }
   };
 
+  /** @param {string} value */
   const applyTreeSearch = (value) => {
     treeSearchValue = value;
     if (treeSearchInput && treeSearchInput.value !== value) {
@@ -223,6 +308,7 @@ export function createTreeController(options) {
     updateTreeSearchControls();
   };
 
+  /** @param {number} direction */
   const moveTreeSearchFocus = (direction) => {
     if (!fileTree || !fileTree.isSearchOpen() || fileTree.getSearchMatchingPaths().length === 0) {
       return;
@@ -235,6 +321,10 @@ export function createTreeController(options) {
     updateTreeSearchControls();
   };
 
+  /**
+   * @param {string} docId
+   * @param {{ scroll?: boolean }} [options]
+   */
   const syncActiveSelection = (docId, { scroll = true } = {}) => {
     if (!fileTree || !docId) {
       return;
@@ -281,7 +371,9 @@ export function createTreeController(options) {
   };
 
   const destroyFileTree = () => {
-    const host = treeRoot?.querySelector("file-tree-container");
+    const host = /** @type {TreeLabelHost | null} */ (
+      treeRoot?.querySelector("file-tree-container") ?? null
+    );
     cleanupTreeLabelDecorations(host, windowRef);
     fileTree?.cleanUp?.();
     fileTree = null;
@@ -289,6 +381,10 @@ export function createTreeController(options) {
     host?.remove();
   };
 
+  /**
+   * @param {FileTreeSortEntry} left
+   * @param {FileTreeSortEntry} right
+   */
   const compareTreesByBranchOrder = (left, right) => {
     const leftIndex = treePathOrder.get(left.path) ?? Number.MAX_SAFE_INTEGER;
     const rightIndex = treePathOrder.get(right.path) ?? Number.MAX_SAFE_INTEGER;
@@ -310,6 +406,7 @@ export function createTreeController(options) {
     });
   };
 
+  /** @param {FileTreeRowDecorationContext} context */
   const renderTreeRowDecoration = ({ item }) => {
     const metadata = navigation.view.trees.metadataByTreePath.get(item.path);
     if (metadata?.kind !== "file" || metadata.isNew !== true) {
@@ -318,6 +415,10 @@ export function createTreeController(options) {
     return { text: "NEW", title: "New document" };
   };
 
+  /**
+   * @param {ContextMenuItem} item
+   * @param {ContextMenuOpenContext} context
+   */
   const renderTreeContextMenu = (item, context) => {
     const route = navigation.view.trees.treePathToRoute.get(item.path);
     if (!route) {
@@ -428,7 +529,9 @@ export function createTreeController(options) {
     syncActiveSelection(navigation.currentDocId || "");
     applyTreeSearch(treeSearchValue);
     setupTreeLabelDecorations(
-      treeRoot.querySelector("file-tree-container"),
+      /** @type {TreeLabelHost | null} */ (
+        treeRoot.querySelector("file-tree-container")
+      ),
       navigation.view.trees.metadataByTreePath,
       documentRef,
       windowRef,
@@ -446,6 +549,7 @@ export function createTreeController(options) {
     treeRoot.replaceChildren(status);
   };
 
+  /** @param {unknown} error */
   const renderTreeFallback = (error) => {
     if (!treeRoot) {
       return;
@@ -494,6 +598,10 @@ export function createTreeController(options) {
     treeRoot.replaceChildren(fallback);
   };
 
+  /**
+   * @param {{ reason: string; retry?: boolean }} loadOptions
+   * @returns {Promise<boolean>}
+   */
   function loadTreeRuntime({ reason, retry = false }) {
     if (treeRuntime) {
       renderTree();
@@ -522,16 +630,13 @@ export function createTreeController(options) {
     renderTreeLoadingState();
     windowRef.performance?.mark?.("eiam-tree-load-start");
     const generationAtLoad = lifecycleGeneration;
+    /** @type {Promise<boolean>} */
     const pending = import(importUrl.href)
-      .then((module) => {
+      .then((/** @type {unknown} */ module) => {
         if (!events || generationAtLoad !== lifecycleGeneration) {
           return false;
         }
-        if (
-          typeof module.FileTree !== "function" ||
-          typeof module.prepareFileTreeInput !== "function" ||
-          typeof module.TREE_UNSAFE_CSS !== "string"
-        ) {
+        if (!isTreeRuntimeModule(module)) {
           throw new Error("Tree runtime exports are invalid");
         }
         treeRuntime = module;
@@ -541,7 +646,7 @@ export function createTreeController(options) {
         windowRef.performance?.mark?.("eiam-tree-ready");
         return true;
       })
-      .catch((error) => {
+      .catch((/** @type {unknown} */ error) => {
         if (!events || generationAtLoad !== lifecycleGeneration) {
           return false;
         }
@@ -563,6 +668,11 @@ export function createTreeController(options) {
     return pending;
   }
 
+  /**
+   * @param {string} reason
+   * @param {{ retry?: boolean }} [requestOptions]
+   * @returns {Promise<boolean>}
+   */
   function requestLoad(reason, requestOptions = {}) {
     if (!treeLoadAllowed) {
       pendingTreeLoadReason = reason;
@@ -572,6 +682,7 @@ export function createTreeController(options) {
     return loadTreeRuntime({ reason, retry: requestOptions.retry === true });
   }
 
+  /** @param {string} branch */
   const handleBranchChange = (branch) => {
     storage.setItem(BRANCH_KEY, branch);
     updateBranchInfo();
@@ -580,6 +691,7 @@ export function createTreeController(options) {
     }
   };
 
+  /** @param {unknown} nextBranch */
   const setActiveBranch = async (nextBranch) => {
     if (!navigation.setActiveBranch(nextBranch)) {
       return false;
@@ -595,13 +707,14 @@ export function createTreeController(options) {
     return true;
   };
 
+  /** @param {Event} event */
   const handleBranchPillClick = (event) => {
     const target = event.target;
     if (!(target instanceof windowRef.Element)) {
       return;
     }
     const pill = target.closest(".branch-pill");
-    if (!pill || !sidebarBranchPills?.contains(pill)) {
+    if (!(pill instanceof windowRef.HTMLElement) || !sidebarBranchPills?.contains(pill)) {
       return;
     }
     void setActiveBranch(pill.dataset.branch);
@@ -611,14 +724,18 @@ export function createTreeController(options) {
     void requestLoad("tree-search");
   };
   const handleSearchInput = () => {
-    applyTreeSearch(treeSearchInput.value);
+    applyTreeSearch(treeSearchInput?.value ?? "");
     void requestLoad("tree-search");
   };
+  /** @param {Event} event */
   const handleSearchKeydown = (event) => {
+    if (!(event instanceof windowRef.KeyboardEvent)) {
+      return;
+    }
     if (event.key === "Enter") {
       event.preventDefault();
       moveTreeSearchFocus(event.shiftKey ? -1 : 1);
-    } else if (event.key === "Escape" && treeSearchInput.value.trim()) {
+    } else if (event.key === "Escape" && treeSearchInput?.value.trim()) {
       event.preventDefault();
       event.stopPropagation();
       applyTreeSearch("");

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -4,10 +4,15 @@
     "module": "ESNext",
     "moduleResolution": "Bundler",
     "strict": true,
+    "allowJs": true,
+    "checkJs": true,
+    "noEmit": true,
+    "allowImportingTsExtensions": true,
     "esModuleInterop": true,
     "allowSyntheticDefaultImports": true,
     "skipLibCheck": true,
+    "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["bun-types"]
   },
-  "include": ["src/**/*.ts"]
+  "include": ["src/**/*"]
 }


### PR DESCRIPTION
## Summary
- strict-check every TypeScript and browser runtime JavaScript module under src
- define shared manifest, navigation, controller, DOM, Mermaid, and Trees contracts
- add a direct TypeScript dependency plus a local typecheck command
- fail CI typechecking before Playwright browser installation

## Validation
- bun install --frozen-lockfile
- bun run typecheck
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size
- bun run check:reproducible
- bun run test:e2e (81 passed)

Closes #31
Part of #34