### PR TITLE
build: require source quality gates

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -24,8 +24,17 @@ jobs:
       - name: Install dependencies
         run: bun install --frozen-lockfile
 
+      - name: Lint source
+        run: bun run lint:source
+
+      - name: Check formatting
+        run: bun run format:check
+
       - name: Typecheck TypeScript and browser runtime
         run: bun run typecheck
+
+      - name: Run unit tests
+        run: bun run test:unit
 
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium

--- a/.prettierignore
+++ b/.prettierignore
@@ -1,0 +1,6 @@
+node_modules
+dist
+.cache
+playwright-report
+test-results
+bun.lock

--- a/.prettierrc.json
+++ b/.prettierrc.json
@@ -1,0 +1,7 @@
+{
+  "printWidth": 100,
+  "proseWrap": "preserve",
+  "semi": true,
+  "singleQuote": false,
+  "trailingComma": "all"
+}

--- a/README.ko.md
+++ b/README.ko.md
@@ -71,6 +71,21 @@ bun run lint:md:publish -- --out-dir ./reports --strict
 - `--vault <path>`: Markdown 루트 디렉터리 재지정 (선택)
 - `--exclude <glob>`: 제외 패턴 추가 (반복 가능)
 
+## 개발 품질 검사
+
+브라우저 설치나 E2E 실행 전에 빠른 source gate를 로컬에서 그대로 실행할 수 있습니다.
+
+```bash
+bun run lint:source
+bun run format:check
+bun run typecheck
+bun run test:unit
+```
+
+`tests/unit/`은 CLI 파싱, 경로와 라우트, cache 안전 가드, manifest 변환, 렌더된 HTML sanitize처럼 결정적인 변환과 안전 계약을 다룹니다. 이 영역의 동작을 바꾸거나 회귀를 수정할 때는 unit test도 함께 추가하거나 갱신하고, Playwright는 브라우저 및 전체 build 통합 동작에 집중합니다.
+
+현재 CI는 숫자 coverage 임계값을 강제하지 않습니다. 추가 test framework 없이 Bun 내장 coverage를 확인하려면 `bun run test:unit:coverage`를 사용합니다.
+
 ## 설정 파일 (`blog.config.ts`)
 
 SEO/UI/정적 파일 설정은 config 파일에서 관리할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -602,11 +602,18 @@ Scripts from `package.json`:
 
 ```bash
 bun install
+bun run lint:source
+bun run format:check
 bun run typecheck
+bun run test:unit
 bun run build -- --vault ./test-vault --out ./dist
 bun run dev -- --vault ./test-vault --out ./dist
 bun run test:e2e
 ```
+
+The fast unit suite in `tests/unit/` covers deterministic transformations and safety contracts: CLI parsing, paths and routes, cache guards, manifest adaptation, and rendered HTML sanitization. Changes or regressions in these areas should add or update a unit test; Playwright remains focused on browser and full-build integration.
+
+CI does not enforce a numeric coverage threshold yet. `bun run test:unit:coverage` provides local visibility using Bun's built-in coverage, so coverage can improve without adding another test framework or turning line count into the goal.
 
 E2E coverage in `tests/e2e/` includes:
 

--- a/bun.lock
+++ b/bun.lock
@@ -17,17 +17,48 @@
         "sanitize-html": "2.17.6",
       },
       "devDependencies": {
+        "@eslint/js": "10.0.1",
         "@playwright/test": "^1.60.0",
         "@types/markdown-it": "^14.1.2",
         "@types/picomatch": "^4.0.3",
         "@types/sanitize-html": "2.16.1",
         "bun-types": "^1.3.14",
+        "eslint": "10.7.0",
+        "globals": "17.7.0",
         "markdownlint": "^0.40.0",
-        "typescript": "7.0.2",
+        "prettier": "3.9.5",
+        "typescript": "6.0.3",
+        "typescript-eslint": "8.64.0",
       },
     },
   },
   "packages": {
+    "@eslint-community/eslint-utils": ["@eslint-community/eslint-utils@4.9.1", "", { "dependencies": { "eslint-visitor-keys": "^3.4.3" }, "peerDependencies": { "eslint": "^6.0.0 || ^7.0.0 || >=8.0.0" } }, "sha512-phrYmNiYppR7znFEdqgfWHXR6NCkZEK7hwWDHZUjit/2/U0r6XvkDl0SYnoM51Hq7FhCGdLDT6zxCCOY1hexsQ=="],
+
+    "@eslint-community/regexpp": ["@eslint-community/regexpp@4.12.2", "", {}, "sha512-EriSTlt5OC9/7SXkRSCAhfSxxoSUgBm33OH+IkwbdpgoqsSsUg7y3uh+IICI/Qg4BBWr3U2i39RpmycbxMq4ew=="],
+
+    "@eslint/config-array": ["@eslint/config-array@0.23.5", "", { "dependencies": { "@eslint/object-schema": "^3.0.5", "debug": "^4.3.1", "minimatch": "^10.2.4" } }, "sha512-Y3kKLvC1dvTOT+oGlqNQ1XLqK6D1HU2YXPc52NmAlJZbMMWDzGYXMiPRJ8TYD39muD/OTjlZmNJ4ib7dvSrMBA=="],
+
+    "@eslint/config-helpers": ["@eslint/config-helpers@0.6.0", "", { "dependencies": { "@eslint/core": "^1.2.1" } }, "sha512-ii6Bw9jJ2zi2cWA2Z+9/QZ/+3DX6kwaV5Q986D/CdP3Lap3w/pgQZ373FV7byY/i7L4IRH/G43I5dz1ClsCbpA=="],
+
+    "@eslint/core": ["@eslint/core@1.2.1", "", { "dependencies": { "@types/json-schema": "^7.0.15" } }, "sha512-MwcE1P+AZ4C6DWlpin/OmOA54mmIZ/+xZuJiQd4SyB29oAJjN30UW9wkKNptW2ctp4cEsvhlLY/CsQ1uoHDloQ=="],
+
+    "@eslint/js": ["@eslint/js@10.0.1", "", { "peerDependencies": { "eslint": "^10.0.0" }, "optionalPeers": ["eslint"] }, "sha512-zeR9k5pd4gxjZ0abRoIaxdc7I3nDktoXZk2qOv9gCNWx3mVwEn32VRhyLaRsDiJjTs0xq/T8mfPtyuXu7GWBcA=="],
+
+    "@eslint/object-schema": ["@eslint/object-schema@3.0.5", "", {}, "sha512-vqTaUEgxzm+YDSdElad6PiRoX4t8VGDjCtt05zn4nU810UIx/uNEV7/lZJ6KwFThKZOzOxzXy48da+No7HZaMw=="],
+
+    "@eslint/plugin-kit": ["@eslint/plugin-kit@0.7.2", "", { "dependencies": { "@eslint/core": "^1.2.1", "levn": "^0.4.1" } }, "sha512-+CNAzxglkrpNf/kKywqQfk74QjtceuOE7Qm+AF8miRvPF/wmmK5+OJOgVh3AVTT3RP2mH3+FOaxlE5v72owk0A=="],
+
+    "@humanfs/core": ["@humanfs/core@0.19.2", "", { "dependencies": { "@humanfs/types": "^0.15.0" } }, "sha512-UhXNm+CFMWcbChXywFwkmhqjs3PRCmcSa/hfBgLIb7oQ5HNb1wS0icWsGtSAUNgefHeI+eBrA8I1fxmbHsGdvA=="],
+
+    "@humanfs/node": ["@humanfs/node@0.16.8", "", { "dependencies": { "@humanfs/core": "^0.19.2", "@humanfs/types": "^0.15.0", "@humanwhocodes/retry": "^0.4.0" } }, "sha512-gE1eQNZ3R++kTzFUpdGlpmy8kDZD/MLyHqDwqjkVQI0JMdI1D51sy1H958PNXYkM2rAac7e5/CnIKZrHtPh3BQ=="],
+
+    "@humanfs/types": ["@humanfs/types@0.15.0", "", {}, "sha512-ZZ1w0aoQkwuUuC7Yf+7sdeaNfqQiiLcSRbfI08oAxqLtpXQr9AIVX7Ay7HLDuiLYAaFPu8oBYNq/QIi9URHJ3Q=="],
+
+    "@humanwhocodes/module-importer": ["@humanwhocodes/module-importer@1.0.1", "", {}, "sha512-bxveV4V8v5Yb4ncFTT3rPSgZBOpCkjfK0y4oVVVJwIuDVBRMDXrPyXRL988i5ap9m9bnyEEjWfm5WkBmtffLfA=="],
+
+    "@humanwhocodes/retry": ["@humanwhocodes/retry@0.4.3", "", {}, "sha512-bV0Tgo9K4hfPCek+aMAn81RppFKv2ySDQeMoSZuvTASywNTnVJCArCZE2FWqpvIatKu7VMRLWlR1EazvVhDyhQ=="],
+
     "@pierre/trees": ["@pierre/trees@1.0.0-beta.4", "", { "dependencies": { "preact": "11.0.0-beta.0", "preact-render-to-string": "6.6.5" }, "peerDependencies": { "react": "^18.3.1 || ^19.0.0", "react-dom": "^18.3.1 || ^19.0.0" } }, "sha512-OfT1yk9ne8Te5+GB5zUY8yqE6B8BqjBHQJleH4lu8ltwNpoocZl4vXt1AzlEExpxI/pp+AFX5QG+lR3JjtTEag=="],
 
     "@playwright/test": ["@playwright/test@1.60.0", "", { "dependencies": { "playwright": "1.60.0" }, "bin": { "playwright": "cli.js" } }, "sha512-O71yZIbAh/PxDMNGns37GHBIfrVkEVyn+AXyIa5dOTfb4/xNvRWV+Vv/NMbNCtODB/pO7vLlF2OTmMVLhmr7Ag=="],
@@ -48,7 +79,13 @@
 
     "@types/debug": ["@types/debug@4.1.12", "", { "dependencies": { "@types/ms": "*" } }, "sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ=="],
 
+    "@types/esrecurse": ["@types/esrecurse@4.3.1", "", {}, "sha512-xJBAbDifo5hpffDBuHl0Y8ywswbiAp/Wi7Y/GtAgSlZyIABppyurxVueOPE8LUQOxdlgi6Zqce7uoEpqNTeiUw=="],
+
+    "@types/estree": ["@types/estree@1.0.9", "", {}, "sha512-GhdPgy1el4/ImP05X05Uw4cw2/M93BCUmnEvWZNStlCzEKME4Fkk+YpoA5OiHNQmoS7Cafb8Xa3Pya8m1Qrzeg=="],
+
     "@types/hast": ["@types/hast@3.0.4", "", { "dependencies": { "@types/unist": "*" } }, "sha512-WPs+bbQw5aCj+x6laNGWLH3wviHtoCv/P3+otBhbOhJgG8qtpdAMlTCxLtsTWA7LH1Oh/bFCHsBn0TPS5m30EQ=="],
+
+    "@types/json-schema": ["@types/json-schema@7.0.15", "", {}, "sha512-5+fP8P8MFNC+AyZCDxrB2pkZFPGzqQWUzpSeuuVLvm8VMcorNYavBqoFcxK8bQz4Qsbn4oUEEem4wDLfcysGHA=="],
 
     "@types/katex": ["@types/katex@0.16.8", "", {}, "sha512-trgaNyfU+Xh2Tc+ABIb44a5AYUpicB3uwirOioeOkNPPbmgRNtcWyDeeFRzjPZENO9Vq8gvVqfhaaXWLlevVwg=="],
 
@@ -70,51 +107,41 @@
 
     "@types/unist": ["@types/unist@3.0.3", "", {}, "sha512-ko/gIFJRv177XgZsZcBwnqJN5x/Gien8qNOn0D5bQU/zAzVf9Zt3BlcUiLqhV9y4ARk0GbT3tnUiPNgnTXzc/Q=="],
 
-    "@typescript/typescript-aix-ppc64": ["@typescript/typescript-aix-ppc64@7.0.2", "", { "os": "aix", "cpu": "ppc64" }, "sha512-MTKKkWB7p/0E9xi1d1tHtZ5PiLkGEMIq88pK2CubZjOsLtYTLqhgIgi6zepFa+9GHZ6h05NMCkQxGKiPXMxXtQ=="],
+    "@typescript-eslint/eslint-plugin": ["@typescript-eslint/eslint-plugin@8.64.0", "", { "dependencies": { "@eslint-community/regexpp": "^4.12.2", "@typescript-eslint/scope-manager": "8.64.0", "@typescript-eslint/type-utils": "8.64.0", "@typescript-eslint/utils": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0", "ignore": "^7.0.5", "natural-compare": "^1.4.0", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "@typescript-eslint/parser": "^8.64.0", "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-CGvQPBxN3wZLu6Rz2kFUpZeoCm78xUic92ck39KPePkO1NPOwjCqdQnm5Q87tpWw9vcBvW8XLrDXjH9PWYtJ3Q=="],
 
-    "@typescript/typescript-darwin-arm64": ["@typescript/typescript-darwin-arm64@7.0.2", "", { "os": "darwin", "cpu": "arm64" }, "sha512-gowzar9MwS/aRWp6f3a4KUqzRjAZjOsmGNCM6LcTgXum+dBfgsBVMN+AgvOCCbguXyick6LJhpBszxMebJ8syA=="],
+    "@typescript-eslint/parser": ["@typescript-eslint/parser@8.64.0", "", { "dependencies": { "@typescript-eslint/scope-manager": "8.64.0", "@typescript-eslint/types": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0", "debug": "^4.4.3" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-KA0OshtlcCCXmbfqyZkM5pV3/WNraJf7DkJRLpyrmwPtud57H5BDX7C3k0LPSPxpprfRL+cJDGabF10mvNCoCw=="],
 
-    "@typescript/typescript-darwin-x64": ["@typescript/typescript-darwin-x64@7.0.2", "", { "os": "darwin", "cpu": "x64" }, "sha512-SZ9xZInqApNlNGc9s0W1VSsktYSOe9cFqNOIqmN1Gs8SmkjKZYFt017G4VwPxASInODuAdbTW7sXiFUf893RgA=="],
+    "@typescript-eslint/project-service": ["@typescript-eslint/project-service@8.64.0", "", { "dependencies": { "@typescript-eslint/tsconfig-utils": "^8.64.0", "@typescript-eslint/types": "^8.64.0", "debug": "^4.4.3" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-tk4WpOJ6IEbGrVHaNmM0YRrwAD3exZlIK3iadQNAxh4YKk6jvUQ4ecq18n+v7+meh+cJ3j+D8nbk8sRKhlwLQg=="],
 
-    "@typescript/typescript-freebsd-arm64": ["@typescript/typescript-freebsd-arm64@7.0.2", "", { "os": "freebsd", "cpu": "arm64" }, "sha512-W5NH4y/J0plIIS5b2xvTEkU7JFxyqdMAOgf+Ilhl0vHQXKO5dZoxd+C/jEtq56c4F3wk71RB4BMRQ2XdI+bwYQ=="],
+    "@typescript-eslint/scope-manager": ["@typescript-eslint/scope-manager@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0" } }, "sha512-CXEaFdYXjSTgKhisNkwCcJwTP8Pl+fmRrEQrri4nm3vU743bALrxzLmq7fHG/7e6a5xO0lDYeURpZmBuhHk54w=="],
 
-    "@typescript/typescript-freebsd-x64": ["@typescript/typescript-freebsd-x64@7.0.2", "", { "os": "freebsd", "cpu": "x64" }, "sha512-UMGDx5sTpzNw3WiPebH7l90IWfJggEd+egHt/q6p7/Cm3zqoV7VxkGXt+3DxPIw8CcmvAB0j3sVVfbhX+M4Tpw=="],
+    "@typescript-eslint/tsconfig-utils": ["@typescript-eslint/tsconfig-utils@8.64.0", "", { "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-2yo8rRNKuzbVWQp5kslhANqZ2uDAeROQHBRZNPu8JDsHmeFNj/XJJhX/FhNUWmkHHvoNsKa6+tHJiig87EzsQw=="],
 
-    "@typescript/typescript-linux-arm": ["@typescript/typescript-linux-arm@7.0.2", "", { "os": "linux", "cpu": "arm" }, "sha512-gffT3xPz9sR7j/YJExkyPntrI0P2EP9XbOyWzth2/Gs0RstK+90RBcO0ncXoXy/beYll1SXw846Nf2zdnEz0QQ=="],
+    "@typescript-eslint/type-utils": ["@typescript-eslint/type-utils@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/utils": "8.64.0", "debug": "^4.4.3", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-XWG4Fmmv/6SvyS9nH8jWrKs6terwJvE8cyRt1CzYYqzp9OrPhCT4cMc/f7C6RZCwG+qMmiffJS1/qJP8G1URtg=="],
 
-    "@typescript/typescript-linux-arm64": ["@typescript/typescript-linux-arm64@7.0.2", "", { "os": "linux", "cpu": "arm64" }, "sha512-Qh4eU4/y3yDjnfjjyPYihMj5/ODIlmt+Bzu17OI+fiSRDW57QmU5SiN63exPRNJPKUzcc1INa1NXdrJ+MqHjUQ=="],
+    "@typescript-eslint/types": ["@typescript-eslint/types@8.64.0", "", {}, "sha512-qjhfuTfLXjA4IOzXvz0rTjT01BqEiIgPoUeMwiEjnaHKJMTNo8rH5pYW1a2L/0Dnux2fPC85AeyJoWaGa8WxTA=="],
 
-    "@typescript/typescript-linux-loong64": ["@typescript/typescript-linux-loong64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-uEHck9i8hoAzXPiYRib1O7miOnz23SxIeVl6F4LXox+qov1K35jHcEW6VHKvZI+pyvl7fZEP4MCU5LYvIq1GuQ=="],
+    "@typescript-eslint/typescript-estree": ["@typescript-eslint/typescript-estree@8.64.0", "", { "dependencies": { "@typescript-eslint/project-service": "8.64.0", "@typescript-eslint/tsconfig-utils": "8.64.0", "@typescript-eslint/types": "8.64.0", "@typescript-eslint/visitor-keys": "8.64.0", "debug": "^4.4.3", "minimatch": "^10.2.2", "semver": "^7.7.3", "tinyglobby": "^0.2.15", "ts-api-utils": "^2.5.0" }, "peerDependencies": { "typescript": ">=4.8.4 <6.1.0" } }, "sha512-Pztpsn1aCE1oWDvDEfUk31nngvvF7vUB5SwHFEaZIFpvw7WJtqUHHL4plBZDA9HfWJJjL13BdG0YrJInTUvoVA=="],
 
-    "@typescript/typescript-linux-mips64el": ["@typescript/typescript-linux-mips64el@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-R4KvAMnE43W5Qeqb0Ly56O3mWMWIAgsMyz36DCaycd5nbg/9kzm0liw3JocfRqyJY0KPmzFjbswozXyW0DnIYA=="],
+    "@typescript-eslint/utils": ["@typescript-eslint/utils@8.64.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.9.1", "@typescript-eslint/scope-manager": "8.64.0", "@typescript-eslint/types": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-aJUGVB3+U0htrrCjoA8qukw8cm8fNCGAxK/tVoS70k8aeb7DETKeFozRiVFIwEeN9WJLsjaP3ph8I60tY2XZoQ=="],
 
-    "@typescript/typescript-linux-ppc64": ["@typescript/typescript-linux-ppc64@7.0.2", "", { "os": "linux", "cpu": "ppc64" }, "sha512-DORx5b3sd/4S7eayxm4FQv+A7CrkUIGRaHiwI8oiHTAI1fAPWhF4J0vAlkC8biAlHSVVwxMQ3tjZ2/DVbnQiiA=="],
-
-    "@typescript/typescript-linux-riscv64": ["@typescript/typescript-linux-riscv64@7.0.2", "", { "os": "linux", "cpu": "none" }, "sha512-wf0jqEDOjrPRnKwYRyyJDRo11KMbvMFrU+q4zqKyChODBzvlkbhNQfKvLxQCcwTpdDaXSHZTVuh0JoCrKCUMHQ=="],
-
-    "@typescript/typescript-linux-s390x": ["@typescript/typescript-linux-s390x@7.0.2", "", { "os": "linux", "cpu": "s390x" }, "sha512-IkwJc3L7yhytWd/ewjyxNDfOmswCm9GWMJT/ue/dU4aZNbwZeYAetq42VyLmsmSjvoX7z74X6ZaYCtzAr0EuGw=="],
-
-    "@typescript/typescript-linux-x64": ["@typescript/typescript-linux-x64@7.0.2", "", { "os": "linux", "cpu": "x64" }, "sha512-EYdf2cNg7rgCWJnxCdJ+F3V39O8ihb37eHAu1LK8oAFizgTQbPOK7zHHXbPt8rX24COqODXeI3sIf0fCXG7H/A=="],
-
-    "@typescript/typescript-netbsd-arm64": ["@typescript/typescript-netbsd-arm64@7.0.2", "", { "os": "none", "cpu": "arm64" }, "sha512-+polYF4MF04aPpO5FTkHran9yUQDSXqy5GiSDKpsll5jy3l3+g9QLhpf39T+ePtefhXLOGrLl0QIjkQP6VnelA=="],
-
-    "@typescript/typescript-netbsd-x64": ["@typescript/typescript-netbsd-x64@7.0.2", "", { "os": "none", "cpu": "x64" }, "sha512-8YIT0EHM/3dq10ZOVF/A7pc/YSMtbcecct4rWtexrnSCHOPcpC2KTLXfTCR6vDpnSiY12heNb1GiN/wu+T/FyA=="],
-
-    "@typescript/typescript-openbsd-arm64": ["@typescript/typescript-openbsd-arm64@7.0.2", "", { "os": "openbsd", "cpu": "arm64" }, "sha512-APT8+ClYnuYm1u9+kgGXoMj2VzWzcymwh2gNSQVySHfkRDGOTVkoWLjCmOQSaO+PoqQ57B0flRp9SA+7GnnkzQ=="],
-
-    "@typescript/typescript-openbsd-x64": ["@typescript/typescript-openbsd-x64@7.0.2", "", { "os": "openbsd", "cpu": "x64" }, "sha512-yX7s+Q0Dln0Dt9tEzZsAjXXR/+ytBM7AlglaqyeMPxQszJ1JhlJdZ6jLA+IzldHtflX81em7lDao1xXu+aRRkg=="],
-
-    "@typescript/typescript-sunos-x64": ["@typescript/typescript-sunos-x64@7.0.2", "", { "os": "sunos", "cpu": "x64" }, "sha512-dLJDGaLZ1D4HPQn62u1n8mBDkJREwMsAkCdkwd4Ieqw+x3TUyTsqY0YiBCtE6H6OzzgGk3iuZ3vFWRS+E8/d1g=="],
-
-    "@typescript/typescript-win32-arm64": ["@typescript/typescript-win32-arm64@7.0.2", "", { "os": "win32", "cpu": "arm64" }, "sha512-Gyl1Vy6OsWesLzmq+EP0Fb7b4Nid5232AvcA2SFcdYreldpNtYFFofPjnt62y9hQy7VTaZp65ICJjuAQRaVcIQ=="],
-
-    "@typescript/typescript-win32-x64": ["@typescript/typescript-win32-x64@7.0.2", "", { "os": "win32", "cpu": "x64" }, "sha512-0BQ3HkAHHlKLSp1qRvf3SUhGpGsDuhB/jgFw75guyqbxJqEaS0Cw/VFO8i2nHglJUzQCRtMMR/IBAKE3ETMC4g=="],
+    "@typescript-eslint/visitor-keys": ["@typescript-eslint/visitor-keys@8.64.0", "", { "dependencies": { "@typescript-eslint/types": "8.64.0", "eslint-visitor-keys": "^5.0.0" } }, "sha512-mrtuL8Nsn6gi2H4mo5KMTp823M+3Q19Ew/i+Zlikq20tIMm99C3Ez0dCmkWWnxut20esQvTg8aUSEhMcAOXhEw=="],
 
     "@ungap/structured-clone": ["@ungap/structured-clone@1.3.0", "", {}, "sha512-WmoN8qaIAo7WTYWbAZuG8PYEhn5fkz7dZrqTBZ7dtt//lL2Gwms1IcnQ5yHqjDfX8Ft5j4YzDM23f87zBfDe9g=="],
+
+    "acorn": ["acorn@8.17.0", "", { "bin": { "acorn": "bin/acorn" } }, "sha512-xRQbDb9BnwDafYNn6Vwl839DYVjqXYb1XVGtWAZ1kcDc6iwAL4hg3B1dZlRiuENFeO2H53gFG3in621AdERVAg=="],
+
+    "acorn-jsx": ["acorn-jsx@5.3.2", "", { "peerDependencies": { "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0" } }, "sha512-rq9s+JNhf0IChjtDXxllJ7g41oZk5SlXtp0LHwyA5cejwn7vKmKp4pPri6YEePv2PU65sAsegbXtIinmDFDXgQ=="],
+
+    "ajv": ["ajv@6.15.0", "", { "dependencies": { "fast-deep-equal": "^3.1.1", "fast-json-stable-stringify": "^2.0.0", "json-schema-traverse": "^0.4.1", "uri-js": "^4.2.2" } }, "sha512-fgFx7Hfoq60ytK2c7DhnF8jIvzYgOMxfugjLOSMHjLIPgenqa7S7oaagATUq99mV6IYvN2tRmC0wnTYX6iPbMw=="],
 
     "ansi-regex": ["ansi-regex@6.2.2", "", {}, "sha512-Bq3SmSpyFHaWjPk8If9yc6svM8c56dB5BAtW4Qbw5jHTwwXXcTLoRMkpDJp6VL0XzlWaCHTXrkFURMYmD0sLqg=="],
 
     "argparse": ["argparse@2.0.1", "", {}, "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q=="],
+
+    "balanced-match": ["balanced-match@4.0.4", "", {}, "sha512-BLrgEcRTwX2o6gGxGOCNyMvGSp35YofuYzw9h1IMTRmKqttAZZVU67bdb9Pr2vUHA8+j3i2tJfjO6C6+4myGTA=="],
+
+    "brace-expansion": ["brace-expansion@5.0.7", "", { "dependencies": { "balanced-match": "^4.0.2" } }, "sha512-7oFy703dxfY3/NLxC1fh2SUCQ0H9rmAY+5EpDVfXjUTTs+HEwR2nYaqLv+GWcTsumwxPfiz6CzCNkwXwBUwqCA=="],
 
     "bun-types": ["bun-types@1.3.14", "", { "dependencies": { "@types/node": "*" } }, "sha512-4N0ig0fEomHt5R0KCFWjovxow98rIoRwKolrYdCcknNwMekCXRnWEUvgu5soYV8QXtVsrUD8B95MBOZGPvr6KQ=="],
 
@@ -134,11 +161,15 @@
 
     "commander": ["commander@8.3.0", "", {}, "sha512-OkTL9umf+He2DZkUq8f8J9of7yL6RJKI24dVITBmNfZBmri9zYZQrKkuXiKhyfPSu8tUhnVBB1iKXevvnlR4Ww=="],
 
+    "cross-spawn": ["cross-spawn@7.0.6", "", { "dependencies": { "path-key": "^3.1.0", "shebang-command": "^2.0.0", "which": "^2.0.1" } }, "sha512-uV2QOWP2nWzsy2aMp8aRibhi9dlzF5Hgh5SHaB9OiTGEyDTiJJyx0uy51QXdyWbtAHNua4XJzUKca3OzKUd3vA=="],
+
     "dayjs": ["dayjs@1.11.21", "", {}, "sha512-98IT+HOahAisibz/yjKbzuOBwYcjJ7BCLPzARyHiyEBmRz4fatF+KPJszEHXsGYjUG234aH/cOjW1wwTbKUZlA=="],
 
     "debug": ["debug@4.4.3", "", { "dependencies": { "ms": "^2.1.3" } }, "sha512-RGwwWnwQvkVfavKVt22FGLw+xYSdzARwm0ru6DhTVA3umU5hZc28V3kO4stgYryrTlLpuvgI9GiijltAjNbcqA=="],
 
     "decode-named-character-reference": ["decode-named-character-reference@1.3.0", "", { "dependencies": { "character-entities": "^2.0.0" } }, "sha512-GtpQYB283KrPp6nRw50q3U9/VfOutZOe103qlN7BPP6Ad27xYnOIWv4lPzo8HCAL+mMZofJ9KEy30fq6MfaK6Q=="],
+
+    "deep-is": ["deep-is@0.1.4", "", {}, "sha512-oIPzksmTg4/MriiaYGO+okXDT7ztn/w3Eptv/+gSIdMdKsJo0u4CfYNFJPy+4SKMuCqGw2wxnA+URMg3t8a/bQ=="],
 
     "deepmerge": ["deepmerge@4.3.1", "", {}, "sha512-3sUqbMEc77XqpdNO7FRyRog+eW3ph+GYCbj+rK+uYyRMuwsVy0rMiVtPn+QJlKFvWP/1PYpapqYn0Me2knFn+A=="],
 
@@ -158,13 +189,49 @@
 
     "escape-string-regexp": ["escape-string-regexp@4.0.0", "", {}, "sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA=="],
 
+    "eslint": ["eslint@10.7.0", "", { "dependencies": { "@eslint-community/eslint-utils": "^4.8.0", "@eslint-community/regexpp": "^4.12.2", "@eslint/config-array": "^0.23.5", "@eslint/config-helpers": "^0.6.0", "@eslint/core": "^1.2.1", "@eslint/plugin-kit": "^0.7.2", "@humanfs/node": "^0.16.6", "@humanwhocodes/module-importer": "^1.0.1", "@humanwhocodes/retry": "^0.4.2", "@types/estree": "^1.0.6", "ajv": "^6.14.0", "cross-spawn": "^7.0.6", "debug": "^4.3.2", "escape-string-regexp": "^4.0.0", "eslint-scope": "^9.1.2", "eslint-visitor-keys": "^5.0.1", "espree": "^11.2.0", "esquery": "^1.7.0", "esutils": "^2.0.2", "fast-deep-equal": "^3.1.3", "file-entry-cache": "^8.0.0", "find-up": "^5.0.0", "glob-parent": "^6.0.2", "ignore": "^5.2.0", "imurmurhash": "^0.1.4", "is-glob": "^4.0.0", "json-stable-stringify-without-jsonify": "^1.0.1", "minimatch": "^10.2.4", "natural-compare": "^1.4.0", "optionator": "^0.9.3" }, "peerDependencies": { "jiti": "*" }, "optionalPeers": ["jiti"], "bin": { "eslint": "bin/eslint.js" } }, "sha512-GVTD7s1vdIl6UYvAfriOPeY1Df8LIZjfofLvHwde+erDHGGuHyuM6xoxRxmHiebhYuD2p1vN4wWh0XzPARSGDQ=="],
+
+    "eslint-scope": ["eslint-scope@9.1.2", "", { "dependencies": { "@types/esrecurse": "^4.3.1", "@types/estree": "^1.0.8", "esrecurse": "^4.3.0", "estraverse": "^5.2.0" } }, "sha512-xS90H51cKw0jltxmvmHy2Iai1LIqrfbw57b79w/J7MfvDfkIkFZ+kj6zC3BjtUwh150HsSSdxXZcsuv72miDFQ=="],
+
+    "eslint-visitor-keys": ["eslint-visitor-keys@5.0.1", "", {}, "sha512-tD40eHxA35h0PEIZNeIjkHoDR4YjjJp34biM0mDvplBe//mB+IHCqHDGV7pxF+7MklTvighcCPPZC7ynWyjdTA=="],
+
+    "espree": ["espree@11.2.0", "", { "dependencies": { "acorn": "^8.16.0", "acorn-jsx": "^5.3.2", "eslint-visitor-keys": "^5.0.1" } }, "sha512-7p3DrVEIopW1B1avAGLuCSh1jubc01H2JHc8B4qqGblmg5gI9yumBgACjWo4JlIc04ufug4xJ3SQI8HkS/Rgzw=="],
+
     "esprima": ["esprima@4.0.1", "", { "bin": { "esparse": "./bin/esparse.js", "esvalidate": "./bin/esvalidate.js" } }, "sha512-eGuFFw7Upda+g4p+QHvnW0RyTX/SVeJBDM/gCtMARO0cLuT2HcEKnTPvhjV6aGeqrCB/sbNop0Kszm0jsaWU4A=="],
 
+    "esquery": ["esquery@1.7.0", "", { "dependencies": { "estraverse": "^5.1.0" } }, "sha512-Ap6G0WQwcU/LHsvLwON1fAQX9Zp0A2Y6Y/cJBl9r/JbW90Zyg4/zbG6zzKa2OTALELarYHmKu0GhpM5EO+7T0g=="],
+
+    "esrecurse": ["esrecurse@4.3.0", "", { "dependencies": { "estraverse": "^5.2.0" } }, "sha512-KmfKL3b6G+RXvP8N1vr3Tq1kL/oCFgn2NYXEtqP8/L3pKapUA4G8cFVaoF3SU323CD4XypR/ffioHmkti6/Tag=="],
+
+    "estraverse": ["estraverse@5.3.0", "", {}, "sha512-MMdARuVEQziNTeJD8DgMqmhwR11BRQ/cBP+pLtYdSTnf3MIO8fFeiINEbX36ZdNlfU/7A9f3gUw49B3oQsvwBA=="],
+
+    "esutils": ["esutils@2.0.3", "", {}, "sha512-kVscqXk4OCp68SZ0dkgEKVi6/8ij300KBWTJq32P/dYeWTSwK41WyTxalN1eRmA5Z9UU/LX9D7FWSmV9SAYx6g=="],
+
     "extend-shallow": ["extend-shallow@2.0.1", "", { "dependencies": { "is-extendable": "^0.1.0" } }, "sha512-zCnTtlxNoAiDc3gqY2aYAWFx7XWWiasuF2K8Me5WbN8otHKTUKBwjPtNpRs/rbUZm7KxWAaNj7P1a/p52GbVug=="],
+
+    "fast-deep-equal": ["fast-deep-equal@3.1.3", "", {}, "sha512-f3qQ9oQy9j2AhBe/H9VC91wLmKBCCU/gDOnKNAYG5hswO7BLKj09Hc5HYNz9cGI++xlpDCIgDaitVs03ATR84Q=="],
+
+    "fast-json-stable-stringify": ["fast-json-stable-stringify@2.1.0", "", {}, "sha512-lhd/wF+Lk98HZoTCtlVraHtfh5XYijIjalXck7saUtuanSDyLMxnHhSXEDJqHxD7msR8D0uCmqlkwjCV8xvwHw=="],
+
+    "fast-levenshtein": ["fast-levenshtein@2.0.6", "", {}, "sha512-DCXu6Ifhqcks7TZKY3Hxp3y6qphY5SJZmrWMDrKcERSOXWQdMhU9Ig/PYrzyw/ul9jOIyh0N4M0tbC5hodg8dw=="],
+
+    "fdir": ["fdir@6.5.0", "", { "peerDependencies": { "picomatch": "^3 || ^4" }, "optionalPeers": ["picomatch"] }, "sha512-tIbYtZbucOs0BRGqPJkshJUYdL+SDH7dVM8gjy+ERp3WAUjLEFJE+02kanyHtwjWOnwrKYBiwAmM0p4kLJAnXg=="],
+
+    "file-entry-cache": ["file-entry-cache@8.0.0", "", { "dependencies": { "flat-cache": "^4.0.0" } }, "sha512-XXTUwCvisa5oacNGRP9SfNtYBNAMi+RPwBFmblZEF7N7swHYQS6/Zfk7SRwx4D5j3CH211YNRco1DEMNVfZCnQ=="],
+
+    "find-up": ["find-up@5.0.0", "", { "dependencies": { "locate-path": "^6.0.0", "path-exists": "^4.0.0" } }, "sha512-78/PXT1wlLLDgTzDs7sjq9hzz0vXD+zn+7wypEe4fXQxCmdmqfGsEPQxmiCSQI3ajFV91bVSsvNtrJRiW6nGng=="],
+
+    "flat-cache": ["flat-cache@4.0.1", "", { "dependencies": { "flatted": "^3.2.9", "keyv": "^4.5.4" } }, "sha512-f7ccFPK3SXFHpx15UIGyRJ/FJQctuKZ0zVuN3frBo4HnK3cay9VEW0R6yPYFHC0AgqhukPzKjq22t5DmAyqGyw=="],
+
+    "flatted": ["flatted@3.4.2", "", {}, "sha512-PjDse7RzhcPkIJwy5t7KPWQSZ9cAbzQXcafsetQoD7sOJRQlGikNbx7yZp2OotDnJyrDcbyRq3Ttb18iYOqkxA=="],
 
     "fsevents": ["fsevents@2.3.2", "", { "os": "darwin" }, "sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA=="],
 
     "get-east-asian-width": ["get-east-asian-width@1.4.0", "", {}, "sha512-QZjmEOC+IT1uk6Rx0sX22V6uHWVwbdbxf1faPqJ1QhLdGgsRGCZoyaQBm/piRdJy/D2um6hM1UP7ZEeQ4EkP+Q=="],
+
+    "glob-parent": ["glob-parent@6.0.2", "", { "dependencies": { "is-glob": "^4.0.3" } }, "sha512-XxwI8EOhVQgWp6iDL+3b0r86f4d6AX6zSU55HfB4ydCEuXLXc5FcYeOu+nnGftS4TEju/11rt4KJPTMgbfmv4A=="],
+
+    "globals": ["globals@17.7.0", "", {}, "sha512-Czmyns5dUsq4seFBR/Kdydhmo8y9kC79hiSkPn0YcGtNnYWnrgt0vjrSjx9tspoDGWm2CMarffRuLjM4xUz8xg=="],
 
     "gray-matter": ["gray-matter@4.0.3", "", { "dependencies": { "js-yaml": "^3.13.1", "kind-of": "^6.0.2", "section-matter": "^1.0.0", "strip-bom-string": "^1.0.0" } }, "sha512-5v6yZd4JK3eMI3FqqCouswVqwugaA9r4dNZB1wwcmrD02QkV5H0y7XBQW8QwQqEaZY1pM9aqORSORhJRdNK44Q=="],
 
@@ -176,6 +243,10 @@
 
     "htmlparser2": ["htmlparser2@10.1.0", "", { "dependencies": { "domelementtype": "^2.3.0", "domhandler": "^5.0.3", "domutils": "^3.2.2", "entities": "^7.0.1" } }, "sha512-VTZkM9GWRAtEpveh7MSF6SjjrpNVNNVJfFup7xTY3UpFtm67foy9HDVXneLtFVt4pMz5kZtgNcvCniNFb1hlEQ=="],
 
+    "ignore": ["ignore@5.3.2", "", {}, "sha512-hsBTNUqQTDwkWtcdYI2i06Y/nUBEsNEDJKjWdigLvegy8kDuJAS8uRlpkkcQpyEXL0Z/pjDy5HBmMjRCJ2gq+g=="],
+
+    "imurmurhash": ["imurmurhash@0.1.4", "", {}, "sha512-JmXMZ6wuvDmLiHEml9ykzqO6lwFbof0GG4IkcGaENdCRDDmMVnny7s5HsIgHCbaq0w2MyPhDqkhTUgS2LU2PHA=="],
+
     "is-alphabetical": ["is-alphabetical@2.0.1", "", {}, "sha512-FWyyY60MeTNyeSRpkM2Iry0G9hpr7/9kD40mD/cGQEuilcZYS4okz8SN2Q6rLCJ8gbCt6fN+rC+6tMGS99LaxQ=="],
 
     "is-alphanumerical": ["is-alphanumerical@2.0.1", "", { "dependencies": { "is-alphabetical": "^2.0.0", "is-decimal": "^2.0.0" } }, "sha512-hmbYhX/9MUMF5uh7tOXyK/n0ZvWpad5caBA17GsC6vyuCqaWliRG5K1qS9inmUhEMaOBIW7/whAnSwveW/LtZw=="],
@@ -184,19 +255,37 @@
 
     "is-extendable": ["is-extendable@0.1.1", "", {}, "sha512-5BMULNob1vgFX6EjQw5izWDxrecWK9AM72rugNr0TFldMOi0fj6Jk+zeKIt0xGj4cEfQIJth4w3OKWOJ4f+AFw=="],
 
+    "is-extglob": ["is-extglob@2.1.1", "", {}, "sha512-SbKbANkN603Vi4jEZv49LeVJMn4yGwsbzZworEoyEiutsN3nJYdbO36zfhGJ6QEDpOZIFkDtnq5JRxmvl3jsoQ=="],
+
+    "is-glob": ["is-glob@4.0.3", "", { "dependencies": { "is-extglob": "^2.1.1" } }, "sha512-xelSayHH36ZgE7ZWhli7pW34hNbNl8Ojv5KVmkJD4hBdD3th8Tfk9vYasLM+mXWOZhFkgZfxhLSnrwRr4elSSg=="],
+
     "is-hexadecimal": ["is-hexadecimal@2.0.1", "", {}, "sha512-DgZQp241c8oO6cA1SbTEWiXeoxV42vlcJxgH+B3hi1AiqqKruZR3ZGF8In3fj4+/y/7rHvlOZLZtgJ/4ttYGZg=="],
 
     "is-plain-object": ["is-plain-object@5.0.0", "", {}, "sha512-VRSzKkbMm5jMDoKLbltAkFQ5Qr7VDiTFGXxYFXXowVj387GeGNOCsOH6Msy00SGZ3Fp84b1Naa1psqgcCIEP5Q=="],
 
+    "isexe": ["isexe@2.0.0", "", {}, "sha512-RHxMLp9lnKHGHRng9QFhRCMbYAcVpn69smSGcq3f36xjgVVWThj4qqLbTLlq7Ssj8B+fIQ1EuCEGI2lKsyQeIw=="],
+
     "js-yaml": ["js-yaml@3.14.2", "", { "dependencies": { "argparse": "^1.0.7", "esprima": "^4.0.0" }, "bin": { "js-yaml": "bin/js-yaml.js" } }, "sha512-PMSmkqxr106Xa156c2M265Z+FTrPl+oxd/rgOQy2tijQeK5TxQ43psO1ZCwhVOSdnn+RzkzlRz/eY4BgJBYVpg=="],
 
+    "json-buffer": ["json-buffer@3.0.1", "", {}, "sha512-4bV5BfR2mqfQTJm+V5tPPdf+ZpuhiIvTuAB5g8kcrXOZpTT/QwwVRWBywX1ozr6lEuPdbHxwaJlm9G6mI2sfSQ=="],
+
+    "json-schema-traverse": ["json-schema-traverse@0.4.1", "", {}, "sha512-xbbCH5dCYU5T8LcEhhuh7HJ88HXuW3qsI3Y0zOZFKfZEHcpWiHU/Jxzk629Brsab/mMiHQti9wMP+845RPe3Vg=="],
+
+    "json-stable-stringify-without-jsonify": ["json-stable-stringify-without-jsonify@1.0.1", "", {}, "sha512-Bdboy+l7tA3OGW6FjyFHWkP5LuByj1Tk33Ljyq0axyzdk9//JSi2u3fP1QSmd1KNwq6VOKYGlAu87CisVir6Pw=="],
+
     "katex": ["katex@0.16.28", "", { "dependencies": { "commander": "^8.3.0" }, "bin": { "katex": "cli.js" } }, "sha512-YHzO7721WbmAL6Ov1uzN/l5mY5WWWhJBSW+jq4tkfZfsxmo1hu6frS0EOswvjBUnWE6NtjEs48SFn5CQESRLZg=="],
+
+    "keyv": ["keyv@4.5.4", "", { "dependencies": { "json-buffer": "3.0.1" } }, "sha512-oxVHkHR/EJf2CNXnWxRLW6mg7JyCCUcG0DtEGmL2ctUo1PNTin1PUil+r/+4r5MpVgC/fn1kjsx7mjSujKqIpw=="],
 
     "kind-of": ["kind-of@6.0.3", "", {}, "sha512-dcS1ul+9tmeD95T+x28/ehLgd9mENa3LsvDTtzm3vyBEO7RPptvAD+t44WVXaUjTBRcrpFeFlC8WCruUR456hw=="],
 
     "launder": ["launder@1.7.1", "", { "dependencies": { "dayjs": "^1.11.7" } }, "sha512-mU6WRz5EusL9ZZuiZ5SO4Y6C0P9PAUR9iwdb6bzj4KDihm28DiHFw+/yk9DBH4f+Pv1wuzQ4e2jV3oQ7mkIqvw=="],
 
+    "levn": ["levn@0.4.1", "", { "dependencies": { "prelude-ls": "^1.2.1", "type-check": "~0.4.0" } }, "sha512-+bT2uH4E5LGE7h/n3evcS/sQlJXCpIp6ym8OWJ5eV6+67Dsql/LaaT7qJBAt2rzfoa/5QBGBhxDix1dMt2kQKQ=="],
+
     "linkify-it": ["linkify-it@5.0.1", "", { "dependencies": { "uc.micro": "^2.0.0" } }, "sha512-wVoTjP4Q6R0NW5hiZkVJaFZPWgtXfoGF+6LucL3/FtiNjmcHhYjEr5f1Kqjirc1nBW07J/ZuRFumqr2oqccEWg=="],
+
+    "locate-path": ["locate-path@6.0.0", "", { "dependencies": { "p-locate": "^5.0.0" } }, "sha512-iPZK6eYjbxRu3uB4/WZ3EsEIMJFMqAoopl3R+zuq0UjcAm/MO6KCweDgPfP3elTztoKP3KtnVHxTn2NHBSDVUw=="],
 
     "markdown-it": ["markdown-it@14.2.0", "", { "dependencies": { "argparse": "^2.0.1", "entities": "^4.4.0", "linkify-it": "^5.0.1", "mdurl": "^2.0.0", "punycode.js": "^2.3.1", "uc.micro": "^2.1.0" }, "bin": { "markdown-it": "bin/markdown-it.mjs" } }, "sha512-1TGiQiJVRQ3NPmZH6sx5Cfnmg6GQm9jvC1ch4TK511NjSJvjzKLzn5pPfZRNZkRPZP0HqCioSndqH8v2nRaWVQ=="],
 
@@ -256,17 +345,31 @@
 
     "micromark-util-types": ["micromark-util-types@2.0.2", "", {}, "sha512-Yw0ECSpJoViF1qTU4DC6NwtC4aWGt1EkzaQB8KPPyCRR8z9TWeV0HbEFGTO+ZY1wB22zmxnJqhPyTpOVCpeHTA=="],
 
+    "minimatch": ["minimatch@10.2.5", "", { "dependencies": { "brace-expansion": "^5.0.5" } }, "sha512-MULkVLfKGYDFYejP07QOurDLLQpcjk7Fw+7jXS2R2czRQzR56yHRveU5NDJEOviH+hETZKSkIk5c+T23GjFUMg=="],
+
     "ms": ["ms@2.1.3", "", {}, "sha512-6FlzubTLZG3J2a/NVCAleEhjzq5oxgHyaCU9yYXvcLsvoVaHJq/s5xXI6/XXP6tz7R9xAOtHnSO/tXtF3WRTlA=="],
 
     "nanoid": ["nanoid@3.3.16", "", { "bin": { "nanoid": "bin/nanoid.cjs" } }, "sha512-bzlKTyNJ7+LdGIIwy8ijFpIqEQIvafahV7eYykJ8Cvh42EdJeODoJ6gUJXpQJvej1BddH8OqTXZNE/KfbWAu8Q=="],
+
+    "natural-compare": ["natural-compare@1.4.0", "", {}, "sha512-OWND8ei3VtNC9h7V60qff3SVobHr996CTwgxubgyQYEpg290h9J0buyECNNJexkFm5sOajh5G116RYA1c8ZMSw=="],
 
     "oniguruma-parser": ["oniguruma-parser@0.12.2", "", {}, "sha512-6HVa5oIrgMC6aA6WF6XyyqbhRPJrKR02L20+2+zpDtO5QAzGHAUGw5TKQvwi5vctNnRHkJYmjAhRVQF2EKdTQw=="],
 
     "oniguruma-to-es": ["oniguruma-to-es@4.3.6", "", { "dependencies": { "oniguruma-parser": "^0.12.2", "regex": "^6.1.0", "regex-recursion": "^6.0.2" } }, "sha512-csuQ9x3Yr0cEIs/Zgx/OEt9iBw9vqIunAPQkx19R/fiMq2oGVTgcMqO/V3Ybqefr1TBvosI6jU539ksaBULJyA=="],
 
+    "optionator": ["optionator@0.9.4", "", { "dependencies": { "deep-is": "^0.1.3", "fast-levenshtein": "^2.0.6", "levn": "^0.4.1", "prelude-ls": "^1.2.1", "type-check": "^0.4.0", "word-wrap": "^1.2.5" } }, "sha512-6IpQ7mKUxRcZNLIObR0hz7lxsapSSIYNZJwXPGeF0mTVqGKFIXj1DQcMoT22S3ROcLyY/rz0PWaWZ9ayWmad9g=="],
+
+    "p-limit": ["p-limit@3.1.0", "", { "dependencies": { "yocto-queue": "^0.1.0" } }, "sha512-TYOanM3wGwNGsZN2cVTYPArw454xnXj5qmWF1bEoAc4+cU/ol7GVh7odevjp1FNHduHc3KZMcFduxU5Xc6uJRQ=="],
+
+    "p-locate": ["p-locate@5.0.0", "", { "dependencies": { "p-limit": "^3.0.2" } }, "sha512-LaNjtRWUBY++zB5nE/NwcaoMylSPk+S+ZHNB1TzdbMJMny6dynpAGt7X/tl/QYq3TIeE6nxHppbo2LGymrG5Pw=="],
+
     "parse-entities": ["parse-entities@4.0.2", "", { "dependencies": { "@types/unist": "^2.0.0", "character-entities-legacy": "^3.0.0", "character-reference-invalid": "^2.0.0", "decode-named-character-reference": "^1.0.0", "is-alphanumerical": "^2.0.0", "is-decimal": "^2.0.0", "is-hexadecimal": "^2.0.0" } }, "sha512-GG2AQYWoLgL877gQIKeRPGO1xF9+eG1ujIb5soS5gPvLQ1y2o8FL90w2QWNdf9I361Mpp7726c+lj3U0qK1uGw=="],
 
     "parse-srcset": ["parse-srcset@1.0.2", "", {}, "sha512-/2qh0lav6CmI15FzA3i/2Bzk2zCgQhGMkvhOhKNcBVQ1ldgpbfiNTVslmooUmWJcADi1f1kIeynbDRVzNlfR6Q=="],
+
+    "path-exists": ["path-exists@4.0.0", "", {}, "sha512-ak9Qy5Q7jYb2Wwcey5Fpvg2KoAc/ZIhLSLOSBmRmygPsGwkVVt0fZa0qrtMz+m6tJTAHfZQ8FnmB4MG4LWy7/w=="],
+
+    "path-key": ["path-key@3.1.1", "", {}, "sha512-ojmeN0qd+y0jszEtoY48r0Peq5dwMEkIlCOu6Q5f41lfkswXuKtYrhgoTpLnyIcHm24Uhqx+5Tqm2InSwLhE6Q=="],
 
     "picocolors": ["picocolors@1.1.1", "", {}, "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="],
 
@@ -282,7 +385,13 @@
 
     "preact-render-to-string": ["preact-render-to-string@6.6.5", "", { "peerDependencies": { "preact": ">=10 || >= 11.0.0-0" } }, "sha512-O6MHzYNIKYaiSX3bOw0gGZfEbOmlIDtDfWwN1JJdc/T3ihzRT6tGGSEWE088dWrEDGa1u7101q+6fzQnO9XCPA=="],
 
+    "prelude-ls": ["prelude-ls@1.2.1", "", {}, "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g=="],
+
+    "prettier": ["prettier@3.9.5", "", { "bin": { "prettier": "bin/prettier.cjs" } }, "sha512-/FVl766LpUfB5vXgCYOYa0MeV/441Ia99AeICQIQFTY/Nw0roZwULcXpku5i1/m5kt/baz+s4Zogspd839HSMg=="],
+
     "property-information": ["property-information@7.1.0", "", {}, "sha512-TwEZ+X+yCJmYfL7TPUOcvBZ4QfoT5YenQiJuX//0th53DE6w0xxLEtfK3iyryQFddXuvkIk51EEgrJQ0WJkOmQ=="],
+
+    "punycode": ["punycode@2.3.1", "", {}, "sha512-vYt7UD1U9Wg6138shLtLOvdAu+8DsC/ilFtEVHcH+wydcSpNE20AfSOduf6MkRFahL5FY7X1oU7nKVZFtfq8Fg=="],
 
     "punycode.js": ["punycode.js@2.3.1", "", {}, "sha512-uxFIHU0YlHYhDQtV4R9J6a52SLx28BCjT+4ieh7IGbgwVJWO+km431c4yRlREUAsAmt/uMjQUyQHNEPf0M39CA=="],
 
@@ -304,6 +413,12 @@
 
     "section-matter": ["section-matter@1.0.0", "", { "dependencies": { "extend-shallow": "^2.0.1", "kind-of": "^6.0.0" } }, "sha512-vfD3pmTzGpufjScBh50YHKzEu2lxBWhVEHsNGoEXmCmn2hKGfeNLYMzCJpe8cD7gqX7TJluOVpBkAequ6dgMmA=="],
 
+    "semver": ["semver@7.8.5", "", { "bin": { "semver": "bin/semver.js" } }, "sha512-Y7/KDsb8LjooZpwaqGyulO6DQlksgCncchHGk+sZIY4SBvUocMBEFH5Ur1fI4dV+Jvl0w6cjvucaIi40puRioA=="],
+
+    "shebang-command": ["shebang-command@2.0.0", "", { "dependencies": { "shebang-regex": "^3.0.0" } }, "sha512-kHxr2zZpYtdmrN1qDjrrX/Z1rR1kG8Dx+gkpK1G4eXmvXswmcE1hTWBWYUzlraYw1/yZp6YuDY77YtvbN0dmDA=="],
+
+    "shebang-regex": ["shebang-regex@3.0.0", "", {}, "sha512-7++dFhtcx3353uBaq8DDR4NuxBetBzC7ZQOhmTQInHEd6bSrXdiEyzCvG07Z44UYdLShWUyXt5M/yhz8ekcb1A=="],
+
     "source-map-js": ["source-map-js@1.2.1", "", {}, "sha512-UXWMKhLOwVKb728IUtQPXxfYU+usdybtUrK/8uGE8CQMvrhOpwvzDBwj0QhSL7MQc7vIsISBG8VQ8+IDQxpfQA=="],
 
     "space-separated-tokens": ["space-separated-tokens@2.0.2", "", {}, "sha512-PEGlAwrG8yXGXRjW32fGbg66JAlOAwbObuqVoJpv/mRgoWDQfgH1wDPvtzWyUSNAXBGSk8h755YDbbcEy3SH2Q=="],
@@ -318,9 +433,17 @@
 
     "strip-bom-string": ["strip-bom-string@1.0.0", "", {}, "sha512-uCC2VHvQRYu+lMh4My/sFNmF2klFymLX1wHJeXnbEJERpV/ZsVuonzerjfrGpIGF7LBVa1O7i9kjiWvJiFck8g=="],
 
+    "tinyglobby": ["tinyglobby@0.2.17", "", { "dependencies": { "fdir": "^6.5.0", "picomatch": "^4.0.4" } }, "sha512-wXR/dYpcqKmfWpEdZjiKJOwCNFndD0DMnrW/cYjVGttEkBfVgcLFHoNrlj47mjOVic9yyNu65alsgF4NQyTa2g=="],
+
     "trim-lines": ["trim-lines@3.0.1", "", {}, "sha512-kRj8B+YHZCc9kQYdWfJB2/oUl9rA99qbowYYBtr4ui4mZyAQ2JpvVBd/6U2YloATfqBhBTSMhTpgBHtU0Mf3Rg=="],
 
-    "typescript": ["typescript@7.0.2", "", { "optionalDependencies": { "@typescript/typescript-aix-ppc64": "7.0.2", "@typescript/typescript-darwin-arm64": "7.0.2", "@typescript/typescript-darwin-x64": "7.0.2", "@typescript/typescript-freebsd-arm64": "7.0.2", "@typescript/typescript-freebsd-x64": "7.0.2", "@typescript/typescript-linux-arm": "7.0.2", "@typescript/typescript-linux-arm64": "7.0.2", "@typescript/typescript-linux-loong64": "7.0.2", "@typescript/typescript-linux-mips64el": "7.0.2", "@typescript/typescript-linux-ppc64": "7.0.2", "@typescript/typescript-linux-riscv64": "7.0.2", "@typescript/typescript-linux-s390x": "7.0.2", "@typescript/typescript-linux-x64": "7.0.2", "@typescript/typescript-netbsd-arm64": "7.0.2", "@typescript/typescript-netbsd-x64": "7.0.2", "@typescript/typescript-openbsd-arm64": "7.0.2", "@typescript/typescript-openbsd-x64": "7.0.2", "@typescript/typescript-sunos-x64": "7.0.2", "@typescript/typescript-win32-arm64": "7.0.2", "@typescript/typescript-win32-x64": "7.0.2" }, "bin": { "tsc": "bin/tsc" } }, "sha512-8FYau96o3NKOhbjKi/qNvG/W5jhzxkbdm5sj9AbZ/5T5sWqn3hJgLfGx27sRKZWTvyzCP8dLRBTf5tBTSRVUNA=="],
+    "ts-api-utils": ["ts-api-utils@2.5.0", "", { "peerDependencies": { "typescript": ">=4.8.4" } }, "sha512-OJ/ibxhPlqrMM0UiNHJ/0CKQkoKF243/AEmplt3qpRgkW8VG7IfOS41h7V8TjITqdByHzrjcS/2si+y4lIh8NA=="],
+
+    "type-check": ["type-check@0.4.0", "", { "dependencies": { "prelude-ls": "^1.2.1" } }, "sha512-XleUoc9uwGXqjWwXaUTZAmzMcFZ5858QA2vvx1Ur5xIcixXIP+8LnFDgRplU30us6teqdlskFfu+ae4K79Ooew=="],
+
+    "typescript": ["typescript@6.0.3", "", { "bin": { "tsc": "bin/tsc", "tsserver": "bin/tsserver" } }, "sha512-y2TvuxSZPDyQakkFRPZHKFm+KKVqIisdg9/CZwm9ftvKXLP8NRWj38/ODjNbr43SsoXqNuAisEf1GdCxqWcdBw=="],
+
+    "typescript-eslint": ["typescript-eslint@8.64.0", "", { "dependencies": { "@typescript-eslint/eslint-plugin": "8.64.0", "@typescript-eslint/parser": "8.64.0", "@typescript-eslint/typescript-estree": "8.64.0", "@typescript-eslint/utils": "8.64.0" }, "peerDependencies": { "eslint": "^8.57.0 || ^9.0.0 || ^10.0.0", "typescript": ">=4.8.4 <6.1.0" } }, "sha512-0qg+pDNMnqYzqH9AnNK+39tejHvsShUOUUoRUgtnTGE7QuMZhiFDnozq8nHJVq+Wae6NMLKNWLg5WmkcC/ndyQ=="],
 
     "uc.micro": ["uc.micro@2.1.0", "", {}, "sha512-ARDJmphmdvUk6Glw7y9DQ2bFkKBHwQHLi2lsaH6PPmz/Ka9sFOBsBluozhDltWmnv9u/cF6Rt87znRTPV+yp/A=="],
 
@@ -336,11 +459,23 @@
 
     "unist-util-visit-parents": ["unist-util-visit-parents@6.0.2", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-is": "^6.0.0" } }, "sha512-goh1s1TBrqSqukSc8wrjwWhL0hiJxgA8m4kFxGlQ+8FYQ3C/m11FcTs4YYem7V664AhHVvgoQLk890Ssdsr2IQ=="],
 
+    "uri-js": ["uri-js@4.4.1", "", { "dependencies": { "punycode": "^2.1.0" } }, "sha512-7rKUyy33Q1yc98pQ1DAmLtwX109F7TIfWlW1Ydo8Wl1ii1SeHieeh0HHfPeL2fMXK6z0s8ecKs9frCuLJvndBg=="],
+
     "vfile": ["vfile@6.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "vfile-message": "^4.0.0" } }, "sha512-KzIbH/9tXat2u30jf+smMwFCsno4wHVdNmzFyL+T/L3UGqqk6JKfVqOFOZEpZSHADH1k40ab6NUIXZq422ov3Q=="],
 
     "vfile-message": ["vfile-message@4.0.3", "", { "dependencies": { "@types/unist": "^3.0.0", "unist-util-stringify-position": "^4.0.0" } }, "sha512-QTHzsGd1EhbZs4AsQ20JX1rC3cOlt/IWJruk893DfLRr57lcnOeMaWG4K0JrRta4mIJZKth2Au3mM3u03/JWKw=="],
 
+    "which": ["which@2.0.2", "", { "dependencies": { "isexe": "^2.0.0" }, "bin": { "node-which": "./bin/node-which" } }, "sha512-BLI3Tl1TW3Pvl70l3yq3Y64i+awpwXqsGBYWkkqMtnbXgrMD+yj7rhW0kuEDxzJaYXGjEW5ogapKNMEKNMjibA=="],
+
+    "word-wrap": ["word-wrap@1.2.5", "", {}, "sha512-BN22B5eaMMI9UMtjrGd5g5eCYPpCPDUy0FJXbYsaT5zYxjFOckS53SQDE3pWkVoWpHXVb3BrYcEN4Twa55B5cA=="],
+
+    "yocto-queue": ["yocto-queue@0.1.0", "", {}, "sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q=="],
+
     "zwitch": ["zwitch@2.0.4", "", {}, "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="],
+
+    "@eslint-community/eslint-utils/eslint-visitor-keys": ["eslint-visitor-keys@3.4.3", "", {}, "sha512-wpc+LXeiyiisxPlEkUzU6svyS1frIO3Mgxj1fdy7Pm8Ygzguax2N3Fa/D/ag1WqbOprdI+uY6wMUl8/a2G+iag=="],
+
+    "@typescript-eslint/eslint-plugin/ignore": ["ignore@7.0.6", "", {}, "sha512-BAg6QkE8W+TuQLrrw0Ugr7HegXduRuuj8/ti2kSOc+jz1dmx8/WNcjr6XGnq5YpDWxFwwaavqD0+jIUOKelTsw=="],
 
     "htmlparser2/entities": ["entities@7.0.1", "", {}, "sha512-TWrgLOFUQTH994YUyl1yT4uyavY5nNB5muff+RtWaqNVCAK408b5ZnnbNAUEWLTCpum9w6arT70i1XdQ4UeOPA=="],
 

--- a/eslint.config.js
+++ b/eslint.config.js
@@ -1,0 +1,43 @@
+import eslint from "@eslint/js";
+import globals from "globals";
+import tseslint from "typescript-eslint";
+
+const SOURCE_FILES = ["src/**/*.{js,ts}", "scripts/**/*.ts"];
+
+export default tseslint.config(
+  {
+    ignores: ["dist/**", "node_modules/**", "playwright-report/**", "test-results/**"],
+  },
+  {
+    ...eslint.configs.recommended,
+    files: SOURCE_FILES,
+  },
+  ...tseslint.configs.recommended.map((config) => ({
+    ...config,
+    files: SOURCE_FILES,
+  })),
+  {
+    files: SOURCE_FILES,
+    languageOptions: {
+      globals: {
+        ...globals.browser,
+        ...globals.node,
+        Bun: "readonly",
+      },
+    },
+    linterOptions: {
+      reportUnusedDisableDirectives: "error",
+    },
+    rules: {
+      "@typescript-eslint/no-unused-vars": [
+        "error",
+        {
+          argsIgnorePattern: "^_",
+          caughtErrorsIgnorePattern: "^_",
+          ignoreRestSiblings: true,
+          varsIgnorePattern: "^_",
+        },
+      ],
+    },
+  },
+);

--- a/package.json
+++ b/package.json
@@ -1,52 +1,62 @@
 {
-	"name": "@limcpf/everything-is-a-markdown",
-	"version": "0.8.0",
-	"license": "MIT",
-	"private": false,
-	"type": "module",
-	"bin": {
-		"eiam": "src/cli.ts"
-	},
-	"files": [
-		"src",
-		"README.md",
-		"bun.lock",
-		"tsconfig.json"
-	],
-	"publishConfig": {
-		"access": "public"
-	},
-	"scripts": {
-		"blog": "bun run src/cli.ts",
-		"build": "bun run src/cli.ts build",
-		"dev": "bun run src/cli.ts dev",
-		"clean": "bun run src/cli.ts clean",
-		"check:size": "bun run scripts/check-output-size.ts --out ./dist",
-		"check:reproducible": "bun run scripts/check-build-reproducibility.ts --vault ./test-vault --out ./dist",
-		"lint:md:publish": "bun run scripts/lint-published-markdown.ts --out-dir dist",
-		"typecheck": "tsc --noEmit",
-		"test:e2e": "playwright test",
-		"test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"
-	},
-	"dependencies": {
-		"@pierre/trees": "1.0.0-beta.4",
-		"@shikijs/core": "4.2.0",
-		"@shikijs/engine-javascript": "4.2.0",
-		"@shikijs/langs": "4.2.0",
-		"@shikijs/themes": "4.2.0",
-		"chokidar": "^5.0.0",
-		"gray-matter": "^4.0.3",
-		"markdown-it": "^14.2.0",
-		"picomatch": "^4.0.4",
-		"sanitize-html": "2.17.6"
-	},
-	"devDependencies": {
-		"@playwright/test": "^1.60.0",
-		"@types/markdown-it": "^14.1.2",
-		"@types/picomatch": "^4.0.3",
-		"@types/sanitize-html": "2.16.1",
-		"bun-types": "^1.3.14",
-		"markdownlint": "^0.40.0",
-		"typescript": "7.0.2"
-	}
+  "name": "@limcpf/everything-is-a-markdown",
+  "version": "0.8.0",
+  "license": "MIT",
+  "private": false,
+  "type": "module",
+  "bin": {
+    "eiam": "src/cli.ts"
+  },
+  "files": [
+    "src",
+    "README.md",
+    "bun.lock",
+    "tsconfig.json"
+  ],
+  "publishConfig": {
+    "access": "public"
+  },
+  "scripts": {
+    "blog": "bun run src/cli.ts",
+    "build": "bun run src/cli.ts build",
+    "dev": "bun run src/cli.ts dev",
+    "clean": "bun run src/cli.ts clean",
+    "check:size": "bun run scripts/check-output-size.ts --out ./dist",
+    "check:reproducible": "bun run scripts/check-build-reproducibility.ts --vault ./test-vault --out ./dist",
+    "format": "prettier --write src scripts tests package.json tsconfig.json playwright.config.ts eslint.config.js .github/workflows",
+    "format:check": "prettier --check src scripts tests package.json tsconfig.json playwright.config.ts eslint.config.js .github/workflows",
+    "lint:source": "eslint src scripts --max-warnings=0",
+    "lint:md:publish": "bun run scripts/lint-published-markdown.ts --out-dir dist",
+    "typecheck": "tsc --noEmit",
+    "test:unit": "bun test tests/unit",
+    "test:unit:coverage": "bun test --coverage tests/unit",
+    "test:e2e": "playwright test",
+    "test:e2e:focus-trap": "playwright test tests/e2e/mobile-sidebar-focus-trap.spec.ts"
+  },
+  "dependencies": {
+    "@pierre/trees": "1.0.0-beta.4",
+    "@shikijs/core": "4.2.0",
+    "@shikijs/engine-javascript": "4.2.0",
+    "@shikijs/langs": "4.2.0",
+    "@shikijs/themes": "4.2.0",
+    "chokidar": "^5.0.0",
+    "gray-matter": "^4.0.3",
+    "markdown-it": "^14.2.0",
+    "picomatch": "^4.0.4",
+    "sanitize-html": "2.17.6"
+  },
+  "devDependencies": {
+    "@eslint/js": "10.0.1",
+    "@playwright/test": "^1.60.0",
+    "@types/markdown-it": "^14.1.2",
+    "@types/picomatch": "^4.0.3",
+    "@types/sanitize-html": "2.16.1",
+    "bun-types": "^1.3.14",
+    "eslint": "10.7.0",
+    "globals": "17.7.0",
+    "markdownlint": "^0.40.0",
+    "prettier": "3.9.5",
+    "typescript": "6.0.3",
+    "typescript-eslint": "8.64.0"
+  }
 }

--- a/scripts/check-build-reproducibility.ts
+++ b/scripts/check-build-reproducibility.ts
@@ -16,10 +16,14 @@ function readOption(argv: string[], name: string, fallback: string): string {
 }
 
 function runBuild(vaultDir: string, outDir: string): void {
-  const result = spawnSync("bun", ["run", "src/cli.ts", "build", "--vault", vaultDir, "--out", outDir], {
-    cwd: process.cwd(),
-    encoding: "utf8",
-  });
+  const result = spawnSync(
+    "bun",
+    ["run", "src/cli.ts", "build", "--vault", vaultDir, "--out", outDir],
+    {
+      cwd: process.cwd(),
+      encoding: "utf8",
+    },
+  );
   if (result.status !== 0) {
     process.stderr.write(result.stdout ?? "");
     process.stderr.write(result.stderr ?? "");
@@ -30,16 +34,19 @@ function runBuild(vaultDir: string, outDir: string): void {
 function snapshotFiles(rootDir: string): Map<string, string> {
   const hashes = new Map<string, string>();
   const walk = (directory: string) => {
-    const entries = fs.readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
-      left.name.localeCompare(right.name, "en"),
-    );
+    const entries = fs
+      .readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name, "en"));
     for (const entry of entries) {
       const absolutePath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
         walk(absolutePath);
       } else if (entry.isFile()) {
         const relativePath = path.relative(rootDir, absolutePath).split(path.sep).join("/");
-        const hash = crypto.createHash("sha256").update(fs.readFileSync(absolutePath)).digest("hex");
+        const hash = crypto
+          .createHash("sha256")
+          .update(fs.readFileSync(absolutePath))
+          .digest("hex");
         hashes.set(relativePath, hash);
       }
     }

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -51,16 +51,25 @@ function parseOutDir(argv: string[]): string {
   return path.resolve(value);
 }
 
-function findRuntimeAsset(assetsDir: string, stem: "app" | "tree", extension: "js" | "css"): string {
+function findRuntimeAsset(
+  assetsDir: string,
+  stem: "app" | "tree",
+  extension: "js" | "css",
+): string {
   const pattern = new RegExp(`^${stem}\\.([a-f0-9]{12})\\.${extension}$`);
   const matches = fs.readdirSync(assetsDir).filter((entry) => pattern.test(entry));
   if (matches.length !== 1) {
-    throw new Error(`[size] Expected exactly one ${stem}.*.${extension} asset, found ${matches.length}`);
+    throw new Error(
+      `[size] Expected exactly one ${stem}.*.${extension} asset, found ${matches.length}`,
+    );
   }
   return path.join(assetsDir, matches[0]);
 }
 
-function inspectAsset(assetPath: string, kind: AssetKind): { failures: string[]; gzipBytes: number; rawBytes: number } {
+function inspectAsset(
+  assetPath: string,
+  kind: AssetKind,
+): { failures: string[]; gzipBytes: number; rawBytes: number } {
   const bytes = fs.readFileSync(assetPath);
   const rawBytes = bytes.byteLength;
   const gzipBytes = gzipSync(bytes, { level: 9 }).byteLength;
@@ -159,7 +168,9 @@ function checkManifest(manifestPath: string): string[] {
     return ["manifest.json tree must be an array"];
   }
 
-  const docIds = parsed.docIds.filter((id): id is string => typeof id === "string" && id.length > 0);
+  const docIds = parsed.docIds.filter(
+    (id): id is string => typeof id === "string" && id.length > 0,
+  );
   const uniqueDocIds = new Set(docIds);
   const docsByIdKeys = Object.keys(parsed.docsById);
   if (docIds.length !== parsed.docIds.length || uniqueDocIds.size !== docIds.length) {
@@ -188,10 +199,14 @@ function checkManifest(manifestPath: string): string[] {
       }
       const keys = Object.keys(node).sort();
       if (keys.join(",") !== "id,name,type") {
-        failures.push(`manifest file node ${String(node.id ?? "<unknown>")} duplicates document metadata`);
+        failures.push(
+          `manifest file node ${String(node.id ?? "<unknown>")} duplicates document metadata`,
+        );
       }
       if (typeof node.id !== "string" || !Object.hasOwn(parsed.docsById, node.id)) {
-        failures.push(`manifest file node ${String(node.id ?? "<unknown>")} has a dangling document reference`);
+        failures.push(
+          `manifest file node ${String(node.id ?? "<unknown>")} has a dangling document reference`,
+        );
       }
     }
   };
@@ -211,10 +226,14 @@ function checkManifest(manifestPath: string): string[] {
 
   if (legacyRaw.byteLength >= MANIFEST_RATIO_MIN_LEGACY_BYTES) {
     if (rawRatio > 0.75) {
-      failures.push(`manifest raw ratio ${(rawRatio * 100).toFixed(1)}% exceeds 75% of the legacy projection`);
+      failures.push(
+        `manifest raw ratio ${(rawRatio * 100).toFixed(1)}% exceeds 75% of the legacy projection`,
+      );
     }
     if (gzipRatio > 0.95) {
-      failures.push(`manifest gzip ratio ${(gzipRatio * 100).toFixed(1)}% exceeds 95% of the legacy projection`);
+      failures.push(
+        `manifest gzip ratio ${(gzipRatio * 100).toFixed(1)}% exceeds 95% of the legacy projection`,
+      );
     }
   } else {
     console.log(
@@ -229,7 +248,9 @@ function checkManifest(manifestPath: string): string[] {
 }
 
 function findRouteHtmlFiles(outDir: string): string[] {
-  const manifest = JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as unknown;
+  const manifest = JSON.parse(
+    fs.readFileSync(path.join(outDir, "manifest.json"), "utf8"),
+  ) as unknown;
   if (!isRecord(manifest) || !isRecord(manifest.routeMap)) {
     return [];
   }
@@ -259,7 +280,9 @@ function checkRouteHtml(outDir: string, treeAssetFileName: string): string[] {
     }
 
     const matches = Array.from(
-      html.matchAll(/<script id="initial-runtime-data" type="application\/json">([^<]*)<\/script>/g),
+      html.matchAll(
+        /<script id="initial-runtime-data" type="application\/json">([^<]*)<\/script>/g,
+      ),
     );
     if (matches.length !== 1) {
       failures.push(`${relativePath} must contain exactly one initial runtime bootstrap`);
@@ -290,7 +313,8 @@ function checkRouteHtml(outDir: string, treeAssetFileName: string): string[] {
       );
       continue;
     }
-    const pathBase = typeof payload.pathBase === "string" ? payload.pathBase.replace(/\/+$/, "") : "";
+    const pathBase =
+      typeof payload.pathBase === "string" ? payload.pathBase.replace(/\/+$/, "") : "";
     const rawManifestUrl = pathBase ? `${pathBase}/manifest.json` : "/manifest.json";
     const expectedManifestUrl = rawManifestUrl
       .split("/")
@@ -314,7 +338,9 @@ function checkRouteHtml(outDir: string, treeAssetFileName: string): string[] {
   if (routeHtmlFiles.length === 0) {
     failures.push("generated output must contain at least one route index.html");
   }
-  console.log(`[size] route-html files=${routeHtmlFiles.length} bootstrap-max=${maxBootstrapBytes}/256`);
+  console.log(
+    `[size] route-html files=${routeHtmlFiles.length} bootstrap-max=${maxBootstrapBytes}/256`,
+  );
   return failures;
 }
 

--- a/scripts/lint-published-markdown.ts
+++ b/scripts/lint-published-markdown.ts
@@ -129,7 +129,10 @@ async function walkMarkdownFiles(
   }
 }
 
-async function collectPublishedDocs(vaultDir: string, excludePatterns: string[]): Promise<TargetScanResult> {
+async function collectPublishedDocs(
+  vaultDir: string,
+  excludePatterns: string[],
+): Promise<TargetScanResult> {
   const files: string[] = [];
   const issues: LintIssue[] = [];
   const skippedWithoutPrefix: string[] = [];
@@ -160,7 +163,8 @@ async function collectPublishedDocs(vaultDir: string, excludePatterns: string[])
     if (parsed.data.publish !== true || parsed.data.draft === true) {
       continue;
     }
-    const hasPrefix = typeof parsed.data.prefix === "string" && parsed.data.prefix.trim().length > 0;
+    const hasPrefix =
+      typeof parsed.data.prefix === "string" && parsed.data.prefix.trim().length > 0;
     if (!hasPrefix) {
       skippedWithoutPrefix.push(relPath);
       continue;
@@ -240,7 +244,9 @@ function collectBodyH1Issues(doc: TargetDoc): LintIssue[] {
   return issues;
 }
 
-function mapMarkdownlintIssues(results: Record<string, Array<Record<string, unknown>>>): LintIssue[] {
+function mapMarkdownlintIssues(
+  results: Record<string, Array<Record<string, unknown>>>,
+): LintIssue[] {
   const issues: LintIssue[] = [];
   for (const [file, fileIssues] of Object.entries(results)) {
     for (const issue of fileIssues) {
@@ -249,8 +255,14 @@ function mapMarkdownlintIssues(results: Record<string, Array<Record<string, unkn
       const line = typeof issue.lineNumber === "number" ? issue.lineNumber : 1;
       const errorRange = Array.isArray(issue.errorRange) ? issue.errorRange : [];
       const column = typeof errorRange[0] === "number" ? errorRange[0] : 1;
-      const description = typeof issue.ruleDescription === "string" ? issue.ruleDescription : "Markdown lint violation";
-      const detail = typeof issue.errorDetail === "string" && issue.errorDetail.length > 0 ? `: ${issue.errorDetail}` : "";
+      const description =
+        typeof issue.ruleDescription === "string"
+          ? issue.ruleDescription
+          : "Markdown lint violation";
+      const detail =
+        typeof issue.errorDetail === "string" && issue.errorDetail.length > 0
+          ? `: ${issue.errorDetail}`
+          : "";
 
       issues.push({
         file,
@@ -285,7 +297,7 @@ async function main(): Promise<void> {
     return;
   }
   if (!cli.outDir || cli.outDir.trim().length === 0) {
-    throw new Error('Missing required option: --out-dir <path>');
+    throw new Error("Missing required option: --out-dir <path>");
   }
 
   const userConfig = await loadUserConfig();
@@ -328,9 +340,13 @@ async function main(): Promise<void> {
   };
   await Bun.write(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 
-  console.log(`[lint:md:publish] targets=${scanResult.docs.length} issues=${allIssues.length} out=${reportPath}`);
+  console.log(
+    `[lint:md:publish] targets=${scanResult.docs.length} issues=${allIssues.length} out=${reportPath}`,
+  );
   if (scanResult.skippedWithoutPrefix.length > 0) {
-    console.warn(`[lint:md:publish] skipped without prefix: ${scanResult.skippedWithoutPrefix.length}`);
+    console.warn(
+      `[lint:md:publish] skipped without prefix: ${scanResult.skippedWithoutPrefix.length}`,
+    );
   }
 
   if (cli.strict && allIssues.length > 0) {

--- a/src/build/content.ts
+++ b/src/build/content.ts
@@ -35,7 +35,8 @@ export async function renderDocuments(
     const previous = previousDocs[doc.id];
     const contentRelPath = `content/${toContentFileName(doc.id)}`;
     const outputPath = path.join(options.outDir, "content", toContentFileName(doc.id));
-    const unchanged = previous?.hash === sourceHash && outputContext.previousHashes[contentRelPath] === sourceHash;
+    const unchanged =
+      previous?.hash === sourceHash && outputContext.previousHashes[contentRelPath] === sourceHash;
 
     nextDocs[doc.id] = { hash: sourceHash, route: doc.route, relPath: doc.relPath };
     outputContext.nextHashes[contentRelPath] = sourceHash;

--- a/src/build/graph.ts
+++ b/src/build/graph.ts
@@ -1,4 +1,3 @@
-import path from "node:path";
 import type { BuildOptions, DocRecord, FileNode, FolderNode, Manifest, TreeNode } from "../types";
 import { filterViewDocsByBranch, pickViewHomeRoute } from "../view-contract";
 import type { DocumentGraphResult, WikiLookup } from "./contracts";

--- a/src/build/output.ts
+++ b/src/build/output.ts
@@ -2,7 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { BuildOptions, DocRecord, Manifest } from "../types";
-import { buildCanonicalUrl, escapeHtmlAttribute } from "../seo";
+import { buildCanonicalUrl } from "../seo";
 import { render404Html, renderAppShellHtml } from "../template";
 import type { AppShellAssets, AppShellInitialView, AppShellMeta } from "../template";
 import { ensureDir, makeHash, removeEmptyParents, removeFileIfExists, toPosixPath } from "../utils";
@@ -20,9 +20,11 @@ import { OUTPUT_MARKER_FILE_NAME, resolveSiteTitle } from "./shared";
 const DEFAULT_SITE_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 const DEFAULT_SITE_TITLE = "File-System Blog";
 
-function pickSeoImageDefaults(
-  seo: BuildOptions["seo"],
-): { social: string | null; og: string | null; twitter: string | null } {
+function pickSeoImageDefaults(seo: BuildOptions["seo"]): {
+  social: string | null;
+  og: string | null;
+  twitter: string | null;
+} {
   if (!seo) {
     return { social: null, og: null, twitter: null };
   }
@@ -53,7 +55,11 @@ function pickSeoImageDefaults(
   };
 }
 
-function buildStructuredData(route: string, doc: DocRecord | null, options: BuildOptions): unknown[] {
+function buildStructuredData(
+  route: string,
+  doc: DocRecord | null,
+  options: BuildOptions,
+): unknown[] {
   const canonicalUrl = options.seo ? buildCanonicalUrl(route, options.seo) : undefined;
   const siteName = options.seo?.siteName ?? options.seo?.defaultTitle ?? DEFAULT_SITE_TITLE;
 
@@ -132,12 +138,19 @@ async function copyOutputFileIfChanged(
 function assertSafeStaticOutputPath(relOutputPath: string): void {
   const normalized = path.posix.normalize(toPosixPath(relOutputPath));
   if (normalized === ".") {
-    throw new Error(`[safety] Refusing static path that resolves to the vault root: ${relOutputPath}`);
+    throw new Error(
+      `[safety] Refusing static path that resolves to the vault root: ${relOutputPath}`,
+    );
   }
   if (normalized === ".." || normalized.startsWith("../") || path.posix.isAbsolute(normalized)) {
-    throw new Error(`[safety] Refusing static output path outside the output directory: ${relOutputPath}`);
+    throw new Error(
+      `[safety] Refusing static output path outside the output directory: ${relOutputPath}`,
+    );
   }
-  if (normalized === OUTPUT_MARKER_FILE_NAME || normalized.startsWith(`${OUTPUT_MARKER_FILE_NAME}/`)) {
+  if (
+    normalized === OUTPUT_MARKER_FILE_NAME ||
+    normalized.startsWith(`${OUTPUT_MARKER_FILE_NAME}/`)
+  ) {
     throw new Error(`[safety] Refusing reserved static output path: ${relOutputPath}`);
   }
 }
@@ -221,7 +234,10 @@ function toRelativeAssetPath(fromOutputPath: string, assetOutputPath: string): s
   return relative.length > 0 ? relative : path.posix.basename(assetOutputPath);
 }
 
-function buildAppShellAssetsForOutput(outputPath: string, runtimeAssets: RuntimeAssets): AppShellAssets {
+function buildAppShellAssetsForOutput(
+  outputPath: string,
+  runtimeAssets: RuntimeAssets,
+): AppShellAssets {
   return {
     cssHref: toRelativeAssetPath(outputPath, runtimeAssets.cssRelPath),
     jsSrc: toRelativeAssetPath(outputPath, runtimeAssets.jsRelPath),
@@ -267,11 +283,15 @@ async function bundleRuntimeJs(
   });
 
   if (!result.success) {
-    const details = result.logs.map((log) => String(log)).filter(Boolean).join("\n");
+    const details = result.logs
+      .map((log) => String(log))
+      .filter(Boolean)
+      .join("\n");
     throw new Error(`Failed to bundle runtime ${options.label}${details ? `:\n${details}` : ""}`);
   }
 
-  const output = result.outputs.find((artifact) => artifact.path.endsWith(".js")) ?? result.outputs[0];
+  const output =
+    result.outputs.find((artifact) => artifact.path.endsWith(".js")) ?? result.outputs[0];
   if (!output) {
     throw new Error(`Failed to bundle runtime ${options.label}: no JavaScript output was produced`);
   }
@@ -296,11 +316,15 @@ async function bundleRuntimeCss(entrypoint: string): Promise<string> {
   });
 
   if (!result.success) {
-    const details = result.logs.map((log) => String(log)).filter(Boolean).join("\n");
+    const details = result.logs
+      .map((log) => String(log))
+      .filter(Boolean)
+      .join("\n");
     throw new Error(`Failed to bundle runtime app.css${details ? `:\n${details}` : ""}`);
   }
 
-  const output = result.outputs.find((artifact) => artifact.path.endsWith(".css")) ?? result.outputs[0];
+  const output =
+    result.outputs.find((artifact) => artifact.path.endsWith(".css")) ?? result.outputs[0];
   if (!output) {
     throw new Error("Failed to bundle runtime app.css: no CSS output was produced");
   }
@@ -354,7 +378,10 @@ function buildShellMeta(route: string, doc: DocRecord | null, options: BuildOpti
   const defaultTitle = options.seo?.defaultTitle ?? options.siteTitle ?? DEFAULT_SITE_TITLE;
   const siteTitle = resolveSiteTitle(options);
   const defaultDescription = options.seo?.defaultDescription ?? DEFAULT_SITE_DESCRIPTION;
-  const description = typeof doc?.description === "string" && doc.description.trim().length > 0 ? doc.description.trim() : undefined;
+  const description =
+    typeof doc?.description === "string" && doc.description.trim().length > 0
+      ? doc.description.trim()
+      : undefined;
   const canonicalUrl = options.seo ? buildCanonicalUrl(route, options.seo) : undefined;
   const baseTitle = doc?.title ?? defaultTitle;
   const title = composeViewDocumentTitle(baseTitle, siteTitle);
@@ -392,7 +419,8 @@ function buildInitialView(
   defaultBranch: string,
 ): AppShellInitialView {
   const manifestDoc = manifestDocById.get(doc.id);
-  const activeBranch = normalizeViewBranch(doc.branch) ?? normalizeViewBranch(defaultBranch) ?? "dev";
+  const activeBranch =
+    normalizeViewBranch(doc.branch) ?? normalizeViewBranch(defaultBranch) ?? "dev";
   const visibleDocs = filterViewDocsByBranch(docs, activeBranch, defaultBranch);
   const chrome = renderViewChrome({
     route: doc.route,
@@ -498,11 +526,17 @@ function buildSitemapXml(urls: string[]): string {
   ].join("\n");
 }
 
-async function writeSeoArtifacts(context: OutputWriteContext, docs: DocRecord[], options: BuildOptions): Promise<void> {
+async function writeSeoArtifacts(
+  context: OutputWriteContext,
+  docs: DocRecord[],
+  options: BuildOptions,
+): Promise<void> {
   if (!options.seo) {
     await removeFileIfExists(path.join(context.outDir, "robots.txt"));
     await removeFileIfExists(path.join(context.outDir, "sitemap.xml"));
-    console.warn('[seo] Skipping robots.txt and sitemap.xml generation. Add "seo.siteUrl" to blog.config.* to enable SEO artifacts.');
+    console.warn(
+      '[seo] Skipping robots.txt and sitemap.xml generation. Add "seo.siteUrl" to blog.config.* to enable SEO artifacts.',
+    );
     return;
   }
 
@@ -547,8 +581,19 @@ export async function emitOutputPhase(
   options: BuildOptions,
   contentByDocId: Map<string, string>,
 ): Promise<void> {
-  await writeOutputIfChanged(output.context, "manifest.json", `${JSON.stringify(manifest, null, 2)}\n`);
-  await writeShellPages(output.context, docs, manifest, options, output.runtimeAssets, contentByDocId);
+  await writeOutputIfChanged(
+    output.context,
+    "manifest.json",
+    `${JSON.stringify(manifest, null, 2)}\n`,
+  );
+  await writeShellPages(
+    output.context,
+    docs,
+    manifest,
+    options,
+    output.runtimeAssets,
+    contentByDocId,
+  );
   await writeSeoArtifacts(output.context, docs, options);
   await removeStaleOutputs(output.context);
 }

--- a/src/build/shared.ts
+++ b/src/build/shared.ts
@@ -10,7 +10,8 @@ export function toContentFileName(id: string): string {
 }
 
 export function resolveSiteTitle(options: BuildOptions): string {
-  const value = options.siteTitle ?? options.seo?.siteName ?? options.seo?.defaultTitle ?? DEFAULT_SITE_TITLE;
+  const value =
+    options.siteTitle ?? options.seo?.siteName ?? options.seo?.defaultTitle ?? DEFAULT_SITE_TITLE;
   const trimmed = value.trim();
   return trimmed.length > 0 ? trimmed : DEFAULT_SITE_TITLE;
 }

--- a/src/build/source.ts
+++ b/src/build/source.ts
@@ -186,7 +186,10 @@ function pickDocPrefix(frontmatter: Record<string, unknown>, raw: string): strin
   return undefined;
 }
 
-function pickDocCategoryPath(frontmatter: Record<string, unknown>, raw: string): string | undefined {
+function pickDocCategoryPath(
+  frontmatter: Record<string, unknown>,
+  raw: string,
+): string | undefined {
   const literal = normalizeCategoryPath(extractFrontmatterScalar(raw, "category_path"));
   if (literal) {
     return literal;
@@ -239,7 +242,9 @@ function ensureUniqueRoutes(docs: DocRecord[]): void {
   }
 
   const used = new Set<string>();
-  const sorted = [...docs].sort((left, right) => left.relNoExt.localeCompare(right.relNoExt, "ko-KR"));
+  const sorted = [...docs].sort((left, right) =>
+    left.relNoExt.localeCompare(right.relNoExt, "ko-KR"),
+  );
 
   for (const doc of sorted) {
     const baseRoute = doc.route;
@@ -318,12 +323,18 @@ function toCachedSourceEntry(
     rawHash,
     publish: parsed.data.publish === true,
     draft: parsed.data.draft === true,
-    title: typeof parsed.data.title === "string" && parsed.data.title.trim().length > 0 ? parsed.data.title.trim() : undefined,
+    title:
+      typeof parsed.data.title === "string" && parsed.data.title.trim().length > 0
+        ? parsed.data.title.trim()
+        : undefined,
     prefix: pickDocPrefix(parsed.data as Record<string, unknown>, raw),
     categoryPath: pickDocCategoryPath(parsed.data as Record<string, unknown>, raw),
     date: pickDocDate(parsed.data as Record<string, unknown>, raw),
     updatedDate: pickDocUpdatedDate(parsed.data as Record<string, unknown>, raw),
-    description: typeof parsed.data.description === "string" ? parsed.data.description.trim() || undefined : undefined,
+    description:
+      typeof parsed.data.description === "string"
+        ? parsed.data.description.trim() || undefined
+        : undefined,
     tags: parseStringArray(parsed.data.tags),
     branch: parseBranch(parsed.data.branch),
     body: parsed.content,
@@ -331,11 +342,7 @@ function toCachedSourceEntry(
   };
 }
 
-function toDocRecord(
-  sourcePath: string,
-  relPath: string,
-  entry: CachedSourceEntry,
-): DocRecord {
+function toDocRecord(sourcePath: string, relPath: string, entry: CachedSourceEntry): DocRecord {
   const relNoExt = stripMdExt(relPath);
   const fileName = path.basename(relPath);
   const id = toDocId(relNoExt);
@@ -363,7 +370,10 @@ function toDocRecord(
   };
 }
 
-export async function readPublishedDocs(options: BuildOptions, previousSources: BuildCache["sources"]): Promise<ReadDocsResult> {
+export async function readPublishedDocs(
+  options: BuildOptions,
+  previousSources: BuildCache["sources"],
+): Promise<ReadDocsResult> {
   const isExcluded = buildExcluder(options.exclude);
   const mdFiles = await walkMarkdownFiles(options.vaultDir, options.vaultDir, isExcluded);
   const fileEntries = await Promise.all(
@@ -390,7 +400,9 @@ export async function readPublishedDocs(options: BuildOptions, previousSources: 
       try {
         parsed = matter(raw);
       } catch (error) {
-        throw new Error(`Frontmatter parse failed: ${relPath}\n${(error as Error).message}`);
+        throw new Error(`Frontmatter parse failed: ${relPath}\n${(error as Error).message}`, {
+          cause: error,
+        });
       }
 
       entry = toCachedSourceEntry(raw, rawHash, parsed);
@@ -562,7 +574,8 @@ export function buildBacklinksByDocId(
         continue;
       }
 
-      const bucket = buckets.get(targetDoc.id) ?? new Map<string, ManifestDoc["backlinks"][number]>();
+      const bucket =
+        buckets.get(targetDoc.id) ?? new Map<string, ManifestDoc["backlinks"][number]>();
       bucket.set(doc.id, {
         id: doc.id,
         route: doc.route,

--- a/src/build/storage.ts
+++ b/src/build/storage.ts
@@ -128,7 +128,11 @@ async function resolveCacheLocation(options: BuildOptions): Promise<CacheLocatio
   return location;
 }
 
-async function assertSafeOutputRoot(outDir: string, vaultDir: string, cacheRoot: string): Promise<string> {
+async function assertSafeOutputRoot(
+  outDir: string,
+  vaultDir: string,
+  cacheRoot: string,
+): Promise<string> {
   const outputRoot = await toCanonicalPath(outDir);
   const filesystemRoot = path.parse(outputRoot).root;
   const cwd = await toCanonicalPath(process.cwd());
@@ -176,7 +180,10 @@ async function writeOutputMarker(outputRoot: string, cacheNamespace: string): Pr
     version: OUTPUT_MARKER_VERSION,
     cacheNamespace,
   };
-  await Bun.write(path.join(outputRoot, OUTPUT_MARKER_FILE_NAME), `${JSON.stringify(marker, null, 2)}\n`);
+  await Bun.write(
+    path.join(outputRoot, OUTPUT_MARKER_FILE_NAME),
+    `${JSON.stringify(marker, null, 2)}\n`,
+  );
 }
 
 async function prepareOwnedOutputDirectory(
@@ -273,7 +280,8 @@ function isRecord(value: unknown): value is Record<string, unknown> {
 function hasExactRecordKeys(value: Record<string, unknown>, expectedKeys: string[]): boolean {
   const actualKeys = Object.keys(value).sort();
   return (
-    actualKeys.length === expectedKeys.length && actualKeys.every((key, index) => key === expectedKeys[index])
+    actualKeys.length === expectedKeys.length &&
+    actualKeys.every((key, index) => key === expectedKeys[index])
   );
 }
 
@@ -344,19 +352,31 @@ function normalizeCachedSourceEntry(value: unknown): CachedSourceEntry | null {
     return null;
   }
 
-  const mtimeMs = typeof value.mtimeMs === "number" && Number.isFinite(value.mtimeMs) ? value.mtimeMs : null;
+  const mtimeMs =
+    typeof value.mtimeMs === "number" && Number.isFinite(value.mtimeMs) ? value.mtimeMs : null;
   const size = typeof value.size === "number" && Number.isFinite(value.size) ? value.size : null;
   const rawHash = typeof value.rawHash === "string" ? value.rawHash : "";
   const publish = value.publish === true;
   const draft = value.draft === true;
-  const title = typeof value.title === "string" && value.title.trim().length > 0 ? value.title.trim() : undefined;
-  const prefix = typeof value.prefix === "string" && value.prefix.trim().length > 0 ? value.prefix.trim() : undefined;
+  const title =
+    typeof value.title === "string" && value.title.trim().length > 0
+      ? value.title.trim()
+      : undefined;
+  const prefix =
+    typeof value.prefix === "string" && value.prefix.trim().length > 0
+      ? value.prefix.trim()
+      : undefined;
   const categoryPath = normalizeCategoryPath(value.categoryPath);
-  const date = typeof value.date === "string" && value.date.trim().length > 0 ? value.date.trim() : undefined;
+  const date =
+    typeof value.date === "string" && value.date.trim().length > 0 ? value.date.trim() : undefined;
   const updatedDate =
-    typeof value.updatedDate === "string" && value.updatedDate.trim().length > 0 ? value.updatedDate.trim() : undefined;
+    typeof value.updatedDate === "string" && value.updatedDate.trim().length > 0
+      ? value.updatedDate.trim()
+      : undefined;
   const description =
-    typeof value.description === "string" && value.description.trim().length > 0 ? value.description.trim() : undefined;
+    typeof value.description === "string" && value.description.trim().length > 0
+      ? value.description.trim()
+      : undefined;
   const tags = parseStringArray(value.tags);
   const branch = parseBranch(value.branch);
   const body = typeof value.body === "string" ? value.body : null;
@@ -432,7 +452,11 @@ async function writeCache(location: CacheLocation, cache: BuildCache): Promise<v
   await Bun.write(location.cachePath, `${JSON.stringify(cache, null, 2)}\n`);
 }
 
-async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, currentDocs: DocRecord[]): Promise<void> {
+async function cleanRemovedOutputs(
+  outDir: string,
+  oldCache: BuildCache,
+  currentDocs: DocRecord[],
+): Promise<void> {
   const currentIds = new Set(currentDocs.map((doc) => doc.id));
   const currentRouteById = new Map(currentDocs.map((doc) => [doc.id, doc.route]));
 
@@ -440,7 +464,10 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
     if (currentIds.has(id)) {
       const currentRoute = currentRouteById.get(id);
       if (currentRoute && currentRoute !== entry.route) {
-        const previousRouteDir = path.join(outDir, entry.route.replace(/^\//, "").replace(/\/$/, ""));
+        const previousRouteDir = path.join(
+          outDir,
+          entry.route.replace(/^\//, "").replace(/\/$/, ""),
+        );
         const previousRouteIndex = path.join(previousRouteDir, "index.html");
         await removeFileIfExists(previousRouteIndex);
         await removeEmptyParents(previousRouteDir, outDir);
@@ -463,7 +490,11 @@ async function cleanRemovedOutputs(outDir: string, oldCache: BuildCache, current
 export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> {
   const cacheLocation = await resolveCacheLocation(options);
   const requestedOutputRoot = path.resolve(options.outDir);
-  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
+  const outputRoot = await assertSafeOutputRoot(
+    options.outDir,
+    options.vaultDir,
+    cacheLocation.rootDir,
+  );
   await removeLegacyCacheIndex();
   let hasOwnedOutput = false;
 
@@ -492,7 +523,11 @@ export async function cleanBuildArtifacts(options: BuildOptions): Promise<void> 
 
 export async function inspectBuildStorage(options: BuildOptions): Promise<BuildStorageState> {
   const cacheLocation = await resolveCacheLocation(options);
-  const outputRoot = await assertSafeOutputRoot(options.outDir, options.vaultDir, cacheLocation.rootDir);
+  const outputRoot = await assertSafeOutputRoot(
+    options.outDir,
+    options.vaultDir,
+    cacheLocation.rootDir,
+  );
   await removeLegacyCacheIndex();
   await assertClaimableOutputDirectory(options, cacheLocation, outputRoot);
 

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,6 +1,12 @@
 #!/usr/bin/env bun
 import { buildSite, cleanBuildArtifacts } from "./build";
-import { parseCliArgs, loadPinnedMenuConfig, loadUserConfig, printHelp, resolveBuildOptions } from "./config";
+import {
+  parseCliArgs,
+  loadPinnedMenuConfig,
+  loadUserConfig,
+  printHelp,
+  resolveBuildOptions,
+} from "./config";
 import { runDev } from "./dev";
 
 async function main(): Promise<void> {
@@ -27,7 +33,9 @@ async function main(): Promise<void> {
   }
 
   const result = await buildSite(buildOptions);
-  console.log(`[build] total=${result.totalDocs} rendered=${result.renderedDocs} skipped=${result.skippedDocs}`);
+  console.log(
+    `[build] total=${result.totalDocs} rendered=${result.renderedDocs} skipped=${result.skippedDocs}`,
+  );
 }
 
 main().catch((error) => {

--- a/src/config.ts
+++ b/src/config.ts
@@ -52,7 +52,9 @@ function normalizeMermaidCdnUrl(value: unknown): string {
   }
 
   if (normalized.length > MERMAID_URL_MAX_LENGTH || !MERMAID_CDN_URL_PATTERN.test(normalized)) {
-    console.warn(`[config] invalid mermaid.cdnUrl: ${JSON.stringify(value)}. fallback to default ${JSON.stringify(DEFAULTS.mermaid.cdnUrl)}.`);
+    console.warn(
+      `[config] invalid mermaid.cdnUrl: ${JSON.stringify(value)}. fallback to default ${JSON.stringify(DEFAULTS.mermaid.cdnUrl)}.`,
+    );
     return DEFAULTS.mermaid.cdnUrl;
   }
 
@@ -66,7 +68,9 @@ function normalizeMermaidTheme(value: unknown): string {
 
   const normalized = value.trim();
   if (!MERMAID_THEME_PATTERN.test(normalized)) {
-    console.warn(`[config] invalid mermaid.theme: ${JSON.stringify(value)}. fallback to default ${JSON.stringify(DEFAULTS.mermaid.theme)}.`);
+    console.warn(
+      `[config] invalid mermaid.theme: ${JSON.stringify(value)}. fallback to default ${JSON.stringify(DEFAULTS.mermaid.theme)}.`,
+    );
     return DEFAULTS.mermaid.theme;
   }
 
@@ -182,7 +186,10 @@ function normalizePinnedMenu(raw: unknown, errorPrefix = "[config]"): PinnedMenu
   const sourceDirRaw = menu.sourceDir;
   const categoryPathRaw = menu.categoryPath;
   const labelRaw = menu.label;
-  const normalizeMenuPath = (value: unknown, fieldName: "sourceDir" | "categoryPath"): string | undefined => {
+  const normalizeMenuPath = (
+    value: unknown,
+    fieldName: "sourceDir" | "categoryPath",
+  ): string | undefined => {
     if (value == null) {
       return undefined;
     }
@@ -215,9 +222,7 @@ function normalizePinnedMenu(raw: unknown, errorPrefix = "[config]"): PinnedMenu
   }
 
   const label =
-    typeof labelRaw === "string" && labelRaw.trim().length > 0
-      ? labelRaw.trim()
-      : "NOTICE";
+    typeof labelRaw === "string" && labelRaw.trim().length > 0 ? labelRaw.trim() : "NOTICE";
 
   return {
     label,
@@ -283,7 +288,9 @@ export async function loadPinnedMenuConfig(
   try {
     parsed = await file.json();
   } catch (error) {
-    throw new Error(`[menu-config] failed to parse JSON: ${(error as Error).message}`);
+    throw new Error(`[menu-config] failed to parse JSON: ${(error as Error).message}`, {
+      cause: error,
+    });
   }
 
   if (typeof parsed !== "object" || parsed == null) {
@@ -294,7 +301,12 @@ export async function loadPinnedMenuConfig(
 }
 
 function ensureIntegerOption(value: unknown, optionLabel: string, min: number): number {
-  if (typeof value !== "number" || !Number.isFinite(value) || !Number.isInteger(value) || value < min) {
+  if (
+    typeof value !== "number" ||
+    !Number.isFinite(value) ||
+    !Number.isInteger(value) ||
+    value < min
+  ) {
     throw new Error(`[config] "${optionLabel}" must be an integer >= ${min}`);
   }
   return value;

--- a/src/dev.ts
+++ b/src/dev.ts
@@ -57,7 +57,9 @@ export async function runDev(options: BuildOptions, devOptions: DevOptions): Pro
     runningBuild = true;
     try {
       const result = await buildSite(options);
-      console.log(`[build] total=${result.totalDocs} rendered=${result.renderedDocs} skipped=${result.skippedDocs}`);
+      console.log(
+        `[build] total=${result.totalDocs} rendered=${result.renderedDocs} skipped=${result.skippedDocs}`,
+      );
     } catch (error) {
       if (failFast) {
         throw error;
@@ -102,7 +104,9 @@ export async function runDev(options: BuildOptions, devOptions: DevOptions): Pro
     }
 
     const isMarkdownChange = /\.md$/i.test(changedPath);
-    const isStaticChange = options.staticPaths.some((staticPath) => isStaticPathMatch(relPath, staticPath));
+    const isStaticChange = options.staticPaths.some((staticPath) =>
+      isStaticPathMatch(relPath, staticPath),
+    );
     if (!isMarkdownChange && !isStaticChange) {
       return;
     }

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -132,6 +132,11 @@ const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
     },
   },
 };
+
+export function sanitizeMarkdownHtml(html: string, allowUnsafeHtml = false): string {
+  return allowUnsafeHtml ? html : sanitizeHtml(html, SAFE_HTML_OPTIONS);
+}
+
 type RenderRule = NonNullable<MarkdownIt["renderer"]["rules"]["fence"]>;
 type RenderRuleArgs = Parameters<RenderRule>;
 type RuleTokens = RenderRuleArgs[0];
@@ -143,7 +148,7 @@ type ImageRule = NonNullable<MarkdownIt["renderer"]["rules"]["image"]>;
 type ParagraphRule = NonNullable<MarkdownIt["renderer"]["rules"]["paragraph_open"]>;
 
 function escapeMarkdownLabel(input: string): string {
-  return input.replace(/[\[\]]/g, "");
+  return input.replaceAll("[", "").replaceAll("]", "");
 }
 
 function escapeHtmlText(input: string): string {
@@ -231,7 +236,9 @@ function isMissingShikiModule(error: unknown, specifier: string): boolean {
   const moduleSubpath = `./${specifier.slice(specifier.lastIndexOf("/") + 1)}`;
   const isMissingCode = code === "ERR_MODULE_NOT_FOUND" || code === "ERR_PACKAGE_PATH_NOT_EXPORTED";
   const matchesSpecifier =
-    message.includes(specifier) || message.includes(`'${moduleSubpath}'`) || message.includes(`"${moduleSubpath}"`);
+    message.includes(specifier) ||
+    message.includes(`'${moduleSubpath}'`) ||
+    message.includes(`"${moduleSubpath}"`);
   return isMissingCode && matchesSpecifier;
 }
 
@@ -249,7 +256,9 @@ async function loadShikiTheme(theme: string): Promise<typeof githubDarkTheme> {
     return themeModule.default;
   } catch (error) {
     if (isMissingShikiModule(error, specifier)) {
-      throw new Error(`[markdown] Unknown Shiki theme: ${JSON.stringify(theme)}.`);
+      throw new Error(`[markdown] Unknown Shiki theme: ${JSON.stringify(theme)}.`, {
+        cause: error,
+      });
     }
     throw error;
   }
@@ -321,7 +330,11 @@ function isStandaloneImageParagraph(tokens: RuleTokens, idx: number): boolean {
   const inline = tokens[idx + 1];
   const close = tokens[idx + 2];
 
-  if (open?.type !== "paragraph_open" || inline?.type !== "inline" || close?.type !== "paragraph_close") {
+  if (
+    open?.type !== "paragraph_open" ||
+    inline?.type !== "inline" ||
+    close?.type !== "paragraph_close"
+  ) {
     return false;
   }
 
@@ -332,11 +345,7 @@ function isStandaloneImageParagraph(tokens: RuleTokens, idx: number): boolean {
   return children.length === 1 && children[0]?.type === "image";
 }
 
-function createMarkdownIt(
-  highlighter: HighlighterCore,
-  theme: string,
-  gfm: boolean,
-): MarkdownIt {
+function createMarkdownIt(highlighter: HighlighterCore, theme: string, gfm: boolean): MarkdownIt {
   const md = new MarkdownIt({
     // Parse raw HTML so the configured sanitizer can apply one policy to generated and authored markup.
     html: true,
@@ -349,7 +358,13 @@ function createMarkdownIt(
     md.disable(["table", "strikethrough"]);
   }
 
-  const fenceRule: RenderRule = (tokens: RuleTokens, idx: number, _options: RuleOptions, _env: RuleEnv, _self: RuleSelf) => {
+  const fenceRule: RenderRule = (
+    tokens: RuleTokens,
+    idx: number,
+    _options: RuleOptions,
+    _env: RuleEnv,
+    _self: RuleSelf,
+  ) => {
     const token = tokens[idx];
     const info = token.info.trim();
     const parts = info.split(/\s+/);
@@ -490,14 +505,19 @@ export async function createMarkdownRenderer(options: BuildOptions): Promise<Mar
 
   return {
     async render(markdown: string, resolver: WikiResolver): Promise<RenderResult> {
-      const { markdown: preprocessed, warnings } = preprocessMarkdown(markdown, resolver, options.imagePolicy, options.wikilinks);
+      const { markdown: preprocessed, warnings } = preprocessMarkdown(
+        markdown,
+        resolver,
+        options.imagePolicy,
+        options.wikilinks,
+      );
       const languageLoad = languageLoadQueue.then(() =>
         loadFenceLanguages(highlighter, loadedLanguages, unavailableLanguages, preprocessed),
       );
       languageLoadQueue = languageLoad.catch(() => undefined);
       await languageLoad;
       const renderedHtml = md.render(preprocessed);
-      const html = options.allowUnsafeHtml ? renderedHtml : sanitizeHtml(renderedHtml, SAFE_HTML_OPTIONS);
+      const html = sanitizeMarkdownHtml(renderedHtml, options.allowUnsafeHtml);
       return { html, warnings };
     },
   };

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -142,7 +142,9 @@ body {
 body {
   background: var(--latte-base);
   color: var(--latte-text);
-  font-family: "Pretendard Variable", "Pretendard", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic", "Segoe UI", sans-serif;
+  font-family:
+    "Pretendard Variable", "Pretendard", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic",
+    "Segoe UI", sans-serif;
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
 }
@@ -417,7 +419,12 @@ a:hover {
   cursor: pointer;
   white-space: nowrap;
   box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease, color 0.15s ease, transform 0.12s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease,
+    transform 0.12s ease;
 }
 
 .branch-pill:hover {
@@ -436,7 +443,9 @@ a:hover {
   border-color: rgba(136, 57, 239, 0.45);
   background: rgba(136, 57, 239, 0.14);
   color: var(--accent-strong);
-  box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset, 0 2px 6px rgba(136, 57, 239, 0.22);
+  box-shadow:
+    0 1px 0 var(--elevated-inset-shadow) inset,
+    0 2px 6px rgba(136, 57, 239, 0.22);
 }
 
 /* Tree search */
@@ -458,7 +467,10 @@ a:hover {
   border-radius: 8px;
   background: var(--elevated-surface);
   box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
-  transition: border-color 0.15s ease, box-shadow 0.15s ease, background-color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    box-shadow 0.15s ease,
+    background-color 0.15s ease;
 }
 
 .sidebar-search-box:focus-within {
@@ -650,7 +662,11 @@ a:hover {
   --trees-focus-ring-offset-override: 1px;
   --trees-selected-bg-override: var(--active-surface-bg);
   --trees-selected-fg-override: var(--latte-text);
-  --trees-selected-focused-border-color-override: color-mix(in srgb, var(--latte-mauve) 36%, transparent);
+  --trees-selected-focused-border-color-override: color-mix(
+    in srgb,
+    var(--latte-mauve) 36%,
+    transparent
+  );
   --trees-font-family-override: inherit;
   --trees-font-size-override: 0.9rem;
   --trees-font-weight-regular-override: 450;
@@ -712,12 +728,19 @@ a:hover {
 }
 
 @keyframes pulse {
-  0%, 100% { opacity: 1; }
-  50% { opacity: 0.5; }
+  0%,
+  100% {
+    opacity: 1;
+  }
+  50% {
+    opacity: 0.5;
+  }
 }
 
 .status-encoding {
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
@@ -824,7 +847,10 @@ a:hover {
   font-size: 0.78rem;
   font-weight: 600;
   cursor: pointer;
-  transition: border-color 0.15s ease, background-color 0.15s ease, color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    background-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .settings-segment-option input:checked + span {
@@ -905,7 +931,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   align-items: center;
   gap: 4px;
   font-size: 0.85rem;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   color: var(--latte-overlay0);
   margin-bottom: 24px;
   flex-wrap: nowrap;
@@ -971,7 +999,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   gap: 16px;
   min-height: 22px;
   font-size: 0.85rem;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   color: var(--latte-subtext1);
 }
 
@@ -1110,7 +1140,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   border: 1px solid var(--latte-surface0);
   border-radius: 4px;
   padding: 2px 6px;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 0.88em;
   color: var(--latte-mauve);
 }
@@ -1145,13 +1177,21 @@ body.mobile-toggle-left .mobile-menu-toggle {
   border-radius: 50%;
 }
 
-.dot-red { background: var(--latte-red); }
-.dot-yellow { background: var(--latte-yellow); }
-.dot-green { background: var(--latte-green); }
+.dot-red {
+  background: var(--latte-red);
+}
+.dot-yellow {
+  background: var(--latte-yellow);
+}
+.dot-green {
+  background: var(--latte-green);
+}
 
 .code-filename {
   flex: 1;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 0.75rem;
   color: #aeb7c2;
   text-align: center;
@@ -1196,7 +1236,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   display: block;
   padding: 18px 20px;
   overflow-x: auto;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 0.95rem;
   font-weight: 500;
   line-height: 1.72;
@@ -1242,7 +1284,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   box-shadow: none;
   background: transparent !important;
   color: var(--latte-subtext1);
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 0.9rem;
   line-height: 1.6;
   white-space: pre-wrap;
@@ -1302,7 +1346,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   display: block;
   padding: 16px;
   overflow-x: auto;
-  font-family: ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New", monospace;
+  font-family:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
   font-size: 0.875rem;
   line-height: 1.6;
 }
@@ -1470,7 +1516,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   border: 1px solid var(--latte-surface0);
   border-radius: 8px;
   background: var(--active-surface-bg);
-  transition: border-color 0.15s ease, color 0.15s ease;
+  transition:
+    border-color 0.15s ease,
+    color 0.15s ease;
 }
 
 .backlink-link:hover {
@@ -1622,7 +1670,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
     border-bottom: 0;
     box-shadow: var(--sidebar-mobile-shadow);
     transform: translateX(-102%);
-    transition: transform 0.2s ease, visibility 0.2s step-end;
+    transition:
+      transform 0.2s ease,
+      visibility 0.2s step-end;
     visibility: hidden;
     pointer-events: none;
     z-index: 100;
@@ -1632,7 +1682,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
     transform: translateX(0);
     visibility: visible;
     pointer-events: auto;
-    transition: transform 0.2s ease, visibility 0s;
+    transition:
+      transform 0.2s ease,
+      visibility 0s;
   }
 
   .mobile-menu-toggle {

--- a/src/runtime/manifest-adapter.js
+++ b/src/runtime/manifest-adapter.js
@@ -34,7 +34,12 @@ function collectLegacyDocs(docs) {
   /** @type {Record<string, Record<string, unknown> & { id: string }>} */
   const docsById = Object.create(null);
   for (const doc of docs) {
-    if (!isRecord(doc) || typeof doc.id !== "string" || !doc.id || Object.hasOwn(docsById, doc.id)) {
+    if (
+      !isRecord(doc) ||
+      typeof doc.id !== "string" ||
+      !doc.id ||
+      Object.hasOwn(docsById, doc.id)
+    ) {
       return null;
     }
     docIds.push(doc.id);

--- a/src/runtime/mermaid-controller.js
+++ b/src/runtime/mermaid-controller.js
@@ -39,8 +39,7 @@ export function resolveMermaidConfig(manifest) {
         ? mermaid.cdnUrl.trim()
         : MERMAID_CDN,
     theme:
-      typeof mermaid?.theme === "string" &&
-      MERMAID_THEME_VALIDATION_RE.test(mermaid.theme.trim())
+      typeof mermaid?.theme === "string" && MERMAID_THEME_VALIDATION_RE.test(mermaid.theme.trim())
         ? mermaid.theme.trim()
         : MERMAID_DEFAULT_THEME,
   };

--- a/src/runtime/navigation-state.js
+++ b/src/runtime/navigation-state.js
@@ -32,7 +32,10 @@ export {
  * @param {unknown} pathBase
  * @param {unknown} [pathname]
  */
-export function resolveRouteFromLocation(pathBase, pathname = globalThis.location?.pathname ?? "/") {
+export function resolveRouteFromLocation(
+  pathBase,
+  pathname = globalThis.location?.pathname ?? "/",
+) {
   return normalizeRoute(stripPathBase(pathname, pathBase));
 }
 
@@ -139,7 +142,8 @@ export function createNavigationState(manifest, options = {}) {
   const savedBranch = normalizeBranch(options.savedBranch);
   /** @type {Map<string, BranchView>} */
   const branchViewCache = new Map();
-  let activeBranch = savedBranch && availableBranchSet.has(savedBranch) ? savedBranch : defaultBranch;
+  let activeBranch =
+    savedBranch && availableBranchSet.has(savedBranch) ? savedBranch : defaultBranch;
   let currentDocId = typeof options.initialDocId === "string" ? options.initialDocId : "";
 
   /** @param {string} branch */
@@ -194,7 +198,7 @@ export function createNavigationState(manifest, options = {}) {
     return {
       route,
       id: id ?? null,
-      doc: id ? docsById.get(id) ?? null : null,
+      doc: id ? (docsById.get(id) ?? null) : null,
       branchChanged: previousBranch !== activeBranch,
     };
   };

--- a/src/runtime/runtime-bootstrap.js
+++ b/src/runtime/runtime-bootstrap.js
@@ -106,7 +106,8 @@ export function resolveSiteTitle(manifest) {
 export async function loadRuntimeBootstrap(options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
-  const fetchManifest = options.fetchManifest ?? ((/** @type {string} */ url) => globalThis.fetch(url));
+  const fetchManifest =
+    options.fetchManifest ?? ((/** @type {string} */ url) => globalThis.fetch(url));
   const initialViewData = loadInitialViewData(documentRef);
   const initialRuntimeData = loadInitialRuntimeData({ documentRef, windowRef });
   const initialPathBase = normalizePathBase(initialRuntimeData?.pathBase);

--- a/src/runtime/settings-controller.js
+++ b/src/runtime/settings-controller.js
@@ -161,9 +161,8 @@ export function createSettingsController(options = {}) {
         return;
       }
 
-      const savedTogglePosition = storage.getItem(MENU_TOGGLE_POSITION_KEY) === "left"
-        ? "left"
-        : "right";
+      const savedTogglePosition =
+        storage.getItem(MENU_TOGGLE_POSITION_KEY) === "left" ? "left" : "right";
       themeMode = normalizeThemeMode(storage.getItem(THEME_MODE_KEY));
       applyMenuTogglePosition(savedTogglePosition);
       applyTheme();

--- a/src/runtime/sidebar-layout-controller.js
+++ b/src/runtime/sidebar-layout-controller.js
@@ -323,11 +323,7 @@ export function createSidebarLayoutController(options = {}) {
       close();
       return;
     }
-    if (
-      event.key !== "Tab" ||
-      !isCompact() ||
-      !appRoot?.classList?.contains("sidebar-open")
-    ) {
+    if (event.key !== "Tab" || !isCompact() || !appRoot?.classList?.contains("sidebar-open")) {
       return;
     }
 
@@ -339,7 +335,8 @@ export function createSidebarLayoutController(options = {}) {
     const first = focusables[0];
     const last = focusables[focusables.length - 1];
     const activeElement = documentRef.activeElement;
-    const activeInsideSidebar = activeElement instanceof windowRef.Node && sidebar?.contains(activeElement);
+    const activeInsideSidebar =
+      activeElement instanceof windowRef.Node && sidebar?.contains(activeElement);
     if (!activeInsideSidebar) {
       event.preventDefault();
       first.focus();

--- a/src/runtime/tree-adapter.js
+++ b/src/runtime/tree-adapter.js
@@ -1,5 +1,6 @@
 const DIRECTORY_SUFFIX = "/";
 const FILE_EXTENSION = ".md";
+// eslint-disable-next-line no-control-regex -- Tree path segments must strip ASCII controls.
 const CONTROL_CHARS_RE = /[\u0000-\u001f\u007f]/g;
 const PATH_SEPARATOR_RE = /[\\/]+/g;
 const WHITESPACE_RE = /\s+/g;
@@ -190,15 +191,18 @@ export function buildTreesAdapterInput(treeNodes, docs = []) {
       }
 
       const doc = docById.get(node.id);
-      const treePath = registerPath(joinTreePath(parentPath, formatTreesFileBasename(node, doc), false), {
-        branch: node.branch ?? doc?.branch ?? null,
-        docId: node.id,
-        isNew: (doc?.isNew ?? node.isNew) === true,
-        kind: "file",
-        prefix: node.prefix ?? doc?.prefix ?? "",
-        route: node.route ?? doc?.route ?? "",
-        title: node.title ?? doc?.title ?? "",
-      });
+      const treePath = registerPath(
+        joinTreePath(parentPath, formatTreesFileBasename(node, doc), false),
+        {
+          branch: node.branch ?? doc?.branch ?? null,
+          docId: node.id,
+          isNew: (doc?.isNew ?? node.isNew) === true,
+          kind: "file",
+          prefix: node.prefix ?? doc?.prefix ?? "",
+          route: node.route ?? doc?.route ?? "",
+          title: node.title ?? doc?.title ?? "",
+        },
+      );
       registerDocPath(treePath, node, doc);
     }
   };

--- a/src/runtime/tree-controller.js
+++ b/src/runtime/tree-controller.js
@@ -529,9 +529,7 @@ export function createTreeController(options) {
     syncActiveSelection(navigation.currentDocId || "");
     applyTreeSearch(treeSearchValue);
     setupTreeLabelDecorations(
-      /** @type {TreeLabelHost | null} */ (
-        treeRoot.querySelector("file-tree-container")
-      ),
+      /** @type {TreeLabelHost | null} */ (treeRoot.querySelector("file-tree-container")),
       navigation.view.trees.metadataByTreePath,
       documentRef,
       windowRef,
@@ -560,8 +558,7 @@ export function createTreeController(options) {
     const message = documentRef.createElement("p");
     message.className = "tree-load-fallback-message";
     message.setAttribute("role", "alert");
-    message.textContent =
-      "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.";
+    message.textContent = "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.";
     const retry = documentRef.createElement("button");
     retry.className = "tree-load-retry";
     retry.type = "button";

--- a/src/seo.ts
+++ b/src/seo.ts
@@ -46,7 +46,13 @@ export function normalizeSeoConfig(raw: UserSeoConfig | undefined): BuildSeoOpti
     throw new Error('[config] "seo.siteUrl" must use http:// or https://');
   }
 
-  if (parsed.pathname !== "/" || parsed.search || parsed.hash || parsed.username || parsed.password) {
+  if (
+    parsed.pathname !== "/" ||
+    parsed.search ||
+    parsed.hash ||
+    parsed.username ||
+    parsed.password
+  ) {
     throw new Error(
       '[config] "seo.siteUrl" must be an origin only, without path, query, hash, or credentials (for example: "https://example.com")',
     );
@@ -54,7 +60,9 @@ export function normalizeSeoConfig(raw: UserSeoConfig | undefined): BuildSeoOpti
 
   const pathBaseRaw = raw.pathBase;
   if (pathBaseRaw != null && typeof pathBaseRaw !== "string") {
-    throw new Error('[config] "seo.pathBase" must be a string when provided (for example: "/blog")');
+    throw new Error(
+      '[config] "seo.pathBase" must be a string when provided (for example: "/blog")',
+    );
   }
 
   const normalizeOptionalString = (value: unknown, key: string): string | undefined => {
@@ -69,8 +77,14 @@ export function normalizeSeoConfig(raw: UserSeoConfig | undefined): BuildSeoOpti
   };
 
   const twitterCardRaw = raw.twitterCard;
-  if (twitterCardRaw != null && twitterCardRaw !== "summary" && twitterCardRaw !== "summary_large_image") {
-    throw new Error('[config] "seo.twitterCard" must be "summary" or "summary_large_image" when provided');
+  if (
+    twitterCardRaw != null &&
+    twitterCardRaw !== "summary" &&
+    twitterCardRaw !== "summary_large_image"
+  ) {
+    throw new Error(
+      '[config] "seo.twitterCard" must be "summary" or "summary_large_image" when provided',
+    );
   }
 
   return {
@@ -89,7 +103,10 @@ export function normalizeSeoConfig(raw: UserSeoConfig | undefined): BuildSeoOpti
   };
 }
 
-export function buildCanonicalUrl(route: string, seo: Pick<BuildSeoOptions, "siteUrl" | "pathBase">): string {
+export function buildCanonicalUrl(
+  route: string,
+  seo: Pick<BuildSeoOptions, "siteUrl" | "pathBase">,
+): string {
   const normalizedRoute = normalizeRoute(route);
   const pathname = `${seo.pathBase}${normalizedRoute}`.replace(/\/+/g, "/") || "/";
   return new URL(pathname, `${seo.siteUrl}/`).toString();

--- a/src/template.ts
+++ b/src/template.ts
@@ -48,7 +48,7 @@ interface AppShellInitialViewPayload {
   title: string;
 }
 
-interface AppShellManifestPayload extends Manifest {}
+type AppShellManifestPayload = Manifest;
 
 interface AppShellRuntimePayload {
   manifestUrl: string;
@@ -87,12 +87,14 @@ function renderHeadMeta(meta: AppShellMeta): string {
   const ogSiteName = typeof meta.ogSiteName === "string" ? meta.ogSiteName.trim() : "";
   const ogLocale = typeof meta.ogLocale === "string" ? meta.ogLocale.trim() : "";
   const ogUrl = typeof meta.ogUrl === "string" ? meta.ogUrl.trim() : "";
-  const ogDescription = (meta.ogDescription ?? (description || DEFAULT_DESCRIPTION)).trim() || DEFAULT_DESCRIPTION;
+  const ogDescription =
+    (meta.ogDescription ?? (description || DEFAULT_DESCRIPTION)).trim() || DEFAULT_DESCRIPTION;
   const ogImage = typeof meta.ogImage === "string" ? meta.ogImage.trim() : "";
 
   const twitterCard = (meta.twitterCard ?? "summary").trim() || "summary";
   const twitterTitle = (meta.twitterTitle ?? title).trim() || title;
-  const twitterDescription = (meta.twitterDescription ?? (description || DEFAULT_DESCRIPTION)).trim() || DEFAULT_DESCRIPTION;
+  const twitterDescription =
+    (meta.twitterDescription ?? (description || DEFAULT_DESCRIPTION)).trim() || DEFAULT_DESCRIPTION;
   const twitterImage = typeof meta.twitterImage === "string" ? meta.twitterImage.trim() : "";
   const twitterSite = typeof meta.twitterSite === "string" ? meta.twitterSite.trim() : "";
   const twitterCreator = typeof meta.twitterCreator === "string" ? meta.twitterCreator.trim() : "";
@@ -100,7 +102,9 @@ function renderHeadMeta(meta: AppShellMeta): string {
 
   const headTags: string[] = [`    <title>${escapeHtmlAttribute(title)}</title>`];
 
-  headTags.push(`    <meta name="description" content="${escapeHtmlAttribute(fallbackDescription)}" />`);
+  headTags.push(
+    `    <meta name="description" content="${escapeHtmlAttribute(fallbackDescription)}" />`,
+  );
 
   if (canonicalUrl) {
     headTags.push(`    <link rel="canonical" href="${escapeHtmlAttribute(canonicalUrl)}" />`);
@@ -114,14 +118,18 @@ function renderHeadMeta(meta: AppShellMeta): string {
   }
 
   if (ogSiteName) {
-    headTags.push(`    <meta property="og:site_name" content="${escapeHtmlAttribute(ogSiteName)}" />`);
+    headTags.push(
+      `    <meta property="og:site_name" content="${escapeHtmlAttribute(ogSiteName)}" />`,
+    );
   }
 
   if (ogLocale) {
     headTags.push(`    <meta property="og:locale" content="${escapeHtmlAttribute(ogLocale)}" />`);
   }
 
-  headTags.push(`    <meta property="og:description" content="${escapeHtmlAttribute(ogDescription)}" />`);
+  headTags.push(
+    `    <meta property="og:description" content="${escapeHtmlAttribute(ogDescription)}" />`,
+  );
 
   if (ogImage) {
     headTags.push(`    <meta property="og:image" content="${escapeHtmlAttribute(ogImage)}" />`);
@@ -129,10 +137,14 @@ function renderHeadMeta(meta: AppShellMeta): string {
 
   headTags.push(`    <meta name="twitter:card" content="${escapeHtmlAttribute(twitterCard)}" />`);
   headTags.push(`    <meta name="twitter:title" content="${escapeHtmlAttribute(twitterTitle)}" />`);
-  headTags.push(`    <meta name="twitter:description" content="${escapeHtmlAttribute(twitterDescription)}" />`);
+  headTags.push(
+    `    <meta name="twitter:description" content="${escapeHtmlAttribute(twitterDescription)}" />`,
+  );
 
   if (twitterImage) {
-    headTags.push(`    <meta name="twitter:image" content="${escapeHtmlAttribute(twitterImage)}" />`);
+    headTags.push(
+      `    <meta name="twitter:image" content="${escapeHtmlAttribute(twitterImage)}" />`,
+    );
   }
 
   if (twitterSite) {
@@ -140,7 +152,9 @@ function renderHeadMeta(meta: AppShellMeta): string {
   }
 
   if (twitterCreator) {
-    headTags.push(`    <meta name="twitter:creator" content="${escapeHtmlAttribute(twitterCreator)}" />`);
+    headTags.push(
+      `    <meta name="twitter:creator" content="${escapeHtmlAttribute(twitterCreator)}" />`,
+    );
   }
 
   for (const schema of jsonLd) {
@@ -201,9 +215,10 @@ export function renderAppShellHtml(
   const runtimeBootstrapScript = renderRuntimeBootstrapScript(manifest, assets);
   const symbolFontStylesheet =
     "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
-  const appTitle = typeof manifest?.siteTitle === "string" && manifest.siteTitle.trim().length > 0
-    ? manifest.siteTitle.trim()
-    : DEFAULT_TITLE;
+  const appTitle =
+    typeof manifest?.siteTitle === "string" && manifest.siteTitle.trim().length > 0
+      ? manifest.siteTitle.trim()
+      : DEFAULT_TITLE;
   const initialTitle = initialView ? escapeHtmlAttribute(initialView.title) : "문서를 선택하세요";
   const initialBreadcrumb = initialView ? initialView.breadcrumbHtml : "";
   const initialMeta = initialView ? initialView.metaHtml : "";

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -20,10 +20,7 @@ export function toDocId(relNoExt: string): string {
 }
 
 export function slugifySegment(input: string): string {
-  const normalized = input
-    .normalize("NFKC")
-    .trim()
-    .toLowerCase();
+  const normalized = input.normalize("NFKC").trim().toLowerCase();
 
   const slug = normalized
     .replace(/['’]/g, "")
@@ -60,7 +57,9 @@ export function isRemoteUrl(input: string): boolean {
   return /^(https?:)?\/\//i.test(input) || /^data:/i.test(input) || /^mailto:/i.test(input);
 }
 
-export function buildExcluder(patterns: string[]): (relPath: string, isDirectory: boolean) => boolean {
+export function buildExcluder(
+  patterns: string[],
+): (relPath: string, isDirectory: boolean) => boolean {
   const matchers = patterns.map((pattern) => picomatch(pattern, { dot: true }));
 
   return (relPath: string, isDirectory: boolean): boolean => {
@@ -89,7 +88,10 @@ export async function removeEmptyParents(startDir: string, stopDir: string): Pro
   let current = startDir;
   const normalizedStop = path.resolve(stopDir);
 
-  while (path.resolve(current).startsWith(normalizedStop) && path.resolve(current) !== normalizedStop) {
+  while (
+    path.resolve(current).startsWith(normalizedStop) &&
+    path.resolve(current) !== normalizedStop
+  ) {
     try {
       const entries = await fs.readdir(current);
       if (entries.length > 0) {

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -56,7 +56,7 @@ function toSafeUrlPath(input: string): string {
 }
 
 export function normalizeViewPathname(pathname: unknown): string {
-  let normalized = "/";
+  let normalized: string;
   try {
     normalized = decodeURIComponent(String(pathname || "/"));
   } catch {
@@ -138,8 +138,9 @@ function normalizeViewDateInput(value: unknown): string | null {
   }
   const normalized = value.trim();
   const dateOnly = /^\d{4}-\d{2}-\d{2}$/.test(normalized);
-  const offsetlessDateTime =
-    /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(normalized);
+  const offsetlessDateTime = /^\d{4}-\d{2}-\d{2}[T ]\d{2}:\d{2}(?::\d{2}(?:\.\d+)?)?$/.test(
+    normalized,
+  );
   return dateOnly
     ? `${normalized}T00:00:00Z`
     : offsetlessDateTime
@@ -205,9 +206,7 @@ export function normalizeViewTags(tags: unknown): string[] {
   if (!Array.isArray(tags)) {
     return [];
   }
-  return tags
-    .map((tag) => String(tag).trim().replace(/^#+/, ""))
-    .filter(Boolean);
+  return tags.map((tag) => String(tag).trim().replace(/^#+/, "")).filter(Boolean);
 }
 
 function normalizeText(value: unknown, fallback = ""): string {
@@ -215,7 +214,10 @@ function normalizeText(value: unknown, fallback = ""): string {
   return normalized || fallback;
 }
 
-function createLinkModel(doc: Pick<ViewDocContract, "route" | "title">, pathBase: unknown): ViewLinkModel {
+function createLinkModel(
+  doc: Pick<ViewDocContract, "route" | "title">,
+  pathBase: unknown,
+): ViewLinkModel {
   const route = normalizeViewRoute(doc.route);
   return {
     route,

--- a/tests/e2e/build-phases.spec.ts
+++ b/tests/e2e/build-phases.spec.ts
@@ -25,7 +25,12 @@ const options: BuildOptions = {
   seo: null,
 };
 
-function createDoc(id: string, title: string, route: string, wikiTargets: string[] = []): DocRecord {
+function createDoc(
+  id: string,
+  title: string,
+  route: string,
+  wikiTargets: string[] = [],
+): DocRecord {
   return {
     sourcePath: `/vault/${id}.md`,
     relPath: `${id}.md`,

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -25,7 +25,9 @@ interface TestTreeNode {
 }
 
 function getManifestDocs<T>(manifest: ManifestDocIndex<T>): T[] {
-  return manifest.docIds.map((id) => manifest.docsById[id]).filter((doc): doc is T => doc !== undefined);
+  return manifest.docIds
+    .map((id) => manifest.docsById[id])
+    .filter((doc): doc is T => doc !== undefined);
 }
 
 function getTreeDocTitles(
@@ -87,16 +89,19 @@ function readManifest(outDir: string): unknown {
 function snapshotOutputHashes(outDir: string): Record<string, string> {
   const hashes: Record<string, string> = {};
   const walk = (directory: string) => {
-    const entries = fs.readdirSync(directory, { withFileTypes: true }).sort((left, right) =>
-      left.name.localeCompare(right.name, "en"),
-    );
+    const entries = fs
+      .readdirSync(directory, { withFileTypes: true })
+      .sort((left, right) => left.name.localeCompare(right.name, "en"));
     for (const entry of entries) {
       const absolutePath = path.join(directory, entry.name);
       if (entry.isDirectory()) {
         walk(absolutePath);
       } else if (entry.isFile()) {
         const relativePath = path.relative(outDir, absolutePath).split(path.sep).join("/");
-        hashes[relativePath] = crypto.createHash("sha256").update(fs.readFileSync(absolutePath)).digest("hex");
+        hashes[relativePath] = crypto
+          .createHash("sha256")
+          .update(fs.readFileSync(absolutePath))
+          .digest("hex");
       }
     }
   };
@@ -124,10 +129,7 @@ function findOnlyCacheIndexPath(workDir: string): string {
   return cachePaths[0];
 }
 
-function findFolderNodeByPath(
-  nodes: TestTreeNode[],
-  targetPath: string,
-): TestTreeNode | null {
+function findFolderNodeByPath(nodes: TestTreeNode[], targetPath: string): TestTreeNode | null {
   for (const node of nodes) {
     if (node.type === "folder" && node.path === targetPath) {
       return node;
@@ -157,7 +159,9 @@ test.describe("빌드 회귀 가드", () => {
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
       const assetsDir = path.join(outDir, "assets");
-      const runtimeJs = fs.readdirSync(assetsDir).find((fileName) => /^app\.[a-f0-9]{12}\.js$/.test(fileName));
+      const runtimeJs = fs
+        .readdirSync(assetsDir)
+        .find((fileName) => /^app\.[a-f0-9]{12}\.js$/.test(fileName));
       expect(runtimeJs).toBeDefined();
       fs.appendFileSync(path.join(assetsDir, runtimeJs!), '"file-tree-builtin-astro";\n', "utf8");
 
@@ -230,10 +234,15 @@ title: Document ${index}
         path.join(workDir, "blog.config.mjs"),
         'export default { vaultDir: "./vault", outDir: "./dist", staticPaths: ["static-site"] };\n',
       );
-      writeText(path.join(vaultDir, "static-site", "index.html"), "<!doctype html><title>Static microsite</title>\n");
+      writeText(
+        path.join(vaultDir, "static-site", "index.html"),
+        "<!doctype html><title>Static microsite</title>\n",
+      );
       const build = runCli(workDir, [cliPath, "build"]);
       expect(build.status, build.output).toBe(0);
-      expect(fs.readFileSync(path.join(outDir, "static-site", "index.html"), "utf8")).toContain("Static microsite");
+      expect(fs.readFileSync(path.join(outDir, "static-site", "index.html"), "utf8")).toContain(
+        "Static microsite",
+      );
 
       const sizeCheck = runCli(workDir, [sizeCheckPath, "--out", outDir]);
       expect(sizeCheck.status, sizeCheck.output).toBe(0);
@@ -273,7 +282,10 @@ ALPHA
         Record<string, unknown>;
       expect(firstManifest).not.toHaveProperty("generatedAt");
       expect(firstManifest.docsById[firstManifest.docIds[0]]).not.toHaveProperty("isNew");
-      const contentPath = firstManifest.docsById[firstManifest.docIds[0]]?.contentUrl.replace(/^\/+/, "");
+      const contentPath = firstManifest.docsById[firstManifest.docIds[0]]?.contentUrl.replace(
+        /^\/+/,
+        "",
+      );
       expect(contentPath).toBeDefined();
 
       await new Promise((resolve) => setTimeout(resolve, 20));
@@ -283,7 +295,14 @@ ALPHA
       expect(second).toEqual(first);
 
       writeText(sourcePath, fs.readFileSync(sourcePath, "utf8").replace("ALPHA", "BRAVO"));
-      const contentBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      const contentBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+      ]);
       expect(contentBuild.status, contentBuild.output).toBe(0);
       const afterContent = snapshotOutputHashes(outDir);
       expect(afterContent[contentPath!]).not.toBe(second[contentPath!]);
@@ -311,7 +330,9 @@ ALPHA
       expect(firstBuild.status, firstBuild.output).toBe(0);
 
       const contentDir = path.join(outDir, "content");
-      const contentFiles = fs.readdirSync(contentDir).filter((fileName) => fileName.endsWith(".html"));
+      const contentFiles = fs
+        .readdirSync(contentDir)
+        .filter((fileName) => fileName.endsWith(".html"));
       expect(contentFiles.length).toBeGreaterThan(0);
 
       const missingFile = contentFiles[0];
@@ -319,7 +340,14 @@ ALPHA
       fs.rmSync(missingFilePath);
       expect(fs.existsSync(missingFilePath)).toBe(false);
 
-      const secondBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      const secondBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        outDir,
+      ]);
       expect(secondBuild.status, secondBuild.output).toBe(0);
       expect(fs.existsSync(missingFilePath)).toBe(true);
     } finally {
@@ -357,7 +385,14 @@ ALPHA
       expect(fs.existsSync(treeRuntimeJsPath)).toBe(false);
       expect(fs.existsSync(runtimeCssPath)).toBe(false);
 
-      const secondBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      const secondBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        outDir,
+      ]);
       expect(secondBuild.status, secondBuild.output).toBe(0);
       expect(fs.existsSync(runtimeJsPath)).toBe(true);
       expect(fs.existsSync(treeRuntimeJsPath)).toBe(true);
@@ -406,7 +441,14 @@ ALPHA
 
       const foreignLegacyNamedContents = `${JSON.stringify({ tool: "another-cache", entries: ["keep"] })}\n`;
       writeText(legacyCacheFile, foreignLegacyNamedContents);
-      const repeatedClean = runCli(workDir, [cliPath, "clean", "--vault", vaultPath, "--out", outDir]);
+      const repeatedClean = runCli(workDir, [
+        cliPath,
+        "clean",
+        "--vault",
+        vaultPath,
+        "--out",
+        outDir,
+      ]);
       expect(repeatedClean.status, repeatedClean.output).toBe(0);
       expect(fs.readFileSync(legacyCacheFile, "utf8")).toBe(foreignLegacyNamedContents);
 
@@ -576,7 +618,9 @@ ALPHA
       expect(buildWithSymlinkedNamespace.output).toContain("Refusing symlinked cache namespace");
       expect(fs.existsSync(namespaceGuardOutDir)).toBe(false);
       expect(fs.lstatSync(symlinkedNamespace).isSymbolicLink()).toBe(true);
-      expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe("keep external namespace data");
+      expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe(
+        "keep external namespace data",
+      );
 
       const cleanWithSymlinkedNamespace = runCli(workDir, [
         cliPath,
@@ -589,7 +633,9 @@ ALPHA
       expect(cleanWithSymlinkedNamespace.status).not.toBe(0);
       expect(cleanWithSymlinkedNamespace.output).toContain("Refusing symlinked cache namespace");
       expect(fs.lstatSync(symlinkedNamespace).isSymbolicLink()).toBe(true);
-      expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe("keep external namespace data");
+      expect(fs.readFileSync(externalNamespaceSentinel, "utf8")).toBe(
+        "keep external namespace data",
+      );
 
       fs.unlinkSync(symlinkedNamespace);
 
@@ -733,9 +779,18 @@ PRIVATE_STATIC_SOURCE_SECRET
       }
 
       writeText(configPath, "export default {};\n");
-      const correctedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      const correctedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+      ]);
       expect(correctedBuild.status, correctedBuild.output).toBe(0);
-      const outputMarker = JSON.parse(fs.readFileSync(path.join(outDir, ".eiam-output.json"), "utf8")) as {
+      const outputMarker = JSON.parse(
+        fs.readFileSync(path.join(outDir, ".eiam-output.json"), "utf8"),
+      ) as {
         format: string;
       };
       expect(outputMarker.format).toBe("everything-is-a-markdown-output");
@@ -762,7 +817,14 @@ PRIVATE_STATIC_SOURCE_SECRET
       expect(fs.existsSync(outDir)).toBe(false);
       expect(findCacheIndexPaths(workDir)).toEqual([]);
 
-      const correctedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      const correctedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        outDir,
+      ]);
       expect(correctedBuild.status, correctedBuild.output).toBe(0);
       expect(fs.existsSync(path.join(outDir, ".eiam-output.json"))).toBe(true);
     } finally {
@@ -822,7 +884,9 @@ VAULT_B_BODY
       expect(wrongVaultBuild.output).toContain("matching .eiam-output.json");
       expect(fs.readFileSync(markerAPath, "utf8")).toBe(markerABefore);
       const manifestAfterWrongBuild = readManifest(outA) as ManifestDocIndex<{ route: string }>;
-      expect(getManifestDocs(manifestAfterWrongBuild).map((doc) => doc.route)).toEqual(["/NS-CACHE-A/"]);
+      expect(getManifestDocs(manifestAfterWrongBuild).map((doc) => doc.route)).toEqual([
+        "/NS-CACHE-A/",
+      ]);
 
       const wrongVaultClean = runCli(workDir, [cliPath, "clean", "--vault", vaultB, "--out", outA]);
       expect(wrongVaultClean.status).not.toBe(0);
@@ -843,7 +907,9 @@ VAULT_B_BODY
       expect(fs.readFileSync(markerAPath, "utf8")).toBe(markerABefore);
       expect(fs.existsSync(path.join(alternateCwd, ".cache", "eiam"))).toBe(false);
       expect(
-        getManifestDocs(readManifest(outA) as ManifestDocIndex<{ route: string }>).map((doc) => doc.route),
+        getManifestDocs(readManifest(outA) as ManifestDocIndex<{ route: string }>).map(
+          (doc) => doc.route,
+        ),
       ).toEqual(["/NS-CACHE-A/"]);
 
       const wrongCwdClean = runCli(alternateCwd, [
@@ -988,7 +1054,10 @@ TARGET_B_BODY
       }
 
       const initialStats = new Map(
-        [mutablePath, linkerPath, frontmatterPath].map((sourcePath) => [sourcePath, fs.statSync(sourcePath)]),
+        [mutablePath, linkerPath, frontmatterPath].map((sourcePath) => [
+          sourcePath,
+          fs.statSync(sourcePath),
+        ]),
       );
       const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(firstBuild.status, firstBuild.output).toBe(0);
@@ -1009,7 +1078,14 @@ TARGET_B_BODY
         expect(current.mtimeMs).toBe(previous.mtimeMs);
       }
 
-      const changedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      const changedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+      ]);
       expect(changedBuild.status, changedBuild.output).toBe(0);
       expect(changedBuild.output).toContain("total=5 rendered=3 skipped=2");
       expect(readDocContentHtml(outDir, "/FP-MUTABLE/")).toContain("BRAVO");
@@ -1098,12 +1174,24 @@ title: HTML Policy
       fs.mkdirSync(unsafeWorkDir, { recursive: true });
 
       const safeOutDir = path.join(safeWorkDir, "dist");
-      const safeBuild = runCli(safeWorkDir, [cliPath, "build", "--vault", vaultDir, "--out", safeOutDir]);
+      const safeBuild = runCli(safeWorkDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        safeOutDir,
+      ]);
       expect(safeBuild.status, safeBuild.output).toBe(0);
       const safeContent = readDocContentHtml(safeOutDir, "/SAFE-HTML-01/");
-      const safeRoute = fs.readFileSync(path.join(safeOutDir, "SAFE-HTML-01", "index.html"), "utf8");
+      const safeRoute = fs.readFileSync(
+        path.join(safeOutDir, "SAFE-HTML-01", "index.html"),
+        "utf8",
+      );
       for (const rendered of [safeContent, safeRoute]) {
-        expect(rendered).toContain('<div class="safe-format"><strong>Allowed formatting</strong></div>');
+        expect(rendered).toContain(
+          '<div class="safe-format"><strong>Allowed formatting</strong></div>',
+        );
         expect(rendered).not.toContain("window.__script_payload");
         expect(rendered).not.toContain("window.__event_payload");
         expect(rendered).not.toContain("javascript:window.__url_payload");
@@ -1126,7 +1214,9 @@ title: HTML Policy
         unsafeOutDir,
       ]);
       expect(unsafeBuild.status, unsafeBuild.output).toBe(0);
-      expect(unsafeBuild.output).toContain("allowUnsafeHtml=true disables rendered HTML sanitization");
+      expect(unsafeBuild.output).toContain(
+        "allowUnsafeHtml=true disables rendered HTML sanitization",
+      );
       const unsafeContent = readDocContentHtml(unsafeOutDir, "/SAFE-HTML-01/");
       expect(unsafeContent).toContain("<script>window.__script_payload = 1</script>");
       expect(unsafeContent).toContain('onerror="window.__event_payload = 1"');
@@ -1222,7 +1312,14 @@ MISSING_CATEGORY_CACHE_SECRET
       expect(firstSources["missing-prefix.md"]).toBeUndefined();
       expect(firstSources["missing-category.md"]).toBeUndefined();
 
-      const incrementalBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      const incrementalBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+      ]);
       expect(incrementalBuild.status, incrementalBuild.output).toBe(0);
       expect(incrementalBuild.output).toContain("total=1 rendered=0 skipped=1");
 
@@ -1267,10 +1364,11 @@ DRAFT_CACHE_SECRET
       const stateBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(stateBuild.status, stateBuild.output).toBe(0);
       const manifest = readManifest(outDir) as ManifestDocIndex<{ route: string }>;
-      expect(getManifestDocs(manifest).map((doc) => doc.route).sort()).toEqual([
-        "/CACHE-DRAFT/",
-        "/CACHE-PRIVATE/",
-      ]);
+      expect(
+        getManifestDocs(manifest)
+          .map((doc) => doc.route)
+          .sort(),
+      ).toEqual(["/CACHE-DRAFT/", "/CACHE-PRIVATE/"]);
 
       const nextCache = fs.readFileSync(cachePath, "utf8");
       expect(nextCache).not.toContain("PUBLIC_CACHE_BODY");
@@ -1345,7 +1443,10 @@ DRAFT_CACHE_SECRET
         expect(omitted.output).toContain(expectedError);
 
         const followedByFlag = runCli(workDir, [cliPath, command, option, "--help"]);
-        expect(followedByFlag.status, `${command} ${option} --help\n${followedByFlag.output}`).not.toBe(0);
+        expect(
+          followedByFlag.status,
+          `${command} ${option} --help\n${followedByFlag.output}`,
+        ).not.toBe(0);
         expect(followedByFlag.output).toContain(expectedError);
       }
     } finally {
@@ -1433,7 +1534,9 @@ title: Duplicate Title
       expect(duplicateContent).toContain("<li>Duplicate Title</li>");
       expect(duplicateContent).not.toContain('href="/DOC-03/"');
       expect(duplicateContent).not.toContain('href="/DOC-04/"');
-      expect(build.output).toContain('[wikilink] Duplicate title target "Duplicate Title" in notes/duplicates.md. Candidates: notes/duplicate-one.md, notes/duplicate-two.md');
+      expect(build.output).toContain(
+        '[wikilink] Duplicate title target "Duplicate Title" in notes/duplicates.md. Candidates: notes/duplicate-one.md, notes/duplicate-two.md',
+      );
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -1501,13 +1604,18 @@ title: API Detail
       const pinnedFolder = manifest.tree[0];
       expect(pinnedFolder.type).toBe("folder");
       expect(pinnedFolder.path).toBe("__virtual__/pinned/category/engineering/guides");
-      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual(["Guide Overview", "API Detail"]);
+      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual([
+        "Guide Overview",
+        "API Detail",
+      ]);
 
       const engineeringFolder = findFolderNodeByPath(manifest.tree, "engineering");
       expect(engineeringFolder).not.toBeNull();
       const guidesFolder = findFolderNodeByPath(manifest.tree, "engineering/guides");
       expect(guidesFolder).not.toBeNull();
-      expect(getTreeDocTitles(guidesFolder?.children, manifest.docsById)).toContain("Guide Overview");
+      expect(getTreeDocTitles(guidesFolder?.children, manifest.docsById)).toContain(
+        "Guide Overview",
+      );
       expect(findFolderNodeByPath(manifest.tree, "misc")).toBeNull();
 
       const apiFolder = findFolderNodeByPath(manifest.tree, "engineering/guides/api");
@@ -1515,7 +1623,9 @@ title: API Detail
       expect(getTreeDocTitles(apiFolder?.children, manifest.docsById)).toContain("API Detail");
 
       expect(docs.find((doc) => doc.route === "/CAT-02/")?.categoryPath).toBe("engineering/guides");
-      expect(docs.find((doc) => doc.route === "/CAT-03/")?.categoryPath).toBe("engineering/guides/api");
+      expect(docs.find((doc) => doc.route === "/CAT-03/")?.categoryPath).toBe(
+        "engineering/guides/api",
+      );
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -1539,7 +1649,9 @@ title: Missing Category
 
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
-      expect(build.output).toContain("[publish] Skipped published doc without category_path: notes/missing-category.md");
+      expect(build.output).toContain(
+        "[publish] Skipped published doc without category_path: notes/missing-category.md",
+      );
 
       const manifest = readManifest(outDir) as ManifestDocIndex<{ route: string }>;
       expect(getManifestDocs(manifest)).toEqual([]);
@@ -1599,7 +1711,9 @@ title: Should Not Pin
       const build = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
       expect(build.status, build.output).toBe(0);
 
-      const manifest = readManifest(outDir) as ManifestDocIndex<{ title: string }> & { tree: TestTreeNode[] };
+      const manifest = readManifest(outDir) as ManifestDocIndex<{ title: string }> & {
+        tree: TestTreeNode[];
+      };
 
       const pinnedFolder = manifest.tree[0];
       expect(pinnedFolder.type).toBe("folder");
@@ -1668,8 +1782,12 @@ title: Normalized API Reference
       ]);
 
       expect(findFolderNodeByPath(manifest.tree, "engineering/guides/api")).not.toBeNull();
-      expect(findFolderNodeByPath(manifest.tree, "engineering/guides/api/reference")).not.toBeNull();
-      expect(docs.find((doc) => doc.route === "/NORM-01/")?.categoryPath).toBe("engineering/guides/api");
+      expect(
+        findFolderNodeByPath(manifest.tree, "engineering/guides/api/reference"),
+      ).not.toBeNull();
+      expect(docs.find((doc) => doc.route === "/NORM-01/")?.categoryPath).toBe(
+        "engineering/guides/api",
+      );
       expect(docs.find((doc) => doc.route === "/NORM-02/")?.categoryPath).toBe(
         "engineering/guides/api/reference",
       );
@@ -1741,12 +1859,16 @@ title: Menu Config Guide
       ]);
       expect(build.status, build.output).toBe(0);
 
-      const manifest = readManifest(outDir) as ManifestDocIndex<{ title: string }> & { tree: TestTreeNode[] };
+      const manifest = readManifest(outDir) as ManifestDocIndex<{ title: string }> & {
+        tree: TestTreeNode[];
+      };
 
       const pinnedFolder = manifest.tree[0];
       expect(pinnedFolder.name).toBe("GUIDES");
       expect(pinnedFolder.path).toBe("__virtual__/pinned/category/engineering/guides");
-      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual(["Menu Config Guide"]);
+      expect(getTreeDocTitles(pinnedFolder.children, manifest.docsById)).toEqual([
+        "Menu Config Guide",
+      ]);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -1766,9 +1888,18 @@ title: Menu Config Guide
 `,
       );
 
-      const missingTarget = runCli(workDir, [cliPath, "build", "--vault", "./vault", "--out", "./dist"]);
+      const missingTarget = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        "./vault",
+        "--out",
+        "./dist",
+      ]);
       expect(missingTarget.status).not.toBe(0);
-      expect(missingTarget.output).toContain('"pinnedMenu" must include "sourceDir" or "categoryPath"');
+      expect(missingTarget.output).toContain(
+        '"pinnedMenu" must include "sourceDir" or "categoryPath"',
+      );
 
       writeText(
         path.join(workDir, "blog.config.mjs"),
@@ -1781,7 +1912,14 @@ title: Menu Config Guide
 `,
       );
 
-      const rootCategory = runCli(workDir, [cliPath, "build", "--vault", "./vault", "--out", "./dist"]);
+      const rootCategory = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        "./vault",
+        "--out",
+        "./dist",
+      ]);
       expect(rootCategory.status).not.toBe(0);
       expect(rootCategory.output).toContain('"pinnedMenu.categoryPath" must not be root');
     } finally {

--- a/tests/e2e/deferred-tree-runtime.spec.ts
+++ b/tests/e2e/deferred-tree-runtime.spec.ts
@@ -4,7 +4,9 @@ import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
 const TREE_MODULE_PATTERN = /\/assets\/tree\.[a-f0-9]{12}\.js(?:\?.*)?$/;
 
 test.describe("deferred tree runtime", () => {
-  test("tree chunk 실패가 SSR content를 막지 않고 fallback 탐색과 재시도를 제공한다", async ({ page }) => {
+  test("tree chunk 실패가 SSR content를 막지 않고 fallback 탐색과 재시도를 제공한다", async ({
+    page,
+  }) => {
     let treeRequestCount = 0;
     await page.route(TREE_MODULE_PATTERN, async (route) => {
       treeRequestCount += 1;
@@ -29,8 +31,9 @@ test.describe("deferred tree runtime", () => {
         appReady: mark("eiam-app-ready"),
         firstPaintOpportunity: mark("eiam-first-content-paint-opportunity"),
         firstContentfulPaint:
-          performance.getEntriesByType("paint").find((entry) => entry.name === "first-contentful-paint")
-            ?.startTime ?? -1,
+          performance
+            .getEntriesByType("paint")
+            .find((entry) => entry.name === "first-contentful-paint")?.startTime ?? -1,
         treeLoadStart: mark("eiam-tree-load-start"),
       };
     });
@@ -56,7 +59,9 @@ test.describe("deferred tree runtime", () => {
     await expect(page.locator("#tree-root file-tree-container")).toBeVisible();
   });
 
-  test("compact layout은 sidebar interaction 전에는 tree chunk를 요청하지 않는다", async ({ page }) => {
+  test("compact layout은 sidebar interaction 전에는 tree chunk를 요청하지 않는다", async ({
+    page,
+  }) => {
     await page.setViewportSize({ width: 390, height: 844 });
     let treeRequestCount = 0;
     page.on("request", (request) => {

--- a/tests/e2e/mermaid-runtime.spec.ts
+++ b/tests/e2e/mermaid-runtime.spec.ts
@@ -85,7 +85,9 @@ function resolveRequestPath(outDir: string, pathname: string): string | null {
   return null;
 }
 
-async function startStaticServer(outDir: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+async function startStaticServer(
+  outDir: string,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
     const filePath = resolveRequestPath(outDir, requestUrl.pathname);
@@ -284,7 +286,10 @@ function writeBlogConfig(workDir: string, options: MermaidFixtureOptions): void 
   );
 }
 
-function createFixture(workDir: string, options: MermaidFixtureOptions): { vaultDir: string; outDir: string } {
+function createFixture(
+  workDir: string,
+  options: MermaidFixtureOptions,
+): { vaultDir: string; outDir: string } {
   const vaultDir = path.join(workDir, "vault");
   const outDir = path.join(workDir, "dist");
 
@@ -333,7 +338,10 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         await expect(mermaidBlock.locator(".code-header")).toHaveCount(0);
         await expect(mermaidBlock.locator(".code-copy")).toHaveCount(0);
         await expect(mermaidBlock.locator("pre.mermaid svg[data-mermaid-mock='ok']")).toBeVisible();
-        await expect(mermaidBlock.locator("pre.mermaid")).toHaveAttribute("data-mermaid-rendered", "true");
+        await expect(mermaidBlock.locator("pre.mermaid")).toHaveAttribute(
+          "data-mermaid-rendered",
+          "true",
+        );
         await expect(mermaidBlock.locator("pre.mermaid")).toHaveCSS("display", "flex");
         await expect(mermaidBlock.locator("pre.mermaid")).toHaveCSS("justify-content", "center");
 
@@ -360,19 +368,28 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         }
         expect(layout.blockScrollWidth).toBeLessThanOrEqual(layout.blockClientWidth + 1);
         expect(layout.svgWidth).toBeLessThanOrEqual(layout.blockWidth + 1);
-        expect(layout.svgWidth).toBeLessThanOrEqual(Math.min(layout.blockWidth, CONTENT_VISUAL_MAX_WIDTH) + 1);
+        expect(layout.svgWidth).toBeLessThanOrEqual(
+          Math.min(layout.blockWidth, CONTENT_VISUAL_MAX_WIDTH) + 1,
+        );
 
         await expect(landscapeImage).toHaveClass(/is-landscape/);
         await expect(portraitImage).toHaveClass(/is-portrait/);
-        await expect(page.locator("#viewer-content figure.content-image").first()).toHaveClass(/is-landscape/);
+        await expect(page.locator("#viewer-content figure.content-image").first()).toHaveClass(
+          /is-landscape/,
+        );
         const imageLayout = await page.locator("#viewer-content").evaluate(() => {
           const content = document.getElementById("viewer-content");
-          const landscape = document.querySelector('#viewer-content img[alt="Large Runtime Diagram"]');
-          const portrait = document.querySelector('#viewer-content img[alt="Tall Runtime Diagram"]');
+          const landscape = document.querySelector(
+            '#viewer-content img[alt="Large Runtime Diagram"]',
+          );
+          const portrait = document.querySelector(
+            '#viewer-content img[alt="Tall Runtime Diagram"]',
+          );
           if (!(landscape instanceof HTMLImageElement) || !(portrait instanceof HTMLImageElement)) {
             return null;
           }
-          const contentRect = content instanceof HTMLElement ? content.getBoundingClientRect() : null;
+          const contentRect =
+            content instanceof HTMLElement ? content.getBoundingClientRect() : null;
           const landscapeRect = landscape.getBoundingClientRect();
           const portraitRect = portrait.getBoundingClientRect();
           return {
@@ -385,8 +402,12 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         if (!imageLayout || imageLayout.contentWidth === null) {
           throw new Error("본문 이미지 레이아웃 정보를 읽지 못했습니다.");
         }
-        expect(imageLayout.landscapeWidth).toBeLessThanOrEqual(Math.min(imageLayout.contentWidth, CONTENT_VISUAL_MAX_WIDTH) + 1);
-        expect(imageLayout.portraitWidth).toBeLessThanOrEqual(Math.min(imageLayout.contentWidth, CONTENT_IMAGE_PORTRAIT_MAX_WIDTH) + 1);
+        expect(imageLayout.landscapeWidth).toBeLessThanOrEqual(
+          Math.min(imageLayout.contentWidth, CONTENT_VISUAL_MAX_WIDTH) + 1,
+        );
+        expect(imageLayout.portraitWidth).toBeLessThanOrEqual(
+          Math.min(imageLayout.contentWidth, CONTENT_IMAGE_PORTRAIT_MAX_WIDTH) + 1,
+        );
         expect(imageLayout.portraitWidth).toBeLessThan(imageLayout.landscapeWidth);
 
         await expect(page.locator(".mermaid-render-error")).toHaveCount(0);
@@ -445,20 +466,27 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         }
         expect(mobileLayout.preDisplay).toBe("flex");
         expect(mobileLayout.preJustifyContent).toBe("center");
-        expect(mobileLayout.blockScrollWidth).toBeLessThanOrEqual(mobileLayout.blockClientWidth + 1);
+        expect(mobileLayout.blockScrollWidth).toBeLessThanOrEqual(
+          mobileLayout.blockClientWidth + 1,
+        );
         expect(mobileLayout.svgWidth).toBeLessThanOrEqual(mobileLayout.blockWidth + 1);
-        expect(mobileLayout.svgWidth).toBeLessThanOrEqual(Math.min(mobileLayout.blockWidth, CONTENT_VISUAL_MAX_WIDTH) + 1);
+        expect(mobileLayout.svgWidth).toBeLessThanOrEqual(
+          Math.min(mobileLayout.blockWidth, CONTENT_VISUAL_MAX_WIDTH) + 1,
+        );
 
         await expect(portraitImage).toBeVisible();
         await expect(portraitImage).toHaveClass(/is-portrait/);
         const mobileImageLayout = await page.locator("#viewer-content").evaluate(() => {
           const content = document.getElementById("viewer-content");
-          const portrait = document.querySelector('#viewer-content img[alt="Tall Runtime Diagram"]');
+          const portrait = document.querySelector(
+            '#viewer-content img[alt="Tall Runtime Diagram"]',
+          );
           if (!(portrait instanceof HTMLImageElement)) {
             return null;
           }
           const imageRect = portrait.getBoundingClientRect();
-          const contentRect = content instanceof HTMLElement ? content.getBoundingClientRect() : null;
+          const contentRect =
+            content instanceof HTMLElement ? content.getBoundingClientRect() : null;
           return {
             imageWidth: imageRect.width,
             contentWidth: contentRect ? contentRect.width : null,
@@ -468,7 +496,9 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         if (!mobileImageLayout || mobileImageLayout.contentWidth === null) {
           throw new Error("모바일 본문 이미지 레이아웃 정보를 읽지 못했습니다.");
         }
-        expect(mobileImageLayout.imageWidth).toBeLessThanOrEqual(mobileImageLayout.contentWidth + 1);
+        expect(mobileImageLayout.imageWidth).toBeLessThanOrEqual(
+          mobileImageLayout.contentWidth + 1,
+        );
       } finally {
         await server.close();
       }
@@ -477,7 +507,9 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
     }
   });
 
-  test("본문 이미지 프레임 유틸리티와 클라이언트 내비게이션 후처리가 유지된다", async ({ page }) => {
+  test("본문 이미지 프레임 유틸리티와 클라이언트 내비게이션 후처리가 유지된다", async ({
+    page,
+  }) => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-content-image-layout-"));
     const { vaultDir, outDir } = createFixture(workDir, {
       enabled: true,
@@ -501,8 +533,8 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         await expect(containFrame).toHaveClass(/is-portrait/);
 
         const frameLayout = await page.locator("#viewer-content").evaluate(() => {
-          const cover = document.querySelector('#viewer-content figure.image-frame.fit-cover');
-          const contain = document.querySelector('#viewer-content figure.image-frame.fit-contain');
+          const cover = document.querySelector("#viewer-content figure.image-frame.fit-cover");
+          const contain = document.querySelector("#viewer-content figure.image-frame.fit-contain");
           const coverImage = cover?.querySelector('img[alt="Framed Cover Diagram"]');
           const containImage = contain?.querySelector('img[alt="Framed Contain Diagram"]');
           if (
@@ -538,7 +570,9 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         await expect(nextLink).toBeVisible();
         await nextLink.click();
         await expect(page.locator("#viewer-title")).toHaveText("Mermaid Runtime Followup Test");
-        await expect(page.locator('#viewer-content img[alt="Followup Tall Diagram"]')).toHaveClass(/is-portrait/);
+        await expect(page.locator('#viewer-content img[alt="Followup Tall Diagram"]')).toHaveClass(
+          /is-portrait/,
+        );
       } finally {
         await server.close();
       }
@@ -663,7 +697,9 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         await expect(mermaidBlock.locator("pre.mermaid")).toContainText("flowchart LR");
         await expect(mermaidBlock.locator(".mermaid-render-error")).toContainText("비활성화");
 
-        const scriptCount = await page.evaluate(() => document.querySelectorAll("#mermaid-runtime").length);
+        const scriptCount = await page.evaluate(
+          () => document.querySelectorAll("#mermaid-runtime").length,
+        );
         expect(scriptCount).toBe(0);
       } finally {
         await server.close();
@@ -692,7 +728,9 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
         const mermaidBlock = page.locator(".mermaid-block");
         await expect(mermaidBlock).toHaveCount(1);
         await expect(mermaidBlock.locator("pre.mermaid")).toContainText("flowchart LR");
-        await expect(mermaidBlock.locator(".mermaid-render-error")).toContainText("Mermaid 렌더링 실패");
+        await expect(mermaidBlock.locator(".mermaid-render-error")).toContainText(
+          "Mermaid 렌더링 실패",
+        );
       } finally {
         await server.close();
       }
@@ -720,10 +758,16 @@ test.describe("Mermaid 런타임 회귀 가드", () => {
       const server = await startStaticServer(outDir);
       try {
         await page.goto(`${server.baseUrl}${TEST_ROUTE}`);
-        await expect(page.locator(".mermaid-block pre.mermaid svg[data-mermaid-mock='ok']")).toHaveCount(1);
+        await expect(
+          page.locator(".mermaid-block pre.mermaid svg[data-mermaid-mock='ok']"),
+        ).toHaveCount(1);
         await expect(page.locator(".mermaid-block .mermaid-render-error")).toHaveCount(1);
-        await expect(page.locator(".mermaid-block .mermaid-render-error")).toContainText("Parse error on line 2");
-        await expect(page.locator(".mermaid-block pre.mermaid").first()).toContainText("BROKEN --> NODE");
+        await expect(page.locator(".mermaid-block .mermaid-render-error")).toContainText(
+          "Parse error on line 2",
+        );
+        await expect(page.locator(".mermaid-block pre.mermaid").first()).toContainText(
+          "BROKEN --> NODE",
+        );
       } finally {
         await server.close();
       }

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -127,7 +127,14 @@ test.describe("pathBase 정식 지원", () => {
         'export default { seo: { siteUrl: "https://example.com", pathBase: " docs/guides/ " } };',
         "utf8",
       );
-      const nestedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      const nestedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        outDir,
+      ]);
       expect(nestedBuild.status, nestedBuild.output).toBe(0);
       const nestedNotFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
       expect(nestedNotFoundHtml).toContain('<a href="/docs/guides/" class="not-found-link">');
@@ -137,7 +144,14 @@ test.describe("pathBase 정식 지원", () => {
         'export default { seo: { siteUrl: "https://example.com", pathBase: " docs guides/한글/ " } };',
         "utf8",
       );
-      const encodedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultPath, "--out", outDir]);
+      const encodedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultPath,
+        "--out",
+        outDir,
+      ]);
       expect(encodedBuild.status, encodedBuild.output).toBe(0);
       const encodedIndexHtml = fs.readFileSync(path.join(outDir, "index.html"), "utf8");
       expect(encodedIndexHtml).toContain(
@@ -194,18 +208,26 @@ test.describe("pathBase 정식 지원", () => {
       await waitForTreeReady(page);
 
       const setupRow = page
-        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')
+        .locator(
+          '#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]',
+        )
         .first();
       await expect(setupRow).toBeVisible();
       await expect(setupRow).toContainText("NEW");
       await setupRow.click({ button: "right" });
-      await expect(page.locator("#tree-root .tree-context-link").first()).toHaveAttribute("href", "/blog/BC-VO-02/");
+      await expect(page.locator("#tree-root .tree-context-link").first()).toHaveAttribute(
+        "href",
+        "/blog/BC-VO-02/",
+      );
       await page.keyboard.press("Escape");
       await setupRow.click();
 
       await expect(page).toHaveURL(/\/blog\/BC-VO-02\/$/);
       await expect(page.locator("#viewer-title")).toHaveText("Setup Guide");
-      await expect(page.locator("#viewer-nav .nav-link-next")).toHaveAttribute("href", "/blog/BC-XSS-01/");
+      await expect(page.locator("#viewer-nav .nav-link-next")).toHaveAttribute(
+        "href",
+        "/blog/BC-XSS-01/",
+      );
 
       const notFoundResponse = await page.goto(`${server.baseUrl}/blog/missing-document/`);
       expect(notFoundResponse?.status()).toBe(404);

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -101,6 +101,7 @@ async function startStaticServer(
     close: () =>
       new Promise<void>((resolve, reject) => {
         server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
       }),
   };
 }

--- a/tests/e2e/prefix-backlinks-branch.spec.ts
+++ b/tests/e2e/prefix-backlinks-branch.spec.ts
@@ -3,7 +3,9 @@ import { waitForAppReady } from "./utils/app-ready";
 import { escapeRegExp, getInitialManifest, getNextRouteInDefaultBranch } from "./utils/manifest";
 
 test.describe("prefix 라우팅/백링크/자동 브랜치 전환", () => {
-  test("main 저장 상태에서 unclassified 문서 진입 시 nav가 활성 브랜치 기준으로 동기화된다", async ({ page }) => {
+  test("main 저장 상태에서 unclassified 문서 진입 시 nav가 활성 브랜치 기준으로 동기화된다", async ({
+    page,
+  }) => {
     await page.addInitScript(() => {
       window.localStorage.setItem("fsblog.branch", "main");
     });
@@ -19,7 +21,9 @@ test.describe("prefix 라우팅/백링크/자동 브랜치 전환", () => {
 
     await expect(page.locator("#viewer-title")).toHaveText("About");
     await expect(page.locator("#sidebar-branch-pills .branch-pill").first()).toBeVisible();
-    await expect(page.locator(`.branch-pill.is-active[data-branch="${manifest.defaultBranch}"]`)).toBeVisible();
+    await expect(
+      page.locator(`.branch-pill.is-active[data-branch="${manifest.defaultBranch}"]`),
+    ).toBeVisible();
 
     const nextToSetupGuide = page.locator(`#viewer-nav .nav-link[data-route="${nextRoute}"]`);
     await expect(nextToSetupGuide).toBeVisible();
@@ -28,7 +32,9 @@ test.describe("prefix 라우팅/백링크/자동 브랜치 전환", () => {
     await expect(page).toHaveURL(new RegExp(`${escapeRegExp(nextRoute)}$`));
   });
 
-  test("backlinks 클릭 시 prefix 경로 이동과 자동 브랜치 전환이 함께 동작한다", async ({ page }) => {
+  test("backlinks 클릭 시 prefix 경로 이동과 자동 브랜치 전환이 함께 동작한다", async ({
+    page,
+  }) => {
     await page.addInitScript(() => {
       window.localStorage.setItem("fsblog.branch", "main");
     });
@@ -52,7 +58,9 @@ test.describe("prefix 라우팅/백링크/자동 브랜치 전환", () => {
     await expect(page).toHaveURL(/\/BC-VO-00\/$/);
     await expect(page.locator("#viewer-title")).toHaveText("About");
     await expect(page.locator("#sidebar-branch-pills .branch-pill").first()).toBeVisible();
-    await expect(page.locator(`.branch-pill.is-active[data-branch="${manifest.defaultBranch}"]`)).toBeVisible();
+    await expect(
+      page.locator(`.branch-pill.is-active[data-branch="${manifest.defaultBranch}"]`),
+    ).toBeVisible();
     await expect(page.locator(`#viewer-nav .nav-link[data-route="${nextRoute}"]`)).toBeVisible();
   });
 });

--- a/tests/e2e/responsive-sidebar-layout.spec.ts
+++ b/tests/e2e/responsive-sidebar-layout.spec.ts
@@ -68,7 +68,9 @@ function toFilePath(outDir: string, pathname: string): string {
   return path.join(outDir, "404.html");
 }
 
-async function startStaticServer(outDir: string): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+async function startStaticServer(
+  outDir: string,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
   const server = createServer((req: IncomingMessage, res: ServerResponse) => {
     const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
     const filePath = toFilePath(outDir, requestUrl.pathname);
@@ -185,7 +187,9 @@ test.describe("responsive Trees sidebar layout", () => {
   });
 
   for (const viewport of VIEWPORTS) {
-    test(`${viewport.width}x${viewport.height} keeps sidebar sections ordered and contained`, async ({ page }) => {
+    test(`${viewport.width}x${viewport.height} keeps sidebar sections ordered and contained`, async ({
+      page,
+    }) => {
       expect(server).not.toBeNull();
       await page.setViewportSize(viewport);
       await openSidebar(page, server!.baseUrl);
@@ -207,10 +211,16 @@ test.describe("responsive Trees sidebar layout", () => {
       const rowState = await page.locator("#tree-root").evaluate(() => {
         const host = document.querySelector("#tree-root file-tree-container");
         const root = host?.shadowRoot;
-        const rows = Array.from(root?.querySelectorAll('[data-type="item"][data-item-type="file"]') ?? []);
+        const rows = Array.from(
+          root?.querySelectorAll('[data-type="item"][data-item-type="file"]') ?? [],
+        );
         const firstRow = rows[0] as HTMLElement | undefined;
-        const content = firstRow?.querySelector('[data-item-section="content"]') as HTMLElement | null;
-        const decoration = firstRow?.querySelector('[data-item-section="decoration"]') as HTMLElement | null;
+        const content = firstRow?.querySelector(
+          '[data-item-section="content"]',
+        ) as HTMLElement | null;
+        const decoration = firstRow?.querySelector(
+          '[data-item-section="decoration"]',
+        ) as HTMLElement | null;
         const rowRect = firstRow?.getBoundingClientRect();
         const contentRect = content?.getBoundingClientRect();
         const decorationRect = decoration?.getBoundingClientRect();
@@ -222,7 +232,8 @@ test.describe("responsive Trees sidebar layout", () => {
             rowRect!.left >= host!.getBoundingClientRect().left - 1 &&
             rowRect!.right <= host!.getBoundingClientRect().right + 1,
           lanesDoNotOverlap:
-            Boolean(contentRect && decorationRect) && contentRect!.right <= decorationRect!.left + 1,
+            Boolean(contentRect && decorationRect) &&
+            contentRect!.right <= decorationRect!.left + 1,
         };
       });
 
@@ -233,7 +244,9 @@ test.describe("responsive Trees sidebar layout", () => {
 
       const scrollState = await page.locator("#tree-root").evaluate((treeRoot) => {
         const host = treeRoot.querySelector("file-tree-container");
-        const scroller = host?.shadowRoot?.querySelector('[data-file-tree-virtualized-scroll="true"]') as HTMLElement | null;
+        const scroller = host?.shadowRoot?.querySelector(
+          '[data-file-tree-virtualized-scroll="true"]',
+        ) as HTMLElement | null;
         const beforeWindowY = window.scrollY;
         if (scroller) {
           scroller.scrollTop = 240;

--- a/tests/e2e/runtime-controller-lifecycle.spec.ts
+++ b/tests/e2e/runtime-controller-lifecycle.spec.ts
@@ -1,7 +1,10 @@
 import { expect, test } from "@playwright/test";
 import { createContentEnhancementController } from "../../src/runtime/content-enhancement-controller.js";
 import { createEventScope } from "../../src/runtime/controller-lifecycle.js";
-import { createMermaidController, resolveMermaidConfig } from "../../src/runtime/mermaid-controller.js";
+import {
+  createMermaidController,
+  resolveMermaidConfig,
+} from "../../src/runtime/mermaid-controller.js";
 import { loadInitialViewData } from "../../src/runtime/runtime-bootstrap.js";
 import {
   createSettingsController,
@@ -226,7 +229,10 @@ function createFakeDocument() {
   const appRoot = new FakeElement();
   const viewer = new FakeElement();
   const inputs = {
-    menu: [Object.assign(new FakeInput(), { value: "left" }), Object.assign(new FakeInput(), { value: "right" })],
+    menu: [
+      Object.assign(new FakeInput(), { value: "left" }),
+      Object.assign(new FakeInput(), { value: "right" }),
+    ],
     theme: [
       Object.assign(new FakeInput(), { value: "system" }),
       Object.assign(new FakeInput(), { value: "light" }),
@@ -288,9 +294,15 @@ test.describe("runtime controller module contracts", () => {
       windowRef: createFakeWindow(),
       clipboard: { async writeText() {} },
       mermaidController: {
-        setup() { calls.setup += 1; },
-        destroy() { calls.destroy += 1; },
-        async render() { calls.render += 1; },
+        setup() {
+          calls.setup += 1;
+        },
+        destroy() {
+          calls.destroy += 1;
+        },
+        async render() {
+          calls.render += 1;
+        },
       },
     });
 
@@ -389,7 +401,9 @@ test.describe("runtime controller module contracts", () => {
           treePathToRoute: new Map(),
         },
       },
-      setActiveBranch() { return true; },
+      setActiveBranch() {
+        return true;
+      },
     };
     const controller = createTreeController({
       navigation,
@@ -418,16 +432,18 @@ test.describe("runtime controller module contracts", () => {
     expect(normalizeThemeMode("unexpected")).toBe("system");
     expect(resolveAppliedTheme("system", true)).toBe("dark");
     expect(clampDesktopSidebarWidth(900, 1200)).toBe(510);
-    expect(resolveMermaidConfig({ mermaid: { cdnUrl: "", theme: "bad theme" } }))
-      .toMatchObject({
-        enabled: true,
-        cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
-        theme: "default",
-      });
-    const mermaid = createMermaidController({ enabled: false, cdnUrl: "/mermaid.js", theme: "default" }, {
-      documentRef: {},
-      windowRef: {},
+    expect(resolveMermaidConfig({ mermaid: { cdnUrl: "", theme: "bad theme" } })).toMatchObject({
+      enabled: true,
+      cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
+      theme: "default",
     });
+    const mermaid = createMermaidController(
+      { enabled: false, cdnUrl: "/mermaid.js", theme: "default" },
+      {
+        documentRef: {},
+        windowRef: {},
+      },
+    );
     expect(typeof mermaid.setup).toBe("function");
     expect(typeof mermaid.destroy).toBe("function");
 

--- a/tests/e2e/runtime-navigation-controller.spec.ts
+++ b/tests/e2e/runtime-navigation-controller.spec.ts
@@ -115,7 +115,12 @@ test.describe("runtime navigation contracts", () => {
       content: new ListenerElement(),
       backlinks,
       nav,
-      viewer: { scrollToCalls: 0, scrollTo() { this.scrollToCalls += 1; } },
+      viewer: {
+        scrollToCalls: 0,
+        scrollTo() {
+          this.scrollToCalls += 1;
+        },
+      },
     };
     const pushed: string[] = [];
     const announcements: string[] = [];
@@ -139,12 +144,20 @@ test.describe("runtime navigation contracts", () => {
         documentTitle: (title: string, siteTitle: string) => `${title} - ${siteTitle}`,
       },
       lifecycle: {
-        async enhanceContent() { enhanced += 1; },
-        announce(message: string) { announcements.push(message); },
+        async enhanceContent() {
+          enhanced += 1;
+        },
+        announce(message: string) {
+          announcements.push(message);
+        },
       },
       fetchContent: async (url: string) => ({ ok: true, text: async () => `content:${url}` }),
-      historyApi: { pushState: (_state: unknown, _unused: string, url: string) => pushed.push(url) },
-      setPageTitle: (value: string) => { pageTitle = value; },
+      historyApi: {
+        pushState: (_state: unknown, _unused: string, url: string) => pushed.push(url),
+      },
+      setPageTitle: (value: string) => {
+        pageTitle = value;
+      },
     });
 
     controller.setup();
@@ -168,7 +181,9 @@ test.describe("runtime navigation contracts", () => {
     expect(backlinks.removed).toEqual(["click"]);
   });
 
-  test("browser back/forward는 content controller의 popstate lifecycle을 따른다", async ({ page }) => {
+  test("browser back/forward는 content controller의 popstate lifecycle을 따른다", async ({
+    page,
+  }) => {
     await page.goto("/BC-VO-00/");
     await waitForAppReady(page);
 
@@ -184,13 +199,17 @@ test.describe("runtime navigation contracts", () => {
     });
 
     await nextLink.click();
-    await expect(page).toHaveURL(new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+    await expect(page).toHaveURL(
+      new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+    );
 
     await page.goBack();
     await expect(page).toHaveURL(/\/BC-VO-00\/$/);
     await expect(page.locator("#viewer-title")).toHaveText("About");
 
     await page.goForward();
-    await expect(page).toHaveURL(new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+    await expect(page).toHaveURL(
+      new RegExp(`${nextRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+    );
   });
 });

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -30,11 +30,15 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     await expect(treeXssRow).toBeVisible();
     await expect(treeXssRow.locator("img")).toHaveCount(0);
 
-    const xssFlag = await page.evaluate(() => (window as Window & { __xss_title?: number }).__xss_title ?? 0);
+    const xssFlag = await page.evaluate(
+      () => (window as Window & { __xss_title?: number }).__xss_title ?? 0,
+    );
     expect(xssFlag).toBe(0);
   });
 
-  test("raw HTML은 직접 route와 client navigation에서 같은 정책으로 sanitize된다", async ({ page }) => {
+  test("raw HTML은 직접 route와 client navigation에서 같은 정책으로 sanitize된다", async ({
+    page,
+  }) => {
     await page.addInitScript(() => {
       const target = window as Window & {
         __raw_script?: number;
@@ -49,11 +53,16 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     });
 
     const assertSanitizedContent = async () => {
-      await expect(page.locator("#viewer-content .raw-html-safe strong")).toHaveText("Allowed raw formatting");
+      await expect(page.locator("#viewer-content .raw-html-safe strong")).toHaveText(
+        "Allowed raw formatting",
+      );
       await expect(page.locator("#viewer-content script")).toHaveCount(0);
       await expect(page.locator("#viewer-content iframe")).toHaveCount(0);
       await expect(page.locator("#viewer-content [onerror]")).toHaveCount(0);
-      await expect(page.locator("#viewer-content .raw-html-url")).not.toHaveAttribute("href", /javascript:/i);
+      await expect(page.locator("#viewer-content .raw-html-url")).not.toHaveAttribute(
+        "href",
+        /javascript:/i,
+      );
       await expect(page.locator("#viewer-content .raw-html-xmp")).toHaveCount(0);
       await expect(page.locator("#viewer-content")).not.toContainText("XMP_RAW_TEXT_SECRET");
 

--- a/tests/e2e/shiki-loading.spec.ts
+++ b/tests/e2e/shiki-loading.spec.ts
@@ -43,7 +43,7 @@ test.describe("fine-grained Shiki loading", () => {
 
     const selectedThemeRenderer = await createMarkdownRenderer(buildOptions("nord"));
     const selectedThemeResult = await selectedThemeRenderer.render(
-      "```json\n{\"answer\": 42}\n```",
+      '```json\n{"answer": 42}\n```',
       resolver,
     );
     expect(selectedThemeResult.html).toContain('class="shiki nord"');

--- a/tests/e2e/tree-adapter.spec.ts
+++ b/tests/e2e/tree-adapter.spec.ts
@@ -87,7 +87,9 @@ test.describe("Trees sidebar adapter", () => {
       "engineering/guides/BC-VO-02 Setup Guide",
     ]);
     expect(adapter.treePathToDocId.get("Recent/BC-VO-02 Setup Guide")).toBe("doc-a");
-    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide")).toBe("/BC-VO-02/");
+    expect(adapter.treePathToRoute.get("engineering/guides/BC-VO-02 Setup Guide")).toBe(
+      "/BC-VO-02/",
+    );
     expect(adapter.docIdToTreePaths.get("doc-a")).toEqual([
       "PINNED/BC-VO-02 Setup Guide",
       "Recent/BC-VO-02 Setup Guide",

--- a/tests/e2e/tree-icon-payload.spec.ts
+++ b/tests/e2e/tree-icon-payload.spec.ts
@@ -13,7 +13,9 @@ const MINIMAL_TREE_ICON_IDS = [
 
 test.describe("minimal Trees icon payload", () => {
   test("beta dependency를 exact version으로 유지한다", () => {
-    const packageJson = JSON.parse(fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"));
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(process.cwd(), "package.json"), "utf8"),
+    );
     const lockfile = fs.readFileSync(path.join(process.cwd(), "bun.lock"), "utf8");
 
     expect(packageJson.dependencies["@pierre/trees"]).toBe("1.0.0-beta.4");
@@ -21,7 +23,9 @@ test.describe("minimal Trees icon payload", () => {
     expect(lockfile).toContain('"@pierre/trees@1.0.0-beta.4"');
   });
 
-  test("generic icon만 사용하면서 keyboard, virtualization, selection, ARIA 동작을 유지한다", async ({ page }) => {
+  test("generic icon만 사용하면서 keyboard, virtualization, selection, ARIA 동작을 유지한다", async ({
+    page,
+  }) => {
     await page.goto("/BC-VO-00/");
     await waitForAppReady(page);
     await waitForTreeReady(page);
@@ -38,8 +42,13 @@ test.describe("minimal Trees icon payload", () => {
       return {
         builtInFileIconCount: root?.querySelectorAll('[id^="file-tree-builtin-"]').length ?? -1,
         fileIconUses,
-        hasVirtualScroller: Boolean(root?.querySelector('[data-file-tree-virtualized-scroll="true"]')),
-        iconIds: Array.from(root?.querySelectorAll("svg[data-icon-sprite] symbol") ?? [], (icon) => icon.id).sort(),
+        hasVirtualScroller: Boolean(
+          root?.querySelector('[data-file-tree-virtualized-scroll="true"]'),
+        ),
+        iconIds: Array.from(
+          root?.querySelectorAll("svg[data-icon-sprite] symbol") ?? [],
+          (icon) => icon.id,
+        ).sort(),
         selectedAriaLabel: selected?.getAttribute("aria-label") ?? "",
         selectedAriaLevel: selected?.getAttribute("aria-level") ?? "",
         selectedPath: selected?.getAttribute("data-item-path") ?? "",
@@ -57,9 +66,9 @@ test.describe("minimal Trees icon payload", () => {
     expect(Number(state.selectedAriaLevel)).toBeGreaterThan(0);
     expect(state.hasVirtualScroller).toBe(true);
 
-    const selectedRow = page.locator(
-      '#tree-root [role="treeitem"][aria-selected="true"][data-item-path]',
-    ).first();
+    const selectedRow = page
+      .locator('#tree-root [role="treeitem"][aria-selected="true"][data-item-path]')
+      .first();
     await selectedRow.focus();
     const beforePath = await selectedRow.getAttribute("data-item-path");
     await page.keyboard.press("ArrowDown");

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -12,7 +12,9 @@ test.describe("Trees sidebar search", () => {
     const searchClear = page.locator("#tree-search-clear");
     const searchNext = page.locator("#tree-search-next");
     const setupRow = page
-      .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]')
+      .locator(
+        '#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]',
+      )
       .first();
 
     await expect(searchInput).toBeVisible();
@@ -33,7 +35,9 @@ test.describe("Trees sidebar search", () => {
 
     await searchNext.click();
     await expect(
-      page.locator('#tree-root [data-type="item"][data-item-type="file"][data-item-focused="true"]').first(),
+      page
+        .locator('#tree-root [data-type="item"][data-item-type="file"][data-item-focused="true"]')
+        .first(),
     ).toContainText("Unsafe");
 
     await unsafeRow.click();

--- a/tests/e2e/utils/app-ready.ts
+++ b/tests/e2e/utils/app-ready.ts
@@ -7,7 +7,9 @@ export async function waitForAppReady(page: Page): Promise<void> {
   let lastState: string | null = null;
 
   while (Date.now() < deadline) {
-    const state = await page.evaluate(() => document.documentElement.getAttribute("data-app-ready"));
+    const state = await page.evaluate(() =>
+      document.documentElement.getAttribute("data-app-ready"),
+    );
     lastState = state;
 
     if (state === "ready") {
@@ -15,7 +17,9 @@ export async function waitForAppReady(page: Page): Promise<void> {
     }
 
     if (state === "error") {
-      throw new Error(`앱 초기화 실패 상태를 감지했습니다. data-app-ready=error, url=${page.url()}`);
+      throw new Error(
+        `앱 초기화 실패 상태를 감지했습니다. data-app-ready=error, url=${page.url()}`,
+      );
     }
 
     await page.waitForTimeout(pollIntervalMs);
@@ -34,7 +38,9 @@ export async function waitForTreeReady(page: Page): Promise<void> {
   let lastState: string | null = null;
 
   while (Date.now() < deadline) {
-    const state = await page.evaluate(() => document.documentElement.getAttribute("data-tree-runtime"));
+    const state = await page.evaluate(() =>
+      document.documentElement.getAttribute("data-tree-runtime"),
+    );
     lastState = state;
 
     if (state === "ready") {
@@ -42,7 +48,9 @@ export async function waitForTreeReady(page: Page): Promise<void> {
     }
 
     if (state === "error") {
-      throw new Error(`트리 초기화 실패 상태를 감지했습니다. data-tree-runtime=error, url=${page.url()}`);
+      throw new Error(
+        `트리 초기화 실패 상태를 감지했습니다. data-tree-runtime=error, url=${page.url()}`,
+      );
     }
 
     await page.waitForTimeout(pollIntervalMs);

--- a/tests/e2e/view-contract.spec.ts
+++ b/tests/e2e/view-contract.spec.ts
@@ -78,12 +78,8 @@ test.describe("shared SSR/client view contract", () => {
       createdAt: "2026-07-19 01:30",
       tags: ["alpha", "<beta>"],
     });
-    expect(model.navigation.previous?.href).toBe(
-      "/docs%20%ED%95%9C%EA%B8%80/Previous/",
-    );
-    expect(model.backlinks[0].href).toBe(
-      "/docs%20%ED%95%9C%EA%B8%80/Back%20link/",
-    );
+    expect(model.navigation.previous?.href).toBe("/docs%20%ED%95%9C%EA%B8%80/Previous/");
+    expect(model.backlinks[0].href).toBe("/docs%20%ED%95%9C%EA%B8%80/Back%20link/");
     expect(rendered.breadcrumbHtml).toContain("Unsafe &lt;route&gt;");
     expect(rendered.metaHtml).toContain("P&lt;1&gt;");
     expect(rendered.backlinksHtml).toContain('&lt;img src=x onerror="alert(1)"&gt;');
@@ -91,9 +87,7 @@ test.describe("shared SSR/client view contract", () => {
     expect(formatViewDateTime("invalid")).toBeNull();
     expect(formatViewDateTime("2024-09-20T09:30:00")).toBe("2024-09-20 09:30");
     expect(normalizeViewTags("not-an-array")).toEqual([]);
-    expect(toViewPathWithBase("/A B/", "/docs 한글")).toBe(
-      "/docs%20%ED%95%9C%EA%B8%80/A%20B/",
-    );
+    expect(toViewPathWithBase("/A B/", "/docs 한글")).toBe("/docs%20%ED%95%9C%EA%B8%80/A%20B/");
     expect(composeViewDocumentTitle("Current", "Site")).toBe("Current - Site");
   });
 
@@ -156,9 +150,7 @@ test.describe("shared SSR/client view contract", () => {
       "base",
       "dev",
     ]);
-    expect(filterViewDocsByBranch(docs, "main", "dev").map((doc) => doc.id)).toEqual([
-      "main",
-    ]);
+    expect(filterViewDocsByBranch(docs, "main", "dev").map((doc) => doc.id)).toEqual(["main"]);
     expect(pickViewHomeRoute(filterViewDocsByBranch(docs, "dev", "dev"))).toBe("/DEV/");
 
     const mainDoc = {
@@ -257,9 +249,7 @@ Main-only content.
         docId: "main-only",
         title: "Main Only",
       });
-      expect(indexHtml).toContain(
-        '<h1 id="viewer-title" class="viewer-title">Main Only</h1>',
-      );
+      expect(indexHtml).toContain('<h1 id="viewer-title" class="viewer-title">Main Only</h1>');
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }
@@ -298,7 +288,10 @@ Main-only content.
     }
   });
 
-  test("direct-load와 client-navigation의 chrome snapshot이 동일하다", async ({ page, context }) => {
+  test("direct-load와 client-navigation의 chrome snapshot이 동일하다", async ({
+    page,
+    context,
+  }) => {
     await page.goto("/BC-VO-00/");
     await waitForAppReady(page);
 
@@ -314,7 +307,9 @@ Main-only content.
     const directSnapshot = await readChromeSnapshot(directPage);
 
     await link.click();
-    await expect(page).toHaveURL(new RegExp(`${targetRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`));
+    await expect(page).toHaveURL(
+      new RegExp(`${targetRoute.replace(/[.*+?^${}()|[\]\\]/g, "\\$&")}$`),
+    );
     await expect(page.locator("#viewer-title")).toHaveText(directSnapshot.title ?? "");
     const clientSnapshot = await readChromeSnapshot(page);
 

--- a/tests/unit/cache-guards.test.ts
+++ b/tests/unit/cache-guards.test.ts
@@ -1,0 +1,75 @@
+import { afterEach, describe, expect, test } from "bun:test";
+import fs from "node:fs/promises";
+import os from "node:os";
+import path from "node:path";
+import { inspectBuildStorage } from "../../src/build/storage";
+import type { BuildOptions } from "../../src/types";
+
+const temporaryRoots: string[] = [];
+
+afterEach(async () => {
+  await Promise.all(
+    temporaryRoots.splice(0).map((temporaryRoot) =>
+      fs.rm(temporaryRoot, {
+        force: true,
+        recursive: true,
+      }),
+    ),
+  );
+});
+
+async function createTemporaryRoot(): Promise<string> {
+  const temporaryRoot = await fs.mkdtemp(path.join(os.tmpdir(), "eiam-cache-unit-"));
+  temporaryRoots.push(temporaryRoot);
+  return temporaryRoot;
+}
+
+function createBuildOptions(vaultDir: string, outDir: string): BuildOptions {
+  return {
+    allowUnsafeHtml: false,
+    exclude: [],
+    gfm: true,
+    imagePolicy: "omit-local",
+    mermaid: {
+      cdnUrl: "https://example.test/mermaid.js",
+      enabled: true,
+      theme: "default",
+    },
+    newWithinDays: 7,
+    outDir,
+    pinnedMenu: null,
+    recentLimit: 5,
+    seo: null,
+    shikiTheme: "github-dark",
+    staticPaths: [],
+    vaultDir,
+    wikilinks: true,
+  };
+}
+
+describe("build storage guards", () => {
+  test("rejects an output directory that contains the vault before mutation", async () => {
+    const temporaryRoot = await createTemporaryRoot();
+    const vaultDir = path.join(temporaryRoot, "vault");
+    await fs.mkdir(vaultDir);
+
+    await expect(inspectBuildStorage(createBuildOptions(vaultDir, temporaryRoot))).rejects.toThrow(
+      "[safety] Refusing dangerous output directory",
+    );
+    expect(await fs.readdir(vaultDir)).toEqual([]);
+  });
+
+  test("inspection derives an isolated cache namespace without claiming output", async () => {
+    const temporaryRoot = await createTemporaryRoot();
+    const vaultDir = path.join(temporaryRoot, "vault");
+    const outDir = path.join(temporaryRoot, "site");
+    await fs.mkdir(vaultDir);
+
+    const storage = await inspectBuildStorage(createBuildOptions(vaultDir, outDir));
+
+    expect(storage.cacheLocation.namespace).toMatch(/^v2-[a-f0-9]{40}$/);
+    expect(storage.outputRoot).toBe(outDir);
+    expect(await Bun.file(outDir).exists()).toBe(false);
+    expect(await Bun.file(storage.cacheLocation.cachePath).exists()).toBe(false);
+  });
+});

--- a/tests/unit/config.test.ts
+++ b/tests/unit/config.test.ts
@@ -1,0 +1,63 @@
+import { describe, expect, test } from "bun:test";
+import { parseCliArgs } from "../../src/config";
+
+describe("CLI parsing", () => {
+  test("parses the command and every value-bearing option", () => {
+    expect(
+      parseCliArgs([
+        "dev",
+        "--vault",
+        "./vault",
+        "--out",
+        "./site",
+        "--exclude",
+        "drafts/**",
+        "--exclude",
+        "private/**",
+        "--new-within-days",
+        "0",
+        "--recent-limit",
+        "10",
+        "--menu-config",
+        "./menu.json",
+        "--port",
+        "4173",
+      ]),
+    ).toEqual({
+      command: "dev",
+      exclude: ["drafts/**", "private/**"],
+      help: false,
+      menuConfigPath: "./menu.json",
+      newWithinDays: 0,
+      outDir: "./site",
+      port: 4173,
+      recentLimit: 10,
+      vaultDir: "./vault",
+    });
+  });
+
+  test("defaults to build when the first token is an option", () => {
+    expect(parseCliArgs(["--vault", "./notes"])).toMatchObject({
+      command: "build",
+      vaultDir: "./notes",
+    });
+  });
+
+  for (const option of [
+    "--vault",
+    "--out",
+    "--exclude",
+    "--new-within-days",
+    "--recent-limit",
+    "--menu-config",
+    "--port",
+  ]) {
+    test(`rejects a missing ${option} value`, () => {
+      expect(() => parseCliArgs(["build", option])).toThrow(`[cli] Missing value for ${option}`);
+    });
+  }
+
+  test("rejects unknown options at the parsing boundary", () => {
+    expect(() => parseCliArgs(["build", "--unknown"])).toThrow("Unknown option: --unknown");
+  });
+});

--- a/tests/unit/manifest-adapter.test.ts
+++ b/tests/unit/manifest-adapter.test.ts
@@ -1,0 +1,98 @@
+import { describe, expect, test } from "bun:test";
+import {
+  getManifestDocs,
+  getRuntimeManifestDocs,
+  normalizeManifestPayload,
+} from "../../src/runtime/manifest-adapter";
+
+const envelope = {
+  branches: ["dev"],
+  defaultBranch: "dev",
+  mermaid: { cdnUrl: "/mermaid.js", enabled: true, theme: "default" },
+  pathBase: "",
+  routeMap: { "/A/": "a", "/B/": "b" },
+  schemaVersion: 2,
+  siteTitle: "Unit Test",
+  tree: [],
+  ui: { newWithinDays: 7, recentLimit: 5 },
+};
+
+describe("manifest transforms", () => {
+  test("preserves canonical schema-v2 document order", () => {
+    const manifest = normalizeManifestPayload({
+      ...envelope,
+      docIds: ["b", "a"],
+      docsById: {
+        a: {
+          branch: null,
+          categoryPath: "guide",
+          contentUrl: "/a.html",
+          id: "a",
+          route: "/A/",
+          tags: [],
+          title: "A",
+          wikiTargets: [],
+          backlinks: [],
+        },
+        b: {
+          branch: null,
+          categoryPath: "guide",
+          contentUrl: "/b.html",
+          id: "b",
+          route: "/B/",
+          tags: [],
+          title: "B",
+          wikiTargets: [],
+          backlinks: [],
+        },
+      },
+    });
+
+    expect(manifest).not.toBeNull();
+    expect(getManifestDocs(manifest).map((doc) => doc.id)).toEqual(["b", "a"]);
+  });
+
+  test("migrates legacy arrays and derives runtime NEW state", () => {
+    const manifest = normalizeManifestPayload({
+      ...envelope,
+      docs: [
+        {
+          branch: null,
+          categoryPath: "guide",
+          contentUrl: "/a.html",
+          date: "2026-07-15",
+          id: "a",
+          route: "/A/",
+          tags: [],
+          title: "A",
+          wikiTargets: [],
+          backlinks: [],
+        },
+      ],
+      schemaVersion: 1,
+    });
+
+    expect(manifest?.schemaVersion).toBe(2);
+    expect(manifest?.docIds).toEqual(["a"]);
+    expect(getRuntimeManifestDocs(manifest, Date.parse("2026-07-19T00:00:00Z"))[0]?.isNew).toBe(
+      true,
+    );
+  });
+
+  test("rejects dangling, duplicate, and unsupported document indexes", () => {
+    expect(normalizeManifestPayload({ ...envelope, docIds: ["missing"], docsById: {} })).toBeNull();
+    expect(
+      normalizeManifestPayload({
+        ...envelope,
+        docs: [
+          { id: "same", route: "/A/" },
+          { id: "same", route: "/B/" },
+        ],
+        schemaVersion: 1,
+      }),
+    ).toBeNull();
+    expect(
+      normalizeManifestPayload({ ...envelope, docIds: [], docsById: {}, schemaVersion: 99 }),
+    ).toBeNull();
+  });
+});

--- a/tests/unit/paths-routes.test.ts
+++ b/tests/unit/paths-routes.test.ts
@@ -1,0 +1,37 @@
+import { describe, expect, test } from "bun:test";
+import { buildExcluder, slugifySegment, stripMdExt, toDocId, toRoute } from "../../src/utils";
+import {
+  normalizeViewPathBase,
+  normalizeViewPathname,
+  normalizeViewRoute,
+  stripViewPathBase,
+  toViewPathWithBase,
+} from "../../src/view-contract";
+
+describe("path and route normalization", () => {
+  test("derives stable document identifiers from Markdown paths", () => {
+    expect(stripMdExt("guides/Setup.MD")).toBe("guides/Setup");
+    expect(toDocId("guides/Setup")).toBe("guides__Setup");
+  });
+
+  test("normalizes Unicode slugs, punctuation, whitespace, and empty segments", () => {
+    expect(slugifySegment(" Alice's  시작_문서! ")).toBe("alices-시작-문서");
+    expect(slugifySegment("---")).toBe("untitled");
+    expect(toRoute(" Guides/Alice's  시작_문서! ")).toBe("/guides/alices-시작-문서/");
+  });
+
+  test("normalizes, strips, and reapplies encoded deployment base paths", () => {
+    expect(normalizeViewPathname("docs%20guides//한글")).toBe("/docs guides/한글");
+    expect(normalizeViewRoute("guide")).toBe("/guide/");
+    expect(normalizeViewPathBase(" docs guides/한글/ ")).toBe("/docs guides/한글");
+    expect(stripViewPathBase("/docs/guide/", "/docs")).toBe("/guide/");
+    expect(toViewPathWithBase("/A B/", "/docs")).toBe("/docs/A%20B/");
+  });
+
+  test("applies the same exclusion patterns to files and directories", () => {
+    const isExcluded = buildExcluder([".obsidian/**", "drafts/**"]);
+    expect(isExcluded(".obsidian/plugins/config.json", false)).toBe(true);
+    expect(isExcluded("drafts", true)).toBe(true);
+    expect(isExcluded("published/post.md", false)).toBe(false);
+  });
+});

--- a/tests/unit/sanitization.test.ts
+++ b/tests/unit/sanitization.test.ts
@@ -1,0 +1,28 @@
+import { describe, expect, test } from "bun:test";
+import { sanitizeMarkdownHtml } from "../../src/markdown";
+
+describe("rendered Markdown sanitization", () => {
+  test("removes executable markup while preserving supported document structure", () => {
+    const safe = sanitizeMarkdownHtml(`
+      <details open onclick="alert(1)">
+        <summary>Read me</summary>
+        <a href="javascript:alert(2)">unsafe</a>
+        <img src="/asset.png" onerror="alert(3)">
+        <script>alert(4)</script>
+      </details>
+    `);
+
+    expect(safe).toContain("<details open>");
+    expect(safe).toContain("<summary>Read me</summary>");
+    expect(safe).toContain('<img src="/asset.png" />');
+    expect(safe).not.toContain("onclick");
+    expect(safe).not.toContain("onerror");
+    expect(safe).not.toContain("javascript:");
+    expect(safe).not.toContain("<script");
+  });
+
+  test("returns authored HTML unchanged only for the explicit unsafe policy", () => {
+    const authored = '<span onclick="trusted()">trusted vault</span>';
+    expect(sanitizeMarkdownHtml(authored, true)).toBe(authored);
+  });
+});

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -14,5 +14,5 @@
     "lib": ["ESNext", "DOM", "DOM.Iterable"],
     "types": ["bun-types"]
   },
-  "include": ["src/**/*"]
+  "include": ["src/**/*", "scripts/**/*.ts", "tests/unit/**/*.ts"]
 }


### PR DESCRIPTION
## Summary
- add reproducible ESLint and Prettier source gates with a formatted repository baseline
- add 21 fast Bun unit tests for CLI parsing, paths/routes, cache guards, manifest transforms, and HTML sanitization
- typecheck scripts and unit tests in addition to source/runtime modules
- split lint, formatting, typecheck, unit, build, and E2E into distinct CI failures before browser setup where possible
- document unit/E2E responsibilities and opt-in Bun coverage without a numeric threshold

## Validation
- bun install --frozen-lockfile
- bun run lint:source
- bun run format:check
- bun run typecheck
- bun run test:unit (21 passed)
- bun run test:unit:coverage
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size
- bun run check:reproducible
- bun run test:e2e (81 passed)

Part of #34