### PR TITLE
refactor: share publication scanner

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -71,6 +71,13 @@ bun run lint:md:publish -- --out-dir ./reports --strict
 - `--vault <path>`: Markdown 루트 디렉터리 재지정 (선택)
 - `--exclude <glob>`: 제외 패턴 추가 (반복 가능)
 
+build와 같은 vault scanner, 제외 규칙, frontmatter parser를 사용하므로 `publish: true`이고
+draft가 아니며 `prefix`와 `category_path`가 모두 있는 문서만 동일하게 선택합니다. JSON
+리포트는 잘못된 publication metadata와 frontmatter parse 진단을 `publicationDiagnostics`에,
+Markdown 규칙 위반을 `markdownStyleIssues`에 분리하고, 호환용 통합 `issues`도 제공합니다.
+publication metadata 진단은 warning이지만 `--strict`에서는 Markdown style finding이나 parse
+error와 마찬가지로 종료 코드 `1`을 반환합니다.
+
 ## 개발 품질 검사
 
 브라우저 설치나 E2E 실행 전에 빠른 source gate를 로컬에서 그대로 실행할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -580,11 +580,16 @@ Options:
 
 What it checks:
 
-- only notes with `publish: true`
-- skips docs missing `prefix`
+- uses the same vault scanner, exclusions, and frontmatter parser as the build
+- selects only `publish: true`, non-draft notes that have both `prefix` and `category_path`
+- reports malformed frontmatter and missing publication metadata separately from Markdown style findings
 - runs `markdownlint`
 - adds a custom rule that forbids H1 in the Markdown body after frontmatter
-- writes a JSON report file
+- writes a JSON report with `targetFiles`, `publicationDiagnostics`, `markdownStyleIssues`, and a backward-compatible combined `issues` list
+
+Publication metadata diagnostics are warnings in the report, while frontmatter parse and Markdown
+style findings are errors. `--strict` exits with status `1` when any of those diagnostics or findings
+exists, including a publication warning.
 
 ## Example Vault
 

--- a/scripts/lint-published-markdown.ts
+++ b/scripts/lint-published-markdown.ts
@@ -2,10 +2,13 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { createRequire } from "node:module";
-import matter from "gray-matter";
 import { lint as lintMarkdown } from "markdownlint/promise";
 import { loadUserConfig, resolveBuildOptions, type CliArgs } from "../src/config";
-import { buildExcluder, relativePosix } from "../src/utils";
+import {
+  formatPublicationDiagnostic,
+  scanPublicationTargets,
+  type PublicationDiagnostic,
+} from "../src/publication";
 
 const require = createRequire(import.meta.url);
 const lintConfigModule = require("../.markdownlint.cjs") as { config: Record<string, unknown> };
@@ -25,24 +28,18 @@ interface LintCliArgs {
 }
 
 interface TargetDoc {
-  absPath: string;
   relPath: string;
   raw: string;
 }
 
 interface LintIssue {
+  category: "publication" | "markdown-style";
   file: string;
   line: number;
   column: number;
   rule: string;
   message: string;
-  severity: "error";
-}
-
-interface TargetScanResult {
-  docs: TargetDoc[];
-  issues: LintIssue[];
-  skippedWithoutPrefix: string[];
+  severity: "error" | "warning";
 }
 
 function printHelp(): void {
@@ -106,76 +103,6 @@ function parseCliArgs(argv: string[]): LintCliArgs {
   return parsed;
 }
 
-async function walkMarkdownFiles(
-  rootDir: string,
-  currentDir: string,
-  isExcluded: (relPath: string, isDirectory: boolean) => boolean,
-  output: string[],
-): Promise<void> {
-  const entries = await fs.readdir(currentDir, { withFileTypes: true });
-  for (const entry of entries) {
-    const absPath = path.join(currentDir, entry.name);
-    const relPath = relativePosix(rootDir, absPath);
-    if (isExcluded(relPath, entry.isDirectory())) {
-      continue;
-    }
-    if (entry.isDirectory()) {
-      await walkMarkdownFiles(rootDir, absPath, isExcluded, output);
-      continue;
-    }
-    if (entry.isFile() && /\.md$/i.test(entry.name)) {
-      output.push(absPath);
-    }
-  }
-}
-
-async function collectPublishedDocs(
-  vaultDir: string,
-  excludePatterns: string[],
-): Promise<TargetScanResult> {
-  const files: string[] = [];
-  const issues: LintIssue[] = [];
-  const skippedWithoutPrefix: string[] = [];
-  const isExcluded = buildExcluder(excludePatterns);
-  await walkMarkdownFiles(vaultDir, vaultDir, isExcluded, files);
-  files.sort((left, right) => left.localeCompare(right, "ko-KR"));
-
-  const docs: TargetDoc[] = [];
-  for (const absPath of files) {
-    const relPath = relativePosix(vaultDir, absPath);
-    const raw = await Bun.file(absPath).text();
-
-    let parsed: matter.GrayMatterFile<string>;
-    try {
-      parsed = matter(raw);
-    } catch (error) {
-      issues.push({
-        file: relPath,
-        line: 1,
-        column: 1,
-        rule: "frontmatter/parse",
-        message: `Frontmatter parse failed: ${(error as Error).message}`,
-        severity: "error",
-      });
-      continue;
-    }
-
-    if (parsed.data.publish !== true || parsed.data.draft === true) {
-      continue;
-    }
-    const hasPrefix =
-      typeof parsed.data.prefix === "string" && parsed.data.prefix.trim().length > 0;
-    if (!hasPrefix) {
-      skippedWithoutPrefix.push(relPath);
-      continue;
-    }
-
-    docs.push({ absPath, relPath, raw });
-  }
-
-  return { docs, issues, skippedWithoutPrefix };
-}
-
 function findFrontmatterEndLine(lines: string[]): number {
   if (lines.length === 0 || lines[0].trim() !== "---") {
     return 0;
@@ -217,6 +144,7 @@ function collectBodyH1Issues(doc: TargetDoc): LintIssue[] {
     const trimmedStart = line.trimStart();
     if (!trimmedStart.startsWith("\\#") && ATX_H1_RE.test(line)) {
       issues.push({
+        category: "markdown-style",
         file: doc.relPath,
         line: i + 1,
         column: 1,
@@ -230,6 +158,7 @@ function collectBodyH1Issues(doc: TargetDoc): LintIssue[] {
       const next = lines[i + 1];
       if (line.trim().length > 0 && SETEXT_H1_UNDERLINE_RE.test(next.trim())) {
         issues.push({
+          category: "markdown-style",
           file: doc.relPath,
           line: i + 2,
           column: 1,
@@ -265,6 +194,7 @@ function mapMarkdownlintIssues(
           : "";
 
       issues.push({
+        category: "markdown-style",
         file,
         line,
         column,
@@ -275,6 +205,18 @@ function mapMarkdownlintIssues(
     }
   }
   return issues;
+}
+
+function mapPublicationDiagnostics(diagnostics: PublicationDiagnostic[]): LintIssue[] {
+  return diagnostics.map((diagnostic) => ({
+    category: "publication",
+    file: diagnostic.file,
+    line: diagnostic.line,
+    column: diagnostic.column,
+    rule: diagnostic.code,
+    message: diagnostic.message,
+    severity: diagnostic.severity,
+  }));
 }
 
 function sortIssues(issues: LintIssue[]): LintIssue[] {
@@ -309,11 +251,15 @@ async function main(): Promise<void> {
   };
   const buildOptions = resolveBuildOptions(buildCli, userConfig, null);
 
-  const scanResult = await collectPublishedDocs(buildOptions.vaultDir, buildOptions.exclude);
-  const lintStrings = Object.fromEntries(scanResult.docs.map((doc) => [doc.relPath, doc.raw]));
+  const scanResult = await scanPublicationTargets(buildOptions.vaultDir, buildOptions.exclude);
+  const targetDocs: TargetDoc[] = scanResult.targets.map(({ source }) => ({
+    relPath: source.relPath,
+    raw: source.raw,
+  }));
+  const lintStrings = Object.fromEntries(targetDocs.map((doc) => [doc.relPath, doc.raw]));
 
   const lintResults =
-    scanResult.docs.length > 0
+    targetDocs.length > 0
       ? ((await lintMarkdown({
           strings: lintStrings,
           config: lintConfigModule.config,
@@ -322,8 +268,19 @@ async function main(): Promise<void> {
       : {};
 
   const markdownlintIssues = mapMarkdownlintIssues(lintResults);
-  const bodyHeadingIssues = scanResult.docs.flatMap((doc) => collectBodyH1Issues(doc));
-  const allIssues = sortIssues([...scanResult.issues, ...markdownlintIssues, ...bodyHeadingIssues]);
+  const bodyHeadingIssues = targetDocs.flatMap((doc) => collectBodyH1Issues(doc));
+  const publicationIssues = sortIssues(mapPublicationDiagnostics(scanResult.diagnostics));
+  const markdownStyleIssues = sortIssues([...markdownlintIssues, ...bodyHeadingIssues]);
+  const allIssues = sortIssues([...publicationIssues, ...markdownStyleIssues]);
+  const missingPrefixCount = scanResult.diagnostics.filter(
+    ({ code }) => code === "publication/missing-prefix",
+  ).length;
+  const missingCategoryPathCount = scanResult.diagnostics.filter(
+    ({ code }) => code === "publication/missing-category-path",
+  ).length;
+  const frontmatterParseErrorCount = scanResult.diagnostics.filter(
+    ({ code }) => code === "frontmatter/parse",
+  ).length;
 
   const outDir = path.resolve(process.cwd(), cli.outDir);
   await fs.mkdir(outDir, { recursive: true });
@@ -332,21 +289,29 @@ async function main(): Promise<void> {
   const report = {
     generatedAt: new Date().toISOString(),
     vaultDir: buildOptions.vaultDir,
-    targetCount: scanResult.docs.length,
-    skippedWithoutPrefixCount: scanResult.skippedWithoutPrefix.length,
+    targetCount: targetDocs.length,
+    targetFiles: targetDocs.map(({ relPath }) => relPath),
+    skippedWithoutPrefixCount: missingPrefixCount,
+    skippedWithoutCategoryPathCount: missingCategoryPathCount,
+    frontmatterParseErrorCount,
+    publicationDiagnosticCount: scanResult.diagnostics.length,
+    markdownStyleIssueCount: markdownStyleIssues.length,
     issueCount: allIssues.length,
     strict: cli.strict,
+    publicationDiagnostics: scanResult.diagnostics.map((diagnostic) => ({
+      ...diagnostic,
+      formatted: formatPublicationDiagnostic(diagnostic),
+    })),
+    markdownStyleIssues,
     issues: allIssues,
   };
   await Bun.write(reportPath, `${JSON.stringify(report, null, 2)}\n`);
 
   console.log(
-    `[lint:md:publish] targets=${scanResult.docs.length} issues=${allIssues.length} out=${reportPath}`,
+    `[lint:md:publish] targets=${targetDocs.length} publication=${scanResult.diagnostics.length} markdown=${markdownStyleIssues.length} issues=${allIssues.length} out=${reportPath}`,
   );
-  if (scanResult.skippedWithoutPrefix.length > 0) {
-    console.warn(
-      `[lint:md:publish] skipped without prefix: ${scanResult.skippedWithoutPrefix.length}`,
-    );
+  for (const diagnostic of scanResult.diagnostics) {
+    console.warn(formatPublicationDiagnostic(diagnostic));
   }
 
   if (cli.strict && allIssues.length > 0) {

--- a/src/build/source.ts
+++ b/src/build/source.ts
@@ -1,49 +1,19 @@
-import crypto from "node:crypto";
-import fs from "node:fs/promises";
 import path from "node:path";
-import matter from "gray-matter";
-import type { BuildCache, BuildOptions, DocRecord, ManifestDoc, WikiResolver } from "../types";
 import {
-  buildExcluder,
-  makeHash,
-  makeTitleFromFileName,
-  relativePosix,
-  stripMdExt,
-  toDocId,
-} from "../utils";
+  evaluatePublication,
+  formatPublicationDiagnostic,
+  parsePublicationSource,
+  scanMarkdownSources,
+  type ParsedPublicationSource,
+} from "../publication";
+import type { BuildCache, BuildOptions, DocRecord, ManifestDoc, WikiResolver } from "../types";
+import { makeHash, makeTitleFromFileName, stripMdExt, toDocId } from "../utils";
 import type { ReadDocsResult, WikiLookup } from "./contracts";
 import { toContentFileName } from "./shared";
 
+export { normalizeCategoryPath } from "../publication";
+
 type CachedSourceEntry = BuildCache["sources"][string];
-
-async function walkMarkdownFiles(
-  dir: string,
-  vaultDir: string,
-  isExcluded: (relPath: string, isDirectory: boolean) => boolean,
-): Promise<string[]> {
-  const entries = await fs.readdir(dir, { withFileTypes: true });
-  const files: string[] = [];
-
-  for (const entry of entries) {
-    const absolutePath = path.join(dir, entry.name);
-    const relPath = relativePosix(vaultDir, absolutePath);
-
-    if (isExcluded(relPath, entry.isDirectory())) {
-      continue;
-    }
-
-    if (entry.isDirectory()) {
-      files.push(...(await walkMarkdownFiles(absolutePath, vaultDir, isExcluded)));
-      continue;
-    }
-
-    if (entry.isFile() && /\.md$/i.test(entry.name)) {
-      files.push(absolutePath);
-    }
-  }
-
-  return files;
-}
 
 export function parseStringArray(value: unknown): string[] {
   if (!Array.isArray(value)) {
@@ -89,24 +59,6 @@ function normalizeFrontmatterDate(value: unknown): string | null {
   }
 
   return null;
-}
-
-export function normalizeCategoryPath(value: unknown): string | undefined {
-  if (typeof value !== "string") {
-    return undefined;
-  }
-
-  const normalized = value
-    .trim()
-    .replace(/\\/g, "/")
-    .replace(/^\/+/, "")
-    .replace(/\/+$/, "")
-    .split("/")
-    .map((segment) => segment.trim())
-    .filter(Boolean)
-    .join("/");
-
-  return normalized.length > 0 ? normalized : undefined;
 }
 
 function extractFrontmatterScalar(raw: string, key: string): string | null {
@@ -165,37 +117,6 @@ function pickDocDate(frontmatter: Record<string, unknown>, raw: string): string 
 
 function pickDocUpdatedDate(frontmatter: Record<string, unknown>, raw: string): string | undefined {
   return pickFrontmatterDate(frontmatter, raw, ["updatedDate", "modifiedDate", "lastModified"]);
-}
-
-function pickDocPrefix(frontmatter: Record<string, unknown>, raw: string): string | undefined {
-  const literal = extractFrontmatterScalar(raw, "prefix");
-  if (literal) {
-    return literal;
-  }
-
-  const value = frontmatter.prefix;
-  if (typeof value === "string") {
-    const trimmed = value.trim();
-    return trimmed.length > 0 ? trimmed : undefined;
-  }
-
-  if (typeof value === "number" && Number.isFinite(value)) {
-    return String(value);
-  }
-
-  return undefined;
-}
-
-function pickDocCategoryPath(
-  frontmatter: Record<string, unknown>,
-  raw: string,
-): string | undefined {
-  const literal = normalizeCategoryPath(extractFrontmatterScalar(raw, "category_path"));
-  if (literal) {
-    return literal;
-  }
-
-  return normalizeCategoryPath(frontmatter.category_path);
 }
 
 function appendRouteSuffix(route: string, suffix: string): string {
@@ -308,37 +229,30 @@ function extractWikiTargets(markdown: string): string[] {
   return Array.from(targets).sort((left, right) => left.localeCompare(right, "ko-KR"));
 }
 
-function makeSourceFingerprint(raw: string): string {
-  return crypto.createHash("sha256").update(raw).digest("hex");
-}
-
-function toCachedSourceEntry(
-  raw: string,
-  rawHash: string,
-  parsed: matter.GrayMatterFile<string>,
-): CachedSourceEntry {
+function toCachedSourceEntry(parsed: ParsedPublicationSource): CachedSourceEntry {
+  const { source, frontmatter, content, metadata } = parsed;
   return {
     mtimeMs: 0,
     size: 0,
-    rawHash,
-    publish: parsed.data.publish === true,
-    draft: parsed.data.draft === true,
+    rawHash: source.rawHash,
+    publish: metadata.publish,
+    draft: metadata.draft,
     title:
-      typeof parsed.data.title === "string" && parsed.data.title.trim().length > 0
-        ? parsed.data.title.trim()
+      typeof frontmatter.title === "string" && frontmatter.title.trim().length > 0
+        ? frontmatter.title.trim()
         : undefined,
-    prefix: pickDocPrefix(parsed.data as Record<string, unknown>, raw),
-    categoryPath: pickDocCategoryPath(parsed.data as Record<string, unknown>, raw),
-    date: pickDocDate(parsed.data as Record<string, unknown>, raw),
-    updatedDate: pickDocUpdatedDate(parsed.data as Record<string, unknown>, raw),
+    prefix: metadata.prefix,
+    categoryPath: metadata.categoryPath,
+    date: pickDocDate(frontmatter, source.raw),
+    updatedDate: pickDocUpdatedDate(frontmatter, source.raw),
     description:
-      typeof parsed.data.description === "string"
-        ? parsed.data.description.trim() || undefined
+      typeof frontmatter.description === "string"
+        ? frontmatter.description.trim() || undefined
         : undefined,
-    tags: parseStringArray(parsed.data.tags),
-    branch: parseBranch(parsed.data.branch),
-    body: parsed.content,
-    wikiTargets: extractWikiTargets(parsed.content),
+    tags: parseStringArray(frontmatter.tags),
+    branch: parseBranch(frontmatter.branch),
+    body: content,
+    wikiTargets: extractWikiTargets(content),
   };
 }
 
@@ -374,61 +288,45 @@ export async function readPublishedDocs(
   options: BuildOptions,
   previousSources: BuildCache["sources"],
 ): Promise<ReadDocsResult> {
-  const isExcluded = buildExcluder(options.exclude);
-  const mdFiles = await walkMarkdownFiles(options.vaultDir, options.vaultDir, isExcluded);
-  const fileEntries = await Promise.all(
-    mdFiles.map(async (sourcePath) => ({
-      sourcePath,
-      relPath: relativePosix(options.vaultDir, sourcePath),
-      stat: await fs.stat(sourcePath),
-    })),
-  );
+  const sources = await scanMarkdownSources(options.vaultDir, options.exclude);
   const docs: DocRecord[] = [];
   const nextSources: BuildCache["sources"] = {};
 
-  for (const { sourcePath, relPath, stat } of fileEntries) {
-    const prev = previousSources[relPath];
-    const raw = await Bun.file(sourcePath).text();
-    const rawHash = makeSourceFingerprint(raw);
+  for (const source of sources) {
+    const prev = previousSources[source.relPath];
 
     let entry: CachedSourceEntry;
-    const canReuse = !!prev && prev.rawHash === rawHash;
+    const canReuse = !!prev && prev.rawHash === source.rawHash;
     if (canReuse) {
       entry = prev;
     } else {
-      let parsed: matter.GrayMatterFile<string>;
-      try {
-        parsed = matter(raw);
-      } catch (error) {
-        throw new Error(`Frontmatter parse failed: ${relPath}\n${(error as Error).message}`, {
-          cause: error,
+      const parsed = parsePublicationSource(source);
+      if (!parsed.ok) {
+        throw new Error(formatPublicationDiagnostic(parsed.diagnostic), {
+          cause: parsed.cause,
         });
       }
-
-      entry = toCachedSourceEntry(raw, rawHash, parsed);
+      entry = toCachedSourceEntry(parsed.value);
     }
 
     const completeEntry: CachedSourceEntry = {
       ...entry,
-      mtimeMs: stat.mtimeMs,
-      size: stat.size,
+      mtimeMs: source.mtimeMs,
+      size: source.size,
     };
-    if (!completeEntry.publish || completeEntry.draft) {
+    const evaluation = evaluatePublication(source.relPath, completeEntry);
+    if (evaluation.status === "ignored") {
+      continue;
+    }
+    if (evaluation.status === "invalid") {
+      for (const diagnostic of evaluation.diagnostics) {
+        console.warn(formatPublicationDiagnostic(diagnostic));
+      }
       continue;
     }
 
-    if (!completeEntry.prefix) {
-      console.warn(`[publish] Skipped published doc without prefix: ${relPath}`);
-      continue;
-    }
-
-    if (!completeEntry.categoryPath) {
-      console.warn(`[publish] Skipped published doc without category_path: ${relPath}`);
-      continue;
-    }
-
-    nextSources[relPath] = completeEntry;
-    docs.push(toDocRecord(sourcePath, relPath, completeEntry));
+    nextSources[source.relPath] = completeEntry;
+    docs.push(toDocRecord(source.sourcePath, source.relPath, completeEntry));
   }
 
   ensureUniqueRoutes(docs);

--- a/src/build/source.ts
+++ b/src/build/source.ts
@@ -288,11 +288,10 @@ export async function readPublishedDocs(
   options: BuildOptions,
   previousSources: BuildCache["sources"],
 ): Promise<ReadDocsResult> {
-  const sources = await scanMarkdownSources(options.vaultDir, options.exclude);
   const docs: DocRecord[] = [];
   const nextSources: BuildCache["sources"] = {};
 
-  for (const source of sources) {
+  for await (const source of scanMarkdownSources(options.vaultDir, options.exclude)) {
     const prev = previousSources[source.relPath];
 
     let entry: CachedSourceEntry;

--- a/src/build/storage.ts
+++ b/src/build/storage.ts
@@ -3,7 +3,8 @@ import path from "node:path";
 import type { BuildCache, BuildOptions, DocRecord } from "../types";
 import { ensureDir, fileExists, makeHash, removeEmptyParents, removeFileIfExists } from "../utils";
 import type { BuildStorageState, CacheLocation } from "./contracts";
-import { parseBranch, parseStringArray, normalizeCategoryPath } from "./source";
+import { normalizeCategoryPath } from "../publication";
+import { parseBranch, parseStringArray } from "./source";
 import { OUTPUT_MARKER_FILE_NAME, toContentFileName } from "./shared";
 
 const CACHE_VERSION = 6;

--- a/src/publication.ts
+++ b/src/publication.ts
@@ -1,0 +1,316 @@
+import crypto from "node:crypto";
+import fs from "node:fs/promises";
+import path from "node:path";
+import matter from "gray-matter";
+import { buildExcluder, relativePosix } from "./utils";
+
+export interface ScannedMarkdownSource {
+  sourcePath: string;
+  relPath: string;
+  raw: string;
+  rawHash: string;
+  mtimeMs: number;
+  size: number;
+}
+
+export interface PublicationMetadata {
+  publish: boolean;
+  draft: boolean;
+  prefix?: string;
+  categoryPath?: string;
+}
+
+export type PublicationDiagnosticCode =
+  "frontmatter/parse" | "publication/missing-prefix" | "publication/missing-category-path";
+
+export interface PublicationDiagnostic {
+  category: "frontmatter-parse" | "publication-metadata";
+  code: PublicationDiagnosticCode;
+  severity: "error" | "warning";
+  file: string;
+  line: number;
+  column: number;
+  message: string;
+}
+
+export interface ParsedPublicationSource {
+  source: ScannedMarkdownSource;
+  frontmatter: Record<string, unknown>;
+  content: string;
+  metadata: PublicationMetadata;
+}
+
+export type PublicationEvaluation =
+  | { status: "ignored"; reason: "not-published" | "draft" }
+  | { status: "invalid"; diagnostics: PublicationDiagnostic[] }
+  | { status: "target" };
+
+export interface PublicationScanResult {
+  sources: ScannedMarkdownSource[];
+  targets: ParsedPublicationSource[];
+  diagnostics: PublicationDiagnostic[];
+  ignored: Array<{
+    file: string;
+    reason: "not-published" | "draft" | "frontmatter-parse" | "invalid-metadata";
+  }>;
+}
+
+async function walkMarkdownFiles(
+  dir: string,
+  vaultDir: string,
+  isExcluded: (relPath: string, isDirectory: boolean) => boolean,
+): Promise<string[]> {
+  const entries = await fs.readdir(dir, { withFileTypes: true });
+  entries.sort((left, right) => left.name.localeCompare(right.name, "ko-KR"));
+  const files: string[] = [];
+
+  for (const entry of entries) {
+    const absolutePath = path.join(dir, entry.name);
+    const relPath = relativePosix(vaultDir, absolutePath);
+
+    if (isExcluded(relPath, entry.isDirectory())) {
+      continue;
+    }
+
+    if (entry.isDirectory()) {
+      files.push(...(await walkMarkdownFiles(absolutePath, vaultDir, isExcluded)));
+      continue;
+    }
+
+    if (entry.isFile() && /\.md$/i.test(entry.name)) {
+      files.push(absolutePath);
+    }
+  }
+
+  return files;
+}
+
+export async function scanMarkdownSources(
+  vaultDir: string,
+  excludePatterns: string[],
+): Promise<ScannedMarkdownSource[]> {
+  const isExcluded = buildExcluder(excludePatterns);
+  const sourcePaths = await walkMarkdownFiles(vaultDir, vaultDir, isExcluded);
+  const sources = await Promise.all(
+    sourcePaths.map(async (sourcePath): Promise<ScannedMarkdownSource> => {
+      const [raw, stat] = await Promise.all([Bun.file(sourcePath).text(), fs.stat(sourcePath)]);
+      return {
+        sourcePath,
+        relPath: relativePosix(vaultDir, sourcePath),
+        raw,
+        rawHash: crypto.createHash("sha256").update(raw).digest("hex"),
+        mtimeMs: stat.mtimeMs,
+        size: stat.size,
+      };
+    }),
+  );
+
+  return sources.sort((left, right) => left.relPath.localeCompare(right.relPath, "ko-KR"));
+}
+
+export function normalizeCategoryPath(value: unknown): string | undefined {
+  if (typeof value !== "string") {
+    return undefined;
+  }
+
+  const normalized = value
+    .trim()
+    .replace(/\\/g, "/")
+    .replace(/^\/+/, "")
+    .replace(/\/+$/, "")
+    .split("/")
+    .map((segment) => segment.trim())
+    .filter(Boolean)
+    .join("/");
+
+  return normalized.length > 0 ? normalized : undefined;
+}
+
+function extractFrontmatterScalar(raw: string, key: string): string | null {
+  const frontmatterMatch = raw.match(/^---\s*\r?\n([\s\S]*?)\r?\n---/);
+  if (!frontmatterMatch) {
+    return null;
+  }
+
+  const body = frontmatterMatch[1];
+  const lineRegex = new RegExp(`^${key}:\\s*(.+?)\\s*$`, "m");
+  const lineMatch = body.match(lineRegex);
+  if (!lineMatch) {
+    return null;
+  }
+
+  let value = lineMatch[1].trim();
+  if (!value || value === "|" || value === ">") {
+    return null;
+  }
+
+  const quoted =
+    (value.startsWith('"') && value.endsWith('"')) ||
+    (value.startsWith("'") && value.endsWith("'"));
+  if (quoted) {
+    value = value.slice(1, -1).trim();
+  }
+
+  return value.length > 0 ? value : null;
+}
+
+export function pickPublicationPrefix(
+  frontmatter: Record<string, unknown>,
+  raw: string,
+): string | undefined {
+  const literal = extractFrontmatterScalar(raw, "prefix");
+  if (literal) {
+    return literal;
+  }
+
+  const value = frontmatter.prefix;
+  if (typeof value === "string") {
+    const trimmed = value.trim();
+    return trimmed.length > 0 ? trimmed : undefined;
+  }
+
+  if (typeof value === "number" && Number.isFinite(value)) {
+    return String(value);
+  }
+
+  return undefined;
+}
+
+export function pickPublicationCategoryPath(
+  frontmatter: Record<string, unknown>,
+  raw: string,
+): string | undefined {
+  const literal = normalizeCategoryPath(extractFrontmatterScalar(raw, "category_path"));
+  if (literal) {
+    return literal;
+  }
+
+  return normalizeCategoryPath(frontmatter.category_path);
+}
+
+function createParseDiagnostic(relPath: string, error: unknown): PublicationDiagnostic {
+  return {
+    category: "frontmatter-parse",
+    code: "frontmatter/parse",
+    severity: "error",
+    file: relPath,
+    line: 1,
+    column: 1,
+    message: error instanceof Error ? error.message : String(error),
+  };
+}
+
+export type ParsePublicationResult =
+  | { ok: true; value: ParsedPublicationSource }
+  | { ok: false; diagnostic: PublicationDiagnostic; cause: unknown };
+
+export function parsePublicationSource(source: ScannedMarkdownSource): ParsePublicationResult {
+  let parsed: matter.GrayMatterFile<string>;
+  try {
+    parsed = matter(source.raw);
+  } catch (error) {
+    return {
+      ok: false,
+      diagnostic: createParseDiagnostic(source.relPath, error),
+      cause: error,
+    };
+  }
+
+  const frontmatter = parsed.data as Record<string, unknown>;
+  return {
+    ok: true,
+    value: {
+      source,
+      frontmatter,
+      content: parsed.content,
+      metadata: {
+        publish: frontmatter.publish === true,
+        draft: frontmatter.draft === true,
+        prefix: pickPublicationPrefix(frontmatter, source.raw),
+        categoryPath: pickPublicationCategoryPath(frontmatter, source.raw),
+      },
+    },
+  };
+}
+
+export function evaluatePublication(
+  relPath: string,
+  metadata: PublicationMetadata,
+): PublicationEvaluation {
+  if (!metadata.publish) {
+    return { status: "ignored", reason: "not-published" };
+  }
+  if (metadata.draft) {
+    return { status: "ignored", reason: "draft" };
+  }
+
+  const diagnostics: PublicationDiagnostic[] = [];
+  if (!metadata.prefix) {
+    diagnostics.push({
+      category: "publication-metadata",
+      code: "publication/missing-prefix",
+      severity: "warning",
+      file: relPath,
+      line: 1,
+      column: 1,
+      message: "Published document is missing required prefix",
+    });
+  }
+  if (!metadata.categoryPath) {
+    diagnostics.push({
+      category: "publication-metadata",
+      code: "publication/missing-category-path",
+      severity: "warning",
+      file: relPath,
+      line: 1,
+      column: 1,
+      message: "Published document is missing required category_path",
+    });
+  }
+
+  return diagnostics.length > 0 ? { status: "invalid", diagnostics } : { status: "target" };
+}
+
+export function formatPublicationDiagnostic(diagnostic: PublicationDiagnostic): string {
+  if (diagnostic.code === "frontmatter/parse") {
+    return `Frontmatter parse failed: ${diagnostic.file}\n${diagnostic.message}`;
+  }
+  if (diagnostic.code === "publication/missing-prefix") {
+    return `[publish] Skipped published doc without prefix: ${diagnostic.file}`;
+  }
+  return `[publish] Skipped published doc without category_path: ${diagnostic.file}`;
+}
+
+export async function scanPublicationTargets(
+  vaultDir: string,
+  excludePatterns: string[],
+): Promise<PublicationScanResult> {
+  const sources = await scanMarkdownSources(vaultDir, excludePatterns);
+  const targets: ParsedPublicationSource[] = [];
+  const diagnostics: PublicationDiagnostic[] = [];
+  const ignored: PublicationScanResult["ignored"] = [];
+
+  for (const source of sources) {
+    const parsed = parsePublicationSource(source);
+    if (!parsed.ok) {
+      diagnostics.push(parsed.diagnostic);
+      ignored.push({ file: source.relPath, reason: "frontmatter-parse" });
+      continue;
+    }
+
+    const evaluation = evaluatePublication(source.relPath, parsed.value.metadata);
+    if (evaluation.status === "ignored") {
+      ignored.push({ file: source.relPath, reason: evaluation.reason });
+      continue;
+    }
+    if (evaluation.status === "invalid") {
+      diagnostics.push(...evaluation.diagnostics);
+      ignored.push({ file: source.relPath, reason: "invalid-metadata" });
+      continue;
+    }
+
+    targets.push(parsed.value);
+  }
+
+  return { sources, targets, diagnostics, ignored };
+}

--- a/src/publication.ts
+++ b/src/publication.ts
@@ -46,7 +46,7 @@ export type PublicationEvaluation =
   | { status: "target" };
 
 export interface PublicationScanResult {
-  sources: ScannedMarkdownSource[];
+  sourceFiles: string[];
   targets: ParsedPublicationSource[];
   diagnostics: PublicationDiagnostic[];
   ignored: Array<{
@@ -55,14 +55,13 @@ export interface PublicationScanResult {
   }>;
 }
 
-async function walkMarkdownFiles(
+async function* walkMarkdownFiles(
   dir: string,
   vaultDir: string,
   isExcluded: (relPath: string, isDirectory: boolean) => boolean,
-): Promise<string[]> {
+): AsyncGenerator<string> {
   const entries = await fs.readdir(dir, { withFileTypes: true });
   entries.sort((left, right) => left.name.localeCompare(right.name, "ko-KR"));
-  const files: string[] = [];
 
   for (const entry of entries) {
     const absolutePath = path.join(dir, entry.name);
@@ -73,39 +72,35 @@ async function walkMarkdownFiles(
     }
 
     if (entry.isDirectory()) {
-      files.push(...(await walkMarkdownFiles(absolutePath, vaultDir, isExcluded)));
+      for await (const nestedPath of walkMarkdownFiles(absolutePath, vaultDir, isExcluded)) {
+        yield nestedPath;
+      }
       continue;
     }
 
     if (entry.isFile() && /\.md$/i.test(entry.name)) {
-      files.push(absolutePath);
+      yield absolutePath;
     }
   }
-
-  return files;
 }
 
-export async function scanMarkdownSources(
+export async function* scanMarkdownSources(
   vaultDir: string,
   excludePatterns: string[],
-): Promise<ScannedMarkdownSource[]> {
+): AsyncGenerator<ScannedMarkdownSource> {
   const isExcluded = buildExcluder(excludePatterns);
-  const sourcePaths = await walkMarkdownFiles(vaultDir, vaultDir, isExcluded);
-  const sources = await Promise.all(
-    sourcePaths.map(async (sourcePath): Promise<ScannedMarkdownSource> => {
-      const [raw, stat] = await Promise.all([Bun.file(sourcePath).text(), fs.stat(sourcePath)]);
-      return {
-        sourcePath,
-        relPath: relativePosix(vaultDir, sourcePath),
-        raw,
-        rawHash: crypto.createHash("sha256").update(raw).digest("hex"),
-        mtimeMs: stat.mtimeMs,
-        size: stat.size,
-      };
-    }),
-  );
-
-  return sources.sort((left, right) => left.relPath.localeCompare(right.relPath, "ko-KR"));
+  for await (const sourcePath of walkMarkdownFiles(vaultDir, vaultDir, isExcluded)) {
+    const raw = await Bun.file(sourcePath).text();
+    const stat = await fs.stat(sourcePath);
+    yield {
+      sourcePath,
+      relPath: relativePosix(vaultDir, sourcePath),
+      raw,
+      rawHash: crypto.createHash("sha256").update(raw).digest("hex"),
+      mtimeMs: stat.mtimeMs,
+      size: stat.size,
+    };
+  }
 }
 
 export function normalizeCategoryPath(value: unknown): string | undefined {
@@ -285,12 +280,13 @@ export async function scanPublicationTargets(
   vaultDir: string,
   excludePatterns: string[],
 ): Promise<PublicationScanResult> {
-  const sources = await scanMarkdownSources(vaultDir, excludePatterns);
+  const sourceFiles: string[] = [];
   const targets: ParsedPublicationSource[] = [];
   const diagnostics: PublicationDiagnostic[] = [];
   const ignored: PublicationScanResult["ignored"] = [];
 
-  for (const source of sources) {
+  for await (const source of scanMarkdownSources(vaultDir, excludePatterns)) {
+    sourceFiles.push(source.relPath);
     const parsed = parsePublicationSource(source);
     if (!parsed.ok) {
       diagnostics.push(parsed.diagnostic);
@@ -312,5 +308,5 @@ export async function scanPublicationTargets(
     targets.push(parsed.value);
   }
 
-  return { sources, targets, diagnostics, ignored };
+  return { sourceFiles, targets, diagnostics, ignored };
 }

--- a/tests/e2e/publication-scanner.spec.ts
+++ b/tests/e2e/publication-scanner.spec.ts
@@ -1,0 +1,270 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+
+interface CliResult {
+  status: number | null;
+  output: string;
+}
+
+interface PublicationReport {
+  targetCount: number;
+  targetFiles: string[];
+  skippedWithoutPrefixCount: number;
+  skippedWithoutCategoryPathCount: number;
+  frontmatterParseErrorCount: number;
+  publicationDiagnosticCount: number;
+  markdownStyleIssueCount: number;
+  issueCount: number;
+  publicationDiagnostics: Array<{
+    category: string;
+    code: string;
+    file: string;
+    formatted: string;
+  }>;
+  markdownStyleIssues: Array<{
+    category: string;
+    rule: string;
+    file: string;
+  }>;
+  issues: Array<{ category: string; rule: string; file: string }>;
+}
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function runBun(cwd: string, args: string[]): CliResult {
+  const result = spawnSync("bun", args, { cwd, encoding: "utf8" });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+function readReport(reportDir: string): PublicationReport {
+  return JSON.parse(
+    fs.readFileSync(path.join(reportDir, "mdlint-report.json"), "utf8"),
+  ) as PublicationReport;
+}
+
+function readOnlyBuildCache(workDir: string): { sources: Record<string, unknown> } {
+  const cacheRoot = path.join(workDir, ".cache", "eiam");
+  const namespaces = fs
+    .readdirSync(cacheRoot, { withFileTypes: true })
+    .filter((entry) => entry.isDirectory());
+  expect(namespaces).toHaveLength(1);
+  return JSON.parse(
+    fs.readFileSync(path.join(cacheRoot, namespaces[0]!.name, "build-index.json"), "utf8"),
+  ) as { sources: Record<string, unknown> };
+}
+
+test.describe("shared publication scanner", () => {
+  const repoRoot = process.cwd();
+  const buildCliPath = path.join(repoRoot, "src/cli.ts");
+  const lintCliPath = path.join(repoRoot, "scripts/lint-published-markdown.ts");
+
+  test("build와 lint가 같은 publish target을 선택하고 report category를 분리한다", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-shared-targets-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "site");
+    const reportDir = path.join(workDir, "report");
+
+    try {
+      writeText(
+        path.join(vaultDir, "target.md"),
+        `---
+publish: true
+prefix: TARGET
+category_path: guides
+---
+
+# Body H1
+`,
+      );
+      writeText(
+        path.join(vaultDir, "missing-prefix.md"),
+        `---
+publish: true
+category_path: guides
+---
+`,
+      );
+      writeText(
+        path.join(vaultDir, "missing-category.md"),
+        `---
+publish: true
+prefix: MISSING-CATEGORY
+---
+`,
+      );
+      writeText(
+        path.join(vaultDir, "draft.md"),
+        `---
+publish: true
+draft: true
+prefix: DRAFT
+category_path: drafts
+---
+`,
+      );
+      writeText(path.join(vaultDir, "private.md"), "---\npublish: false\n---\n");
+      writeText(
+        path.join(vaultDir, "excluded", "published.md"),
+        `---
+publish: true
+prefix: EXCLUDED
+category_path: excluded
+---
+`,
+      );
+
+      const build = runBun(workDir, [
+        buildCliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+        "--exclude",
+        "excluded/**",
+      ]);
+      expect(build.status, build.output).toBe(0);
+      expect(build.output).toContain(
+        "[publish] Skipped published doc without prefix: missing-prefix.md",
+      );
+      expect(build.output).toContain(
+        "[publish] Skipped published doc without category_path: missing-category.md",
+      );
+
+      const lint = runBun(workDir, [
+        lintCliPath,
+        "--out-dir",
+        reportDir,
+        "--vault",
+        vaultDir,
+        "--exclude",
+        "excluded/**",
+      ]);
+      expect(lint.status, lint.output).toBe(0);
+      const report = readReport(reportDir);
+      const cache = readOnlyBuildCache(workDir);
+
+      expect(report.targetCount).toBe(1);
+      expect(report.targetFiles).toEqual(["target.md"]);
+      expect(Object.keys(cache.sources).sort()).toEqual(report.targetFiles);
+      expect(report.skippedWithoutPrefixCount).toBe(1);
+      expect(report.skippedWithoutCategoryPathCount).toBe(1);
+      expect(report.frontmatterParseErrorCount).toBe(0);
+      expect(report.publicationDiagnosticCount).toBe(2);
+      expect(report.markdownStyleIssueCount).toBe(1);
+      expect(report.issueCount).toBe(3);
+      expect(
+        report.publicationDiagnostics.map(({ category, code, file }) => ({
+          category,
+          code,
+          file,
+        })),
+      ).toEqual([
+        {
+          category: "publication-metadata",
+          code: "publication/missing-category-path",
+          file: "missing-category.md",
+        },
+        {
+          category: "publication-metadata",
+          code: "publication/missing-prefix",
+          file: "missing-prefix.md",
+        },
+      ]);
+      expect(report.markdownStyleIssues).toMatchObject([
+        { category: "markdown-style", rule: "custom/no-h1-body", file: "target.md" },
+      ]);
+      expect(new Set(report.issues.map(({ category }) => category))).toEqual(
+        new Set(["publication", "markdown-style"]),
+      );
+
+      writeText(
+        path.join(vaultDir, "target.md"),
+        `---
+publish: true
+prefix: TARGET
+category_path: guides
+---
+
+## Body H2
+`,
+      );
+      const strictLint = runBun(workDir, [
+        lintCliPath,
+        "--out-dir",
+        reportDir,
+        "--strict",
+        "--vault",
+        vaultDir,
+        "--exclude",
+        "excluded/**",
+      ]);
+      expect(strictLint.status).toBe(1);
+      const strictReport = readReport(reportDir);
+      expect(strictReport.publicationDiagnosticCount).toBe(2);
+      expect(strictReport.markdownStyleIssueCount).toBe(0);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("build와 lint가 malformed frontmatter 진단 형식을 공유한다", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-shared-parse-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "site");
+    const reportDir = path.join(workDir, "report");
+
+    try {
+      writeText(
+        path.join(vaultDir, "broken.md"),
+        `---
+publish: true
+prefix: [unterminated
+category_path: broken
+---
+`,
+      );
+      writeText(
+        path.join(vaultDir, "valid.md"),
+        `---
+publish: true
+prefix: VALID
+category_path: valid
+---
+
+## Valid
+`,
+      );
+
+      const build = runBun(workDir, [buildCliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(build.status).not.toBe(0);
+      expect(fs.existsSync(outDir)).toBe(false);
+
+      const lint = runBun(workDir, [lintCliPath, "--out-dir", reportDir, "--vault", vaultDir]);
+      expect(lint.status, lint.output).toBe(0);
+      const report = readReport(reportDir);
+
+      expect(report.targetFiles).toEqual(["valid.md"]);
+      expect(report.frontmatterParseErrorCount).toBe(1);
+      expect(report.publicationDiagnostics).toHaveLength(1);
+      expect(report.publicationDiagnostics[0]).toMatchObject({
+        category: "frontmatter-parse",
+        code: "frontmatter/parse",
+        file: "broken.md",
+      });
+      expect(build.output).toContain(report.publicationDiagnostics[0]!.formatted);
+      expect(lint.output).toContain(report.publicationDiagnostics[0]!.formatted);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+});

--- a/tests/unit/publication-scanner.test.ts
+++ b/tests/unit/publication-scanner.test.ts
@@ -1,0 +1,166 @@
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  evaluatePublication,
+  formatPublicationDiagnostic,
+  scanPublicationTargets,
+} from "../../src/publication";
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function markdown(frontmatter: string, body = "## Body\n"): string {
+  return `---\n${frontmatter}\n---\n\n${body}`;
+}
+
+describe("shared publication scanner", () => {
+  test("shares exclusions and all publication metadata rules", async () => {
+    const vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-publication-scan-"));
+
+    try {
+      writeText(
+        path.join(vaultDir, "valid.MD"),
+        markdown(`publish: true
+prefix: 42
+category_path: " engineering//guides\\api/ "`),
+      );
+      writeText(
+        path.join(vaultDir, "missing-prefix.md"),
+        markdown(`publish: true
+category_path: guides`),
+      );
+      writeText(
+        path.join(vaultDir, "missing-category.md"),
+        markdown(`publish: true
+prefix: MISSING-CATEGORY`),
+      );
+      writeText(
+        path.join(vaultDir, "draft.md"),
+        markdown(`publish: true
+draft: true
+prefix: DRAFT
+category_path: drafts`),
+      );
+      writeText(path.join(vaultDir, "private.md"), markdown("publish: false"));
+      writeText(
+        path.join(vaultDir, "excluded", "published.md"),
+        markdown(`publish: true
+prefix: EXCLUDED
+category_path: excluded`),
+      );
+      writeText(path.join(vaultDir, "ignored.txt"), "not markdown\n");
+
+      const result = await scanPublicationTargets(vaultDir, ["excluded/**"]);
+
+      expect(result.sources.map(({ relPath }) => relPath)).toEqual([
+        "draft.md",
+        "missing-category.md",
+        "missing-prefix.md",
+        "private.md",
+        "valid.MD",
+      ]);
+      expect(result.targets.map(({ source }) => source.relPath)).toEqual(["valid.MD"]);
+      expect(result.targets[0]?.metadata).toEqual({
+        publish: true,
+        draft: false,
+        prefix: "42",
+        categoryPath: "engineering/guides/api",
+      });
+      expect(result.diagnostics.map(({ file, code }) => ({ file, code }))).toEqual([
+        {
+          file: "missing-category.md",
+          code: "publication/missing-category-path",
+        },
+        { file: "missing-prefix.md", code: "publication/missing-prefix" },
+      ]);
+      expect(result.ignored).toEqual([
+        { file: "draft.md", reason: "draft" },
+        { file: "missing-category.md", reason: "invalid-metadata" },
+        { file: "missing-prefix.md", reason: "invalid-metadata" },
+        { file: "private.md", reason: "not-published" },
+      ]);
+    } finally {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    }
+  });
+
+  test("returns one structured and formatted diagnostic for malformed frontmatter", async () => {
+    const vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-publication-malformed-"));
+
+    try {
+      writeText(
+        path.join(vaultDir, "broken.md"),
+        `---
+publish: true
+prefix: [unterminated
+category_path: broken
+---
+`,
+      );
+      writeText(
+        path.join(vaultDir, "excluded", "broken.md"),
+        `---
+publish: [also broken
+---
+`,
+      );
+
+      const result = await scanPublicationTargets(vaultDir, ["excluded/**"]);
+
+      expect(result.targets).toEqual([]);
+      expect(result.diagnostics).toHaveLength(1);
+      expect(result.diagnostics[0]).toMatchObject({
+        category: "frontmatter-parse",
+        code: "frontmatter/parse",
+        severity: "error",
+        file: "broken.md",
+        line: 1,
+        column: 1,
+      });
+      expect(formatPublicationDiagnostic(result.diagnostics[0]!)).toStartWith(
+        "Frontmatter parse failed: broken.md\n",
+      );
+    } finally {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    }
+  });
+
+  test("evaluates publish and draft before required metadata", () => {
+    expect(
+      evaluatePublication("private.md", {
+        publish: false,
+        draft: false,
+      }),
+    ).toEqual({ status: "ignored", reason: "not-published" });
+    expect(
+      evaluatePublication("draft.md", {
+        publish: true,
+        draft: true,
+      }),
+    ).toEqual({ status: "ignored", reason: "draft" });
+    expect(
+      evaluatePublication("invalid.md", {
+        publish: true,
+        draft: false,
+      }),
+    ).toMatchObject({
+      status: "invalid",
+      diagnostics: [
+        { code: "publication/missing-prefix" },
+        { code: "publication/missing-category-path" },
+      ],
+    });
+    expect(
+      evaluatePublication("target.md", {
+        publish: true,
+        draft: false,
+        prefix: "TARGET",
+        categoryPath: "guides",
+      }),
+    ).toEqual({ status: "target" });
+  });
+});

--- a/tests/unit/publication-scanner.test.ts
+++ b/tests/unit/publication-scanner.test.ts
@@ -5,6 +5,7 @@ import { describe, expect, test } from "bun:test";
 import {
   evaluatePublication,
   formatPublicationDiagnostic,
+  scanMarkdownSources,
   scanPublicationTargets,
 } from "../../src/publication";
 
@@ -56,7 +57,7 @@ category_path: excluded`),
 
       const result = await scanPublicationTargets(vaultDir, ["excluded/**"]);
 
-      expect(result.sources.map(({ relPath }) => relPath)).toEqual([
+      expect(result.sourceFiles).toEqual([
         "draft.md",
         "missing-category.md",
         "missing-prefix.md",
@@ -83,6 +84,26 @@ category_path: excluded`),
         { file: "missing-prefix.md", reason: "invalid-metadata" },
         { file: "private.md", reason: "not-published" },
       ]);
+    } finally {
+      fs.rmSync(vaultDir, { recursive: true, force: true });
+    }
+  });
+
+  test("reads source bodies lazily instead of retaining every vault file", async () => {
+    const vaultDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-publication-stream-"));
+
+    try {
+      writeText(path.join(vaultDir, "a.md"), markdown("publish: false"));
+      const secondPath = path.join(vaultDir, "b.md");
+      writeText(secondPath, markdown("publish: false"));
+
+      const iterator = scanMarkdownSources(vaultDir, [])[Symbol.asyncIterator]();
+      const first = await iterator.next();
+      expect(first.done).toBe(false);
+      expect(first.value?.relPath).toBe("a.md");
+
+      fs.rmSync(secondPath);
+      await expect(iterator.next()).rejects.toThrow();
     } finally {
       fs.rmSync(vaultDir, { recursive: true, force: true });
     }


### PR DESCRIPTION
## Summary
- add one reusable Markdown scanner and publication-validation result model
- make build and publish-only lint share exclusion, frontmatter, publish, draft, prefix, and category_path rules
- separate publication diagnostics from Markdown style findings in lint reports
- cover exclusions, malformed frontmatter, target parity, strict mode, and cache behavior

## Validation
- bun install --frozen-lockfile
- bun run lint:source
- bun run format:check
- bun run typecheck
- bun run test:unit (73 passed)
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size
- bun run check:reproducible
- bun run test:e2e (84 passed)

Closes #33
Part of #34