### PR TITLE
feat: centralize runtime defaults

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -101,6 +101,7 @@ SEO/UI/정적 파일 설정은 config 파일에서 관리할 수 있습니다.
 const config = {
   vaultDir: "./vault",
   outDir: "./dist",
+  defaultBranch: "dev",
   staticPaths: ["assets", "public/favicon.ico"],
   pinnedMenu: {
     label: "NOTICE",
@@ -123,6 +124,10 @@ const config = {
 
 export default config;
 ```
+
+`defaultBranch`는 런타임이 처음 선택하는 브랜치이며 기본값은 `"dev"`입니다. 값은 앞뒤
+공백을 제거하고 소문자로 정규화하며, frontmatter에 `branch`가 없는 문서는 이 기본 브랜치에
+포함됩니다.
 
 Config module은 신뢰되지 않은 런타임 입력으로 취급합니다. 지원하는 모든 필드를 검증하고
 정규화한 뒤에만 `build`, `dev`, `clean`이 output/cache 경로를 생성·변경·삭제할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -251,6 +251,7 @@ Example:
 export default {
   vaultDir: "./vault",
   outDir: "./dist",
+  defaultBranch: "dev",
   exclude: [".obsidian/**", "private/**"],
   staticPaths: ["assets", "public/favicon.ico"],
   pinnedMenu: {
@@ -297,6 +298,8 @@ export default {
 
 - `vaultDir`: default vault root.
 - `outDir`: default output directory.
+- `defaultBranch`: initial runtime branch, default `"dev"`; values are trimmed and normalized to
+  lowercase. Notes without a `branch` belong to this branch.
 - `exclude`: extra exclude globs.
 - `staticPaths`: vault-relative files or directories copied into output.
 - `pinnedMenu`: optional virtual folder shown above `Recent`.

--- a/src/build/graph.ts
+++ b/src/build/graph.ts
@@ -1,10 +1,9 @@
 import type { BuildOptions, DocRecord, FileNode, FolderNode, Manifest, TreeNode } from "../types";
+import { DEFAULT_BRANCH } from "../defaults";
 import { filterViewDocsByBranch, pickViewHomeRoute } from "../view-contract";
 import type { DocumentGraphResult, WikiLookup } from "./contracts";
 import { buildBacklinksByDocId, createWikiLookup } from "./source";
 import { resolveSiteTitle } from "./shared";
-
-const DEFAULT_BRANCH = "dev";
 
 function fileNodeFromDoc(doc: DocRecord): FileNode {
   return {
@@ -66,8 +65,8 @@ function matchesPathPrefix(value: string, prefix: string): boolean {
   return value === prefix || value.startsWith(`${prefix}/`);
 }
 
-export function pickHomeDoc(docs: DocRecord[]): DocRecord | null {
-  const defaultCandidates = filterViewDocsByBranch(docs, DEFAULT_BRANCH, DEFAULT_BRANCH);
+export function pickHomeDoc(docs: DocRecord[], defaultBranch = DEFAULT_BRANCH): DocRecord | null {
+  const defaultCandidates = filterViewDocsByBranch(docs, defaultBranch, defaultBranch);
   const candidates = defaultCandidates.length > 0 ? defaultCandidates : docs;
   const route = pickViewHomeRoute(candidates);
   return candidates.find((doc) => doc.route === route) ?? null;
@@ -197,7 +196,7 @@ function buildManifest(
     ]),
   );
 
-  const branchSet = new Set<string>([DEFAULT_BRANCH]);
+  const branchSet = new Set<string>([options.defaultBranch]);
   for (const doc of docs) {
     if (doc.branch) {
       branchSet.add(doc.branch);
@@ -205,10 +204,10 @@ function buildManifest(
   }
 
   const branches = Array.from(branchSet).sort((left, right) => {
-    if (left === DEFAULT_BRANCH) {
+    if (left === options.defaultBranch) {
       return -1;
     }
-    if (right === DEFAULT_BRANCH) {
+    if (right === options.defaultBranch) {
       return 1;
     }
     return left.localeCompare(right, "ko-KR");
@@ -218,8 +217,9 @@ function buildManifest(
     schemaVersion: 2,
     siteTitle: resolveSiteTitle(options),
     pathBase: options.seo?.pathBase ?? "",
-    defaultBranch: DEFAULT_BRANCH,
+    defaultBranch: options.defaultBranch,
     mermaid: options.mermaid,
+    layout: options.layout,
     branches,
     ui: {
       newWithinDays: options.newWithinDays,

--- a/src/build/output.ts
+++ b/src/build/output.ts
@@ -2,6 +2,7 @@ import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
 import type { BuildOptions, DocRecord, Manifest } from "../types";
+import { DEFAULT_BRANCH, type RuntimeLayoutConfig } from "../defaults";
 import { buildCanonicalUrl } from "../seo";
 import { render404Html, renderAppShellHtml } from "../template";
 import type { AppShellAssets, AppShellInitialView, AppShellMeta } from "../template";
@@ -18,7 +19,6 @@ import type { OutputPhaseState, OutputWriteContext, RuntimeAssets } from "./cont
 import { OUTPUT_MARKER_FILE_NAME, resolveSiteTitle } from "./shared";
 
 const DEFAULT_SITE_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
-const DEFAULT_SITE_TITLE = "File-System Blog";
 
 function pickSeoImageDefaults(seo: BuildOptions["seo"]): {
   social: string | null;
@@ -61,7 +61,7 @@ function buildStructuredData(
   options: BuildOptions,
 ): unknown[] {
   const canonicalUrl = options.seo ? buildCanonicalUrl(route, options.seo) : undefined;
-  const siteName = options.seo?.siteName ?? options.seo?.defaultTitle ?? DEFAULT_SITE_TITLE;
+  const siteName = resolveSiteTitle(options);
 
   if (!doc) {
     const websiteSchema: Record<string, string> = {
@@ -267,6 +267,48 @@ function createMinimalTreeIconPlugin(): { plugin: Bun.BunPlugin; replacementCoun
   };
 }
 
+const COMPACT_BREAKPOINT_MARKER = "0px /* eiam-compact-breakpoint */";
+
+function createRuntimeCssDefaultsPlugin(layout: RuntimeLayoutConfig): {
+  plugin: Bun.BunPlugin;
+  replacementCount: () => number;
+} {
+  let replacements = 0;
+  const generatedDefaults = `:root {
+  --desktop-sidebar-default: ${layout.desktopSidebarDefaultPx}px;
+  --desktop-sidebar-min: ${layout.desktopSidebarMinPx}px;
+  --desktop-viewer-min: ${layout.desktopViewerMinPx}px;
+  --splitter-width: ${layout.splitterWidthPx}px;
+  --mobile-sidebar-min: ${layout.mobileSidebarMinPx}px;
+  --mobile-sidebar-max: ${layout.mobileSidebarMaxPx}px;
+}`;
+
+  return {
+    plugin: {
+      name: "eiam-runtime-css-defaults",
+      setup(builder) {
+        builder.onLoad({ filter: /app[.]css$/ }, async (args) => {
+          const source = await fs.readFile(args.path, "utf8");
+          replacements = source.split(COMPACT_BREAKPOINT_MARKER).length - 1;
+          if (replacements !== 2) {
+            throw new Error(
+              `Expected 2 compact breakpoint markers in app.css, found ${replacements}`,
+            );
+          }
+          return {
+            contents: `${generatedDefaults}\n${source.replaceAll(
+              COMPACT_BREAKPOINT_MARKER,
+              `${layout.compactBreakpointPx}px`,
+            )}`,
+            loader: "css",
+          };
+        });
+      },
+    },
+    replacementCount: () => replacements,
+  };
+}
+
 async function bundleRuntimeJs(
   entrypoint: string,
   options: { label: string; replaceTreeIcons: boolean },
@@ -307,12 +349,14 @@ async function bundleRuntimeJs(
   return runtimeJs;
 }
 
-async function bundleRuntimeCss(entrypoint: string): Promise<string> {
+async function bundleRuntimeCss(entrypoint: string, layout: RuntimeLayoutConfig): Promise<string> {
+  const runtimeCssDefaults = createRuntimeCssDefaultsPlugin(layout);
   const result = await Bun.build({
     entrypoints: [entrypoint],
     target: "browser",
     sourcemap: "none",
     minify: true,
+    plugins: [runtimeCssDefaults.plugin],
   });
 
   if (!result.success) {
@@ -328,11 +372,17 @@ async function bundleRuntimeCss(entrypoint: string): Promise<string> {
   if (!output) {
     throw new Error("Failed to bundle runtime app.css: no CSS output was produced");
   }
+  if (runtimeCssDefaults.replacementCount() !== 2) {
+    throw new Error("Failed to generate runtime CSS defaults");
+  }
 
   return output.text();
 }
 
-async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeAssets> {
+async function writeRuntimeAssets(
+  context: OutputWriteContext,
+  layout: RuntimeLayoutConfig,
+): Promise<RuntimeAssets> {
   const runtimeDir = path.join(import.meta.dir, "..", "runtime");
   const [runtimeJs, treeRuntimeJs, runtimeCss] = await Promise.all([
     bundleRuntimeJs(path.join(runtimeDir, "app.js"), {
@@ -343,7 +393,7 @@ async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeA
       label: "tree-runtime.js",
       replaceTreeIcons: true,
     }),
-    bundleRuntimeCss(path.join(runtimeDir, "app.css")),
+    bundleRuntimeCss(path.join(runtimeDir, "app.css"), layout),
   ]);
 
   const jsRelPath = `assets/app.${makeHash(runtimeJs).slice(0, 12)}.js`;
@@ -375,8 +425,8 @@ async function writeRuntimeAssets(context: OutputWriteContext): Promise<RuntimeA
 }
 
 function buildShellMeta(route: string, doc: DocRecord | null, options: BuildOptions): AppShellMeta {
-  const defaultTitle = options.seo?.defaultTitle ?? options.siteTitle ?? DEFAULT_SITE_TITLE;
   const siteTitle = resolveSiteTitle(options);
+  const defaultTitle = options.seo?.defaultTitle ?? siteTitle;
   const defaultDescription = options.seo?.defaultDescription ?? DEFAULT_SITE_DESCRIPTION;
   const description =
     typeof doc?.description === "string" && doc.description.trim().length > 0
@@ -420,7 +470,7 @@ function buildInitialView(
 ): AppShellInitialView {
   const manifestDoc = manifestDocById.get(doc.id);
   const activeBranch =
-    normalizeViewBranch(doc.branch) ?? normalizeViewBranch(defaultBranch) ?? "dev";
+    normalizeViewBranch(doc.branch) ?? normalizeViewBranch(defaultBranch) ?? DEFAULT_BRANCH;
   const visibleDocs = filterViewDocsByBranch(docs, activeBranch, defaultBranch);
   const chrome = renderViewChrome({
     route: doc.route,
@@ -480,6 +530,7 @@ async function writeShellPages(
     render404Html(
       buildAppShellAssetsForOutput("404.html", runtimeAssets),
       toViewPathWithBase("/", pathBase),
+      resolveSiteTitle(options),
     ),
   );
 
@@ -569,7 +620,7 @@ export async function prepareOutputPhase(
     previousHashes,
     nextHashes: {},
   };
-  const runtimeAssets = await writeRuntimeAssets(context);
+  const runtimeAssets = await writeRuntimeAssets(context, options.layout);
   await copyStaticPaths(context, options);
   return { context, runtimeAssets };
 }

--- a/src/build/shared.ts
+++ b/src/build/shared.ts
@@ -1,7 +1,6 @@
 import type { BuildOptions } from "../types";
+import { DEFAULT_SITE_TITLE } from "../defaults";
 import { makeHash } from "../utils";
-
-const DEFAULT_SITE_TITLE = "File-System Blog";
 
 export const OUTPUT_MARKER_FILE_NAME = ".eiam-output.json";
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -1,6 +1,7 @@
 import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { OUTPUT_MARKER_FILE_NAME } from "./build/shared";
+import { DEFAULT_RUNTIME_CONFIG } from "./defaults";
 import { normalizeSeoConfig } from "./seo";
 import type { BuildOptions, PinnedMenuOption, UserConfig, UserSeoConfig } from "./types";
 
@@ -27,11 +28,8 @@ const DEFAULTS = {
   gfm: true,
   allowUnsafeHtml: false,
   shikiTheme: "github-dark",
-  mermaid: {
-    enabled: true,
-    cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
-    theme: "default",
-  },
+  defaultBranch: DEFAULT_RUNTIME_CONFIG.defaultBranch,
+  mermaid: DEFAULT_RUNTIME_CONFIG.mermaid,
 };
 
 const MERMAID_URL_MAX_LENGTH = 1024;
@@ -589,7 +587,17 @@ export function validateUserConfig(
   const config = requireRecord(raw, "<root>");
   warnUnknownFields(
     config,
-    ["vaultDir", "outDir", "exclude", "staticPaths", "pinnedMenu", "ui", "markdown", "seo"],
+    [
+      "vaultDir",
+      "outDir",
+      "defaultBranch",
+      "exclude",
+      "staticPaths",
+      "pinnedMenu",
+      "ui",
+      "markdown",
+      "seo",
+    ],
     "",
     "[config]",
     warn,
@@ -598,9 +606,14 @@ export function validateUserConfig(
   const normalized: ValidatedUserConfig = {};
   const vaultDir = optionalString(config, "vaultDir", "vaultDir");
   const outDir = optionalString(config, "outDir", "outDir");
+  const defaultBranch = optionalString(config, "defaultBranch", "defaultBranch", {
+    trim: true,
+    allowEmpty: false,
+  });
 
   if (vaultDir !== undefined) normalized.vaultDir = vaultDir;
   if (outDir !== undefined) normalized.outDir = outDir;
+  if (defaultBranch !== undefined) normalized.defaultBranch = defaultBranch.toLowerCase();
   if (config.exclude !== undefined)
     normalized.exclude = normalizeStringArray(config.exclude, "exclude");
   if (config.staticPaths !== undefined) {
@@ -697,6 +710,7 @@ export function resolveBuildOptions(
     staticPaths,
     newWithinDays,
     recentLimit,
+    defaultBranch: config.defaultBranch ?? DEFAULTS.defaultBranch,
     siteTitle,
     pinnedMenu: resolvedPinnedMenu,
     wikilinks: config.markdown?.wikilinks ?? DEFAULTS.wikilinks,
@@ -709,6 +723,7 @@ export function resolveBuildOptions(
       cdnUrl: config.markdown?.mermaid?.cdnUrl ?? DEFAULTS.mermaid.cdnUrl,
       theme: config.markdown?.mermaid?.theme ?? DEFAULTS.mermaid.theme,
     },
+    layout: { ...DEFAULT_RUNTIME_CONFIG.layout },
     seo,
   };
 }

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,0 +1,52 @@
+export interface RuntimeLayoutConfig {
+  compactBreakpointPx: number;
+  desktopSidebarDefaultPx: number;
+  desktopSidebarMinPx: number;
+  desktopViewerMinPx: number;
+  splitterWidthPx: number;
+  splitterStepPx: number;
+  mobileSidebarMinPx: number;
+  mobileSidebarMaxPx: number;
+}
+
+export const DEFAULT_BRANCH = "dev";
+export const DEFAULT_SITE_TITLE = "File-System Blog";
+
+export const DEFAULT_MERMAID_CONFIG = Object.freeze({
+  enabled: true,
+  cdnUrl: "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js",
+  theme: "default",
+});
+
+export const DEFAULT_RUNTIME_LAYOUT: Readonly<RuntimeLayoutConfig> = Object.freeze({
+  compactBreakpointPx: 1024,
+  desktopSidebarDefaultPx: 420,
+  desktopSidebarMinPx: 320,
+  desktopViewerMinPx: 680,
+  splitterWidthPx: 10,
+  splitterStepPx: 24,
+  mobileSidebarMinPx: 300,
+  mobileSidebarMaxPx: 560,
+});
+
+export const DEFAULT_RUNTIME_CONFIG = Object.freeze({
+  defaultBranch: DEFAULT_BRANCH,
+  siteTitle: DEFAULT_SITE_TITLE,
+  mermaid: DEFAULT_MERMAID_CONFIG,
+  layout: DEFAULT_RUNTIME_LAYOUT,
+});
+
+export function resolveRuntimeLayoutConfig(value: unknown): RuntimeLayoutConfig {
+  const layout =
+    typeof value === "object" && value !== null && !Array.isArray(value)
+      ? (value as Partial<RuntimeLayoutConfig>)
+      : {};
+  const resolved: RuntimeLayoutConfig = { ...DEFAULT_RUNTIME_LAYOUT };
+  for (const key of Object.keys(resolved) as Array<keyof RuntimeLayoutConfig>) {
+    const candidate = layout[key];
+    if (typeof candidate === "number" && Number.isFinite(candidate) && candidate > 0) {
+      resolved[key] = candidate;
+    }
+  }
+  return resolved;
+}

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -75,10 +75,6 @@
   --content-image-frame-bg: linear-gradient(180deg, var(--latte-base), var(--latte-mantle));
   --mermaid-wide-max-width: 820px;
   --mermaid-tall-max-height: 560px;
-  --desktop-sidebar-default: 420px;
-  --desktop-sidebar-min: 320px;
-  --desktop-viewer-min: 680px;
-  --splitter-width: 10px;
 }
 
 :root[data-theme="dark"] {
@@ -1646,7 +1642,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 /* Responsive */
-@media (max-width: 1024px) {
+@media (max-width: 0px /* eiam-compact-breakpoint */) {
   .app-root {
     grid-template-columns: 1fr;
   }
@@ -1664,8 +1660,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
     height: 100dvh;
     max-height: 100dvh;
     width: 70vw;
-    min-width: 300px;
-    max-width: 560px;
+    min-width: var(--mobile-sidebar-min);
+    max-width: var(--mobile-sidebar-max);
     border-right: 1px solid var(--latte-surface0);
     border-bottom: 0;
     box-shadow: var(--sidebar-mobile-shadow);
@@ -1811,7 +1807,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   }
 }
 
-@media (max-width: 1024px) and (max-height: 640px) {
+@media (max-width: 0px /* eiam-compact-breakpoint */) and (max-height: 640px) {
   .sidebar-header {
     padding-top: 12px;
     padding-bottom: 10px;

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -121,6 +121,7 @@ async function start() {
   /** @type {TreeController | null} */
   let treeController = null;
   const layoutController = createSidebarLayoutController({
+    layout: bootstrap.manifest.layout,
     closeSettings: () => settingsController.close(),
     requestTreeLoad: (reason) => treeController?.requestLoad(reason) ?? Promise.resolve(false),
   });

--- a/src/runtime/mermaid-controller.js
+++ b/src/runtime/mermaid-controller.js
@@ -1,5 +1,5 @@
-const MERMAID_CDN = "https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js";
-const MERMAID_DEFAULT_THEME = "default";
+import { DEFAULT_MERMAID_CONFIG } from "../defaults.ts";
+
 const MERMAID_SELECTOR = "pre.mermaid";
 const MERMAID_ERROR_CLASS = "mermaid-render-error";
 const MERMAID_THEME_VALIDATION_RE = /^[a-zA-Z][a-zA-Z0-9._-]*$/;
@@ -33,15 +33,16 @@ const mermaidRuntime = {
 export function resolveMermaidConfig(manifest) {
   const mermaid = manifest?.mermaid;
   return {
-    enabled: mermaid?.enabled !== false,
+    enabled:
+      typeof mermaid?.enabled === "boolean" ? mermaid.enabled : DEFAULT_MERMAID_CONFIG.enabled,
     cdnUrl:
       typeof mermaid?.cdnUrl === "string" && mermaid.cdnUrl.trim()
         ? mermaid.cdnUrl.trim()
-        : MERMAID_CDN,
+        : DEFAULT_MERMAID_CONFIG.cdnUrl,
     theme:
       typeof mermaid?.theme === "string" && MERMAID_THEME_VALIDATION_RE.test(mermaid.theme.trim())
         ? mermaid.theme.trim()
-        : MERMAID_DEFAULT_THEME,
+        : DEFAULT_MERMAID_CONFIG.theme,
   };
 }
 
@@ -49,7 +50,7 @@ export function resolveMermaidConfig(manifest) {
 function normalizeMermaidTheme(value) {
   const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized || !MERMAID_THEME_VALIDATION_RE.test(normalized)) {
-    return MERMAID_DEFAULT_THEME;
+    return DEFAULT_MERMAID_CONFIG.theme;
   }
   return normalized;
 }
@@ -58,7 +59,7 @@ function normalizeMermaidTheme(value) {
 function normalizeMermaidUrl(value) {
   const normalized = typeof value === "string" ? value.trim() : "";
   if (!normalized || !MERMAID_URL_VALIDATION_RE.test(normalized)) {
-    return MERMAID_CDN;
+    return DEFAULT_MERMAID_CONFIG.cdnUrl;
   }
   return normalized;
 }
@@ -129,7 +130,7 @@ function normalizeRenderedMermaidSvg(block, windowRef) {
   svg.style.width = "auto";
   svg.style.height = "auto";
   svg.style.margin = "0 auto";
-  svg.style.maxWidth = "min(100%, var(--content-visual-max-width, 880px))";
+  svg.style.maxWidth = "min(100%, var(--content-visual-max-width))";
   svg.style.removeProperty("max-height");
 
   const viewBox = svg.viewBox?.baseVal;
@@ -149,12 +150,12 @@ function normalizeRenderedMermaidSvg(block, windowRef) {
   const aspectRatio = intrinsicWidth / intrinsicHeight;
   if (container && aspectRatio >= MERMAID_WIDE_RATIO) {
     container.classList.add(MERMAID_BLOCK_WIDE_CLASS);
-    svg.style.maxWidth = "min(100%, var(--mermaid-wide-max-width, 820px))";
+    svg.style.maxWidth = "min(100%, var(--mermaid-wide-max-width))";
   }
 
   if (container && aspectRatio <= MERMAID_TALL_RATIO) {
     container.classList.add(MERMAID_BLOCK_TALL_CLASS);
-    svg.style.maxHeight = "min(var(--mermaid-tall-max-height, 560px), 68vh)";
+    svg.style.maxHeight = "min(var(--mermaid-tall-max-height), 68vh)";
   }
 }
 

--- a/src/runtime/navigation-state.js
+++ b/src/runtime/navigation-state.js
@@ -1,5 +1,6 @@
 import { getRuntimeManifestDocs } from "./manifest-adapter.js";
 import { buildTreesAdapterInput } from "./tree-adapter.js";
+import { DEFAULT_BRANCH } from "../defaults.ts";
 import {
   filterViewDocsByBranch,
   normalizeViewBranch as normalizeBranch,
@@ -10,8 +11,6 @@ import {
   stripViewPathBase as stripPathBase,
   toViewPathWithBase as toPathWithBase,
 } from "../view-contract.ts";
-
-const DEFAULT_BRANCH = "dev";
 
 /** @typedef {import("./contracts").BranchView} BranchView */
 /** @typedef {import("./contracts").NavigationState} NavigationState */

--- a/src/runtime/runtime-bootstrap.js
+++ b/src/runtime/runtime-bootstrap.js
@@ -1,12 +1,11 @@
 import { normalizeManifestPayload } from "./manifest-adapter.js";
+import { DEFAULT_SITE_TITLE } from "../defaults.ts";
 import {
   normalizePathBase,
   normalizeRoute,
   stripPathBase,
   toPathWithBase,
 } from "./navigation-state.js";
-
-const DEFAULT_SITE_TITLE = "File-System Blog";
 
 /** @typedef {import("./contracts").InitialRuntimeData} InitialRuntimeData */
 /** @typedef {import("./contracts").InitialViewData} InitialViewData */

--- a/src/runtime/sidebar-layout-controller.js
+++ b/src/runtime/sidebar-layout-controller.js
@@ -1,12 +1,7 @@
 import { createEventScope } from "./controller-lifecycle.js";
+import { DEFAULT_RUNTIME_LAYOUT, resolveRuntimeLayoutConfig } from "../defaults.ts";
 
-const COMPACT_LAYOUT_QUERY = "(max-width: 1024px)";
 const SIDEBAR_WIDTH_KEY = "fsblog.desktopSidebarWidth";
-const DESKTOP_SIDEBAR_DEFAULT = 420;
-const DESKTOP_SIDEBAR_MIN = 320;
-const DESKTOP_VIEWER_MIN = 680;
-const DESKTOP_SPLITTER_WIDTH = 10;
-const DESKTOP_SPLITTER_STEP = 24;
 const FOCUSABLE_SELECTOR =
   'a[href], button:not([disabled]), input:not([disabled]), textarea:not([disabled]), select:not([disabled]), [tabindex]:not([tabindex="-1"])';
 
@@ -63,13 +58,31 @@ function getFocusableElements(container, windowRef) {
 /**
  * @param {number} width
  * @param {number} viewportWidth
+ * @param {import("../defaults").RuntimeLayoutConfig} layout
  */
-export function clampDesktopSidebarWidth(width, viewportWidth) {
+function clampResolvedDesktopSidebarWidth(width, viewportWidth, layout) {
   const max = Math.max(
-    DESKTOP_SIDEBAR_MIN,
-    viewportWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
+    layout.desktopSidebarMinPx,
+    viewportWidth - layout.desktopViewerMinPx - layout.splitterWidthPx,
   );
-  return Math.min(Math.max(width, DESKTOP_SIDEBAR_MIN), max);
+  return Math.min(Math.max(width, layout.desktopSidebarMinPx), max);
+}
+
+/**
+ * @param {number} width
+ * @param {number} viewportWidth
+ * @param {unknown} [layoutConfig]
+ */
+export function clampDesktopSidebarWidth(
+  width,
+  viewportWidth,
+  layoutConfig = DEFAULT_RUNTIME_LAYOUT,
+) {
+  return clampResolvedDesktopSidebarWidth(
+    width,
+    viewportWidth,
+    resolveRuntimeLayoutConfig(layoutConfig),
+  );
 }
 
 /**
@@ -77,6 +90,7 @@ export function clampDesktopSidebarWidth(width, viewportWidth) {
  *   documentRef?: Document;
  *   windowRef?: RuntimeWindow;
  *   storage?: Storage;
+ *   layout?: unknown;
  *   requestTreeLoad?: (reason: string) => Promise<boolean>;
  *   closeSettings?: () => void;
  * }} [options]
@@ -86,6 +100,7 @@ export function createSidebarLayoutController(options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
   const storage = options.storage ?? globalThis.localStorage;
+  const layout = resolveRuntimeLayoutConfig(options.layout);
   const requestTreeLoad = options.requestTreeLoad ?? (() => Promise.resolve(false));
   const closeSettings = options.closeSettings ?? (() => {});
   const appRoot = documentRef.querySelector(".app-root");
@@ -95,10 +110,10 @@ export function createSidebarLayoutController(options = {}) {
   const sidebarClose = documentRef.getElementById("sidebar-close");
   const sidebarOverlay = documentRef.getElementById("sidebar-overlay");
   const viewer = documentRef.querySelector(".viewer");
-  const compactMediaQuery = windowRef.matchMedia(COMPACT_LAYOUT_QUERY);
+  const compactMediaQuery = windowRef.matchMedia(`(max-width: ${layout.compactBreakpointPx}px)`);
   /** @type {EventScope | null} */
   let events = null;
-  let desktopSidebarWidth = DESKTOP_SIDEBAR_DEFAULT;
+  let desktopSidebarWidth = layout.desktopSidebarDefaultPx;
   /** @type {number | null} */
   let activeResizePointerId = null;
   let resizeStartX = 0;
@@ -111,10 +126,10 @@ export function createSidebarLayoutController(options = {}) {
       return;
     }
     const max = Math.max(
-      DESKTOP_SIDEBAR_MIN,
-      windowRef.innerWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
+      layout.desktopSidebarMinPx,
+      windowRef.innerWidth - layout.desktopViewerMinPx - layout.splitterWidthPx,
     );
-    splitter.setAttribute("aria-valuemin", String(DESKTOP_SIDEBAR_MIN));
+    splitter.setAttribute("aria-valuemin", String(layout.desktopSidebarMinPx));
     splitter.setAttribute("aria-valuemax", String(Math.round(max)));
     splitter.setAttribute("aria-valuenow", String(Math.round(desktopSidebarWidth)));
     splitter.setAttribute("aria-valuetext", `${Math.round(desktopSidebarWidth)}px`);
@@ -123,7 +138,11 @@ export function createSidebarLayoutController(options = {}) {
 
   /** @param {boolean} persist */
   const syncDesktopSidebarWidth = (persist) => {
-    desktopSidebarWidth = clampDesktopSidebarWidth(desktopSidebarWidth, windowRef.innerWidth);
+    desktopSidebarWidth = clampResolvedDesktopSidebarWidth(
+      desktopSidebarWidth,
+      windowRef.innerWidth,
+      layout,
+    );
     if (appRoot instanceof windowRef.HTMLElement) {
       if (isCompact()) {
         appRoot.style.removeProperty("--sidebar-width");
@@ -294,16 +313,16 @@ export function createSidebarLayoutController(options = {}) {
       return;
     }
     const max = Math.max(
-      DESKTOP_SIDEBAR_MIN,
-      windowRef.innerWidth - DESKTOP_VIEWER_MIN - DESKTOP_SPLITTER_WIDTH,
+      layout.desktopSidebarMinPx,
+      windowRef.innerWidth - layout.desktopViewerMinPx - layout.splitterWidthPx,
     );
     let nextWidth = desktopSidebarWidth;
     if (event.key === "ArrowLeft") {
-      nextWidth -= DESKTOP_SPLITTER_STEP;
+      nextWidth -= layout.splitterStepPx;
     } else if (event.key === "ArrowRight") {
-      nextWidth += DESKTOP_SPLITTER_STEP;
+      nextWidth += layout.splitterStepPx;
     } else if (event.key === "Home") {
-      nextWidth = DESKTOP_SIDEBAR_MIN;
+      nextWidth = layout.desktopSidebarMinPx;
     } else if (event.key === "End") {
       nextWidth = max;
     } else {
@@ -371,7 +390,9 @@ export function createSidebarLayoutController(options = {}) {
         return;
       }
       const storedWidth = Number.parseInt(storage.getItem(SIDEBAR_WIDTH_KEY) ?? "", 10);
-      desktopSidebarWidth = Number.isFinite(storedWidth) ? storedWidth : DESKTOP_SIDEBAR_DEFAULT;
+      desktopSidebarWidth = Number.isFinite(storedWidth)
+        ? storedWidth
+        : layout.desktopSidebarDefaultPx;
       events = createEventScope();
       events.listen(sidebarToggle, "click", open);
       events.listen(sidebarClose, "click", close);

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,8 +1,8 @@
 import { escapeHtmlAttribute } from "./seo";
+import { DEFAULT_SITE_TITLE } from "./defaults";
 import type { Manifest } from "./types";
 import { toViewPathWithBase } from "./view-contract";
 
-const DEFAULT_TITLE = "File-System Blog";
 const DEFAULT_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 
 export interface AppShellMeta {
@@ -77,7 +77,7 @@ function stringifyJsonLd(value: unknown): string {
 }
 
 function renderHeadMeta(meta: AppShellMeta): string {
-  const title = (meta.title ?? DEFAULT_TITLE).trim() || DEFAULT_TITLE;
+  const title = (meta.title ?? DEFAULT_SITE_TITLE).trim() || DEFAULT_SITE_TITLE;
   const description = typeof meta.description === "string" ? meta.description.trim() : "";
   const fallbackDescription = description || DEFAULT_DESCRIPTION;
   const canonicalUrl = typeof meta.canonicalUrl === "string" ? meta.canonicalUrl.trim() : "";
@@ -218,7 +218,7 @@ export function renderAppShellHtml(
   const appTitle =
     typeof manifest?.siteTitle === "string" && manifest.siteTitle.trim().length > 0
       ? manifest.siteTitle.trim()
-      : DEFAULT_TITLE;
+      : DEFAULT_SITE_TITLE;
   const initialTitle = initialView ? escapeHtmlAttribute(initialView.title) : "문서를 선택하세요";
   const initialBreadcrumb = initialView ? initialView.breadcrumbHtml : "";
   const initialMeta = initialView ? initialView.metaHtml : "";
@@ -386,7 +386,11 @@ ${runtimeBootstrapScript}
 `;
 }
 
-export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS, homeHref = "/"): string {
+export function render404Html(
+  assets: AppShellAssets = DEFAULT_ASSETS,
+  homeHref = "/",
+  siteTitle = DEFAULT_SITE_TITLE,
+): string {
   const symbolFontStylesheet =
     "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
 
@@ -395,7 +399,7 @@ export function render404Html(assets: AppShellAssets = DEFAULT_ASSETS, homeHref 
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>404 - File-System Blog</title>
+    <title>404 - ${escapeHtmlAttribute(siteTitle.trim() || DEFAULT_SITE_TITLE)}</title>
     <link rel="preconnect" href="https://fonts.googleapis.com" />
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
     <link rel="preload" as="style" href="${escapeHtmlAttribute(symbolFontStylesheet)}" />

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,3 +1,5 @@
+import type { RuntimeLayoutConfig } from "./defaults";
+
 export type ImagePolicy = "keep" | "omit-local";
 
 export interface UserSeoConfig {
@@ -39,6 +41,7 @@ export interface PinnedMenuOption {
 export interface UserConfig {
   vaultDir?: string;
   outDir?: string;
+  defaultBranch?: string;
   exclude?: string[];
   staticPaths?: string[];
   pinnedMenu?: {
@@ -75,6 +78,7 @@ export interface BuildOptions {
   staticPaths: string[];
   newWithinDays: number;
   recentLimit: number;
+  defaultBranch: string;
   siteTitle?: string;
   pinnedMenu: PinnedMenuOption | null;
   wikilinks: boolean;
@@ -87,6 +91,7 @@ export interface BuildOptions {
     cdnUrl: string;
     theme: string;
   };
+  layout: RuntimeLayoutConfig;
   seo: BuildSeoOptions | null;
 }
 
@@ -160,6 +165,7 @@ export interface Manifest {
     cdnUrl: string;
     theme: string;
   };
+  layout: RuntimeLayoutConfig;
   ui: {
     newWithinDays: number;
     recentLimit: number;

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -1,5 +1,4 @@
-const DEFAULT_BRANCH = "dev";
-const DEFAULT_SITE_TITLE = "File-System Blog";
+import { DEFAULT_BRANCH, DEFAULT_SITE_TITLE } from "./defaults";
 
 export interface ViewBacklinkContract {
   route?: unknown;

--- a/tests/e2e/build-phases.spec.ts
+++ b/tests/e2e/build-phases.spec.ts
@@ -1,7 +1,8 @@
 import fs from "node:fs/promises";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
-import { buildDocumentGraph } from "../../src/build/graph";
+import { buildDocumentGraph, pickHomeDoc } from "../../src/build/graph";
+import { DEFAULT_RUNTIME_LAYOUT } from "../../src/defaults";
 import type { BuildOptions, DocRecord } from "../../src/types";
 
 const options: BuildOptions = {
@@ -11,6 +12,7 @@ const options: BuildOptions = {
   staticPaths: [],
   newWithinDays: 7,
   recentLimit: 5,
+  defaultBranch: "dev",
   pinnedMenu: null,
   wikilinks: true,
   imagePolicy: "omit-local",
@@ -22,6 +24,7 @@ const options: BuildOptions = {
     cdnUrl: "https://example.test/mermaid.js",
     theme: "default",
   },
+  layout: { ...DEFAULT_RUNTIME_LAYOUT },
   seo: null,
 };
 
@@ -65,6 +68,23 @@ test.describe("build phase contracts", () => {
     ]);
     expect(graph.wikiLookup.byTitle.get("target")).toEqual([target]);
     expect(graph.tree[0]).toMatchObject({ type: "folder", name: "Recent", virtual: true });
+  });
+
+  test("custom defaultBranch가 manifest, branch order, home selection에 일관되게 적용된다", () => {
+    const main = { ...createDoc("main", "Main", "/MAIN/"), branch: "main" };
+    const dev = { ...createDoc("dev", "Dev", "/DEV/"), branch: "dev" };
+    const unclassified = createDoc("unclassified", "Unclassified", "/UNCLASSIFIED/");
+    unclassified.updatedDate = "2026-07-20";
+    const customOptions = { ...options, defaultBranch: "main" };
+
+    const graph = buildDocumentGraph([dev, main, unclassified], customOptions);
+
+    expect(graph.manifest.defaultBranch).toBe("main");
+    expect(graph.manifest.branches).toEqual(["main", "dev"]);
+    expect(graph.manifest.layout).toEqual(DEFAULT_RUNTIME_LAYOUT);
+    expect(pickHomeDoc([dev, main, unclassified], customOptions.defaultBranch)?.id).toBe(
+      "unclassified",
+    );
   });
 
   test("pipeline entry는 phase composition만 소유한다", async () => {

--- a/tests/e2e/runtime-defaults.spec.ts
+++ b/tests/e2e/runtime-defaults.spec.ts
@@ -1,0 +1,148 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import {
+  DEFAULT_BRANCH,
+  DEFAULT_MERMAID_CONFIG,
+  DEFAULT_RUNTIME_LAYOUT,
+  DEFAULT_SITE_TITLE,
+} from "../../src/defaults";
+import { resolveMermaidConfig } from "../../src/runtime/mermaid-controller.js";
+import { createNavigationState } from "../../src/runtime/navigation-state.js";
+import { resolveSiteTitle } from "../../src/runtime/runtime-bootstrap.js";
+import { clampDesktopSidebarWidth } from "../../src/runtime/sidebar-layout-controller.js";
+import type { Manifest } from "../../src/types";
+
+interface BuiltFixture {
+  appCss: string;
+  appJs: string;
+  indexHtml: string;
+  notFoundHtml: string;
+  manifest: Manifest;
+}
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function writeDoc(vaultDir: string, id: string, branch: string | null, date: string): void {
+  const branchLine = branch ? `branch: ${branch}\n` : "";
+  writeText(
+    path.join(vaultDir, `${id}.md`),
+    `---
+publish: true
+prefix: ${id.toUpperCase()}
+category_path: defaults
+title: ${id}
+date: ${date}
+${branchLine}---
+
+## ${id}
+`,
+  );
+}
+
+function buildFixture(repoRoot: string, configSource?: string): BuiltFixture {
+  const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-runtime-defaults-"));
+  const vaultDir = path.join(workDir, "vault");
+  const outDir = path.join(workDir, "dist");
+
+  try {
+    writeDoc(vaultDir, "dev", "dev", "2026-07-18");
+    writeDoc(vaultDir, "main", "main", "2026-07-19");
+    writeDoc(vaultDir, "unclassified", null, "2026-07-20");
+    if (configSource) {
+      writeText(path.join(workDir, "blog.config.mjs"), configSource);
+    }
+
+    const result = spawnSync(
+      "bun",
+      [path.join(repoRoot, "src/cli.ts"), "build", "--vault", vaultDir, "--out", outDir],
+      { cwd: workDir, encoding: "utf8" },
+    );
+    const output = `${result.stdout ?? ""}${result.stderr ?? ""}`;
+    expect(result.status, output).toBe(0);
+
+    const assets = fs.readdirSync(path.join(outDir, "assets"));
+    const appCssName = assets.find((name) => /^app\.[a-f0-9]{12}\.css$/.test(name));
+    const appJsName = assets.find((name) => /^app\.[a-f0-9]{12}\.js$/.test(name));
+    expect(appCssName).toBeTruthy();
+    expect(appJsName).toBeTruthy();
+
+    return {
+      appCss: fs.readFileSync(path.join(outDir, "assets", appCssName!), "utf8"),
+      appJs: fs.readFileSync(path.join(outDir, "assets", appJsName!), "utf8"),
+      indexHtml: fs.readFileSync(path.join(outDir, "index.html"), "utf8"),
+      notFoundHtml: fs.readFileSync(path.join(outDir, "404.html"), "utf8"),
+      manifest: JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as Manifest,
+    };
+  } finally {
+    fs.rmSync(workDir, { recursive: true, force: true });
+  }
+}
+
+test("default와 custom config가 emitted runtime defaults를 같은 경로로 소비한다", () => {
+  const repoRoot = process.cwd();
+  const defaults = buildFixture(repoRoot);
+  const custom = buildFixture(
+    repoRoot,
+    `export default {
+  defaultBranch: " MAIN ",
+  seo: { siteName: "Custom Notes" },
+  markdown: {
+    mermaid: {
+      enabled: false,
+      cdnUrl: "/assets/mermaid.js",
+      theme: "forest",
+    },
+  },
+};
+`,
+  );
+
+  expect(defaults.manifest).toMatchObject({
+    defaultBranch: DEFAULT_BRANCH,
+    siteTitle: DEFAULT_SITE_TITLE,
+    mermaid: DEFAULT_MERMAID_CONFIG,
+    layout: DEFAULT_RUNTIME_LAYOUT,
+  });
+  expect(custom.manifest).toMatchObject({
+    defaultBranch: "main",
+    siteTitle: "Custom Notes",
+    mermaid: {
+      enabled: false,
+      cdnUrl: "/assets/mermaid.js",
+      theme: "forest",
+    },
+    layout: DEFAULT_RUNTIME_LAYOUT,
+  });
+  expect(custom.manifest.branches).toEqual(["main", "dev"]);
+
+  const defaultNavigation = createNavigationState(defaults.manifest);
+  const customNavigation = createNavigationState(custom.manifest);
+  expect(defaultNavigation.defaultBranch).toBe(DEFAULT_BRANCH);
+  expect(defaultNavigation.view.docs.map(({ id }) => id).sort()).toEqual(["dev", "unclassified"]);
+  expect(customNavigation.defaultBranch).toBe("main");
+  expect(customNavigation.view.docs.map(({ id }) => id).sort()).toEqual(["main", "unclassified"]);
+  expect(resolveSiteTitle(defaults.manifest)).toBe(DEFAULT_SITE_TITLE);
+  expect(resolveSiteTitle(custom.manifest)).toBe("Custom Notes");
+  expect(resolveMermaidConfig(defaults.manifest)).toEqual(DEFAULT_MERMAID_CONFIG);
+  expect(resolveMermaidConfig(custom.manifest)).toEqual(custom.manifest.mermaid);
+  expect(clampDesktopSidebarWidth(9999, 1440, custom.manifest.layout)).toBe(750);
+
+  expect(custom.indexHtml).toContain("Custom Notes");
+  expect(custom.indexHtml).toContain('"name":"Custom Notes"');
+  expect(custom.notFoundHtml).toContain("<title>404 - Custom Notes</title>");
+  expect(custom.appCss).toBe(defaults.appCss);
+  expect(custom.appJs).toBe(defaults.appJs);
+  expect(defaults.appCss).toContain("--desktop-sidebar-default:420px");
+  expect(defaults.appCss).toContain("--desktop-sidebar-min:320px");
+  expect(defaults.appCss).toContain("--mobile-sidebar-min:300px");
+  expect(defaults.appCss).toContain("--mobile-sidebar-max:560px");
+  expect(defaults.appCss).toContain("@media (max-width:1024px)");
+  expect(defaults.appCss).not.toContain("eiam-compact-breakpoint");
+  expect(defaults.appJs.match(/mermaid@10\/dist\/mermaid\.min\.js/g)).toHaveLength(1);
+});

--- a/tests/e2e/shiki-loading.spec.ts
+++ b/tests/e2e/shiki-loading.spec.ts
@@ -2,6 +2,7 @@ import fs from "node:fs";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
 import { createMarkdownRenderer } from "../../src/markdown";
+import { DEFAULT_RUNTIME_LAYOUT } from "../../src/defaults";
 import type { BuildOptions, WikiResolver } from "../../src/types";
 
 const resolver: WikiResolver = {
@@ -16,6 +17,7 @@ function buildOptions(shikiTheme = "github-dark"): BuildOptions {
     staticPaths: [],
     newWithinDays: 7,
     recentLimit: 5,
+    defaultBranch: "dev",
     pinnedMenu: null,
     wikilinks: false,
     imagePolicy: "omit-local",
@@ -27,6 +29,7 @@ function buildOptions(shikiTheme = "github-dark"): BuildOptions {
       cdnUrl: "",
       theme: "default",
     },
+    layout: { ...DEFAULT_RUNTIME_LAYOUT },
     seo: null,
   };
 }

--- a/tests/unit/cache-guards.test.ts
+++ b/tests/unit/cache-guards.test.ts
@@ -3,6 +3,7 @@ import fs from "node:fs/promises";
 import os from "node:os";
 import path from "node:path";
 import { inspectBuildStorage } from "../../src/build/storage";
+import { DEFAULT_RUNTIME_LAYOUT } from "../../src/defaults";
 import type { BuildOptions } from "../../src/types";
 
 const temporaryRoots: string[] = [];
@@ -27,6 +28,7 @@ async function createTemporaryRoot(): Promise<string> {
 function createBuildOptions(vaultDir: string, outDir: string): BuildOptions {
   return {
     allowUnsafeHtml: false,
+    defaultBranch: "dev",
     exclude: [],
     gfm: true,
     imagePolicy: "omit-local",
@@ -35,6 +37,7 @@ function createBuildOptions(vaultDir: string, outDir: string): BuildOptions {
       enabled: true,
       theme: "default",
     },
+    layout: { ...DEFAULT_RUNTIME_LAYOUT },
     newWithinDays: 7,
     outDir,
     pinnedMenu: null,

--- a/tests/unit/config-validation.test.ts
+++ b/tests/unit/config-validation.test.ts
@@ -22,6 +22,7 @@ describe("user config validation", () => {
       {
         vaultDir: "./vault",
         outDir: "./site",
+        defaultBranch: " Main ",
         exclude: ["private/**"],
         staticPaths: ["./assets/", "assets", "public/favicon.ico"],
         pinnedMenu: {
@@ -70,6 +71,7 @@ describe("user config validation", () => {
     expect(config).toMatchObject({
       vaultDir: "./vault",
       outDir: "./site",
+      defaultBranch: "main",
       exclude: ["private/**"],
       staticPaths: ["assets", "public/favicon.ico"],
       pinnedMenu: {
@@ -149,6 +151,12 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
     },
     { name: "vaultDir", config: { vaultDir: 42 }, field: "vaultDir", receivedType: "number" },
     { name: "outDir", config: { outDir: null }, field: "outDir", receivedType: "null" },
+    {
+      name: "defaultBranch",
+      config: { defaultBranch: 42 },
+      field: "defaultBranch",
+      receivedType: "number",
+    },
     {
       name: "exclude array",
       config: { exclude: "private/**" },
@@ -421,6 +429,15 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
     });
   });
 
+  test("rejects an empty defaultBranch and normalizes a configured branch", () => {
+    expect(() => validateUserConfig({ defaultBranch: "   " }, () => {})).toThrow(
+      '"defaultBranch" must be a non-empty string',
+    );
+    expect(validateUserConfig({ defaultBranch: " Release " }, () => {})).toEqual({
+      defaultBranch: "release",
+    });
+  });
+
   test("validates the complete user config even when CLI values would override it", () => {
     expect(() =>
       resolveBuildOptions(
@@ -448,7 +465,12 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
     expect(options.vaultDir).toBe(path.join("/workspace", "vault"));
     expect(options.outDir).toBe(path.join("/workspace", "site"));
     expect(options.exclude).toEqual([".obsidian/**", "private/**", "drafts/**"]);
+    expect(options.defaultBranch).toBe("dev");
     expect(options.siteTitle).toBe("Notes without canonical URLs");
+    expect(options.layout).toMatchObject({
+      compactBreakpointPx: 1024,
+      desktopSidebarDefaultPx: 420,
+    });
     expect(options.seo).toBeNull();
   });
 });

--- a/tests/unit/runtime-defaults.test.ts
+++ b/tests/unit/runtime-defaults.test.ts
@@ -1,0 +1,62 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_BRANCH,
+  DEFAULT_MERMAID_CONFIG,
+  DEFAULT_RUNTIME_CONFIG,
+  DEFAULT_RUNTIME_LAYOUT,
+  DEFAULT_SITE_TITLE,
+  resolveRuntimeLayoutConfig,
+} from "../../src/defaults";
+
+describe("canonical runtime defaults", () => {
+  test("exposes one immutable default payload", () => {
+    expect(DEFAULT_RUNTIME_CONFIG).toEqual({
+      defaultBranch: DEFAULT_BRANCH,
+      siteTitle: DEFAULT_SITE_TITLE,
+      mermaid: DEFAULT_MERMAID_CONFIG,
+      layout: DEFAULT_RUNTIME_LAYOUT,
+    });
+    expect(Object.isFrozen(DEFAULT_RUNTIME_CONFIG)).toBe(true);
+    expect(Object.isFrozen(DEFAULT_MERMAID_CONFIG)).toBe(true);
+    expect(Object.isFrozen(DEFAULT_RUNTIME_LAYOUT)).toBe(true);
+  });
+
+  test("normalizes emitted layout values with field-level safe defaults", () => {
+    expect(
+      resolveRuntimeLayoutConfig({
+        compactBreakpointPx: 900,
+        desktopSidebarDefaultPx: 480,
+        desktopSidebarMinPx: -1,
+        splitterStepPx: Number.NaN,
+      }),
+    ).toEqual({
+      ...DEFAULT_RUNTIME_LAYOUT,
+      compactBreakpointPx: 900,
+      desktopSidebarDefaultPx: 480,
+    });
+    expect(resolveRuntimeLayoutConfig(null)).toEqual(DEFAULT_RUNTIME_LAYOUT);
+  });
+
+  test("keeps branch, title, and Mermaid fallback literals out of consumers", () => {
+    const consumerPaths = [
+      "src/config.ts",
+      "src/build/graph.ts",
+      "src/build/output.ts",
+      "src/build/shared.ts",
+      "src/template.ts",
+      "src/view-contract.ts",
+      "src/runtime/navigation-state.js",
+      "src/runtime/runtime-bootstrap.js",
+      "src/runtime/mermaid-controller.js",
+    ];
+    const consumers = consumerPaths
+      .map((filePath) => fs.readFileSync(path.resolve(process.cwd(), filePath), "utf8"))
+      .join("\n");
+
+    expect(consumers).not.toContain("https://cdn.jsdelivr.net/npm/mermaid@10/dist/mermaid.min.js");
+    expect(consumers).not.toContain('const DEFAULT_BRANCH = "dev"');
+    expect(consumers).not.toContain('const DEFAULT_SITE_TITLE = "File-System Blog"');
+  });
+});


### PR DESCRIPTION
## Summary
- define one canonical payload for default branch, site title, Mermaid, and runtime layout values
- add validated and documented defaultBranch config, then emit it through the manifest for SSR and browser navigation
- generate sidebar CSS variables and compact media breakpoints from the same layout payload consumed by the runtime controller
- remove repeated Mermaid/title/branch fallbacks and cover default/custom parity

## Validation
- bun install --frozen-lockfile
- bun run lint:source
- bun run format:check
- bun run typecheck
- bun run test:unit (79 passed)
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size
- bun run check:reproducible
- bun run test:e2e (86 passed)

Closes #35
Part of #34