### PR TITLE
refactor: introduce semantic theme tokens

### DIFF
--- a/docs/solutions/20260719-semantic-theme-tokens.md
+++ b/docs/solutions/20260719-semantic-theme-tokens.md
@@ -1,0 +1,21 @@
+# Semantic theme token contract
+
+Issue #37 begins the visual-system work by separating component intent from the
+Catppuccin palette that supplies it. `src/runtime/app.css` now exposes semantic
+roles at the `:root` theme boundary:
+
+- canvas, surface, and muted-surface backgrounds;
+- primary, secondary, muted, and subtle text;
+- default, strong, and emphasis borders;
+- accent, link, focus, success, warning, danger, and code-accent colors;
+- component-level elevation, overlay, tooltip, badge, and content tokens.
+
+Light values live in the default `:root` declaration and dark values override
+the same roles in `:root[data-theme="dark"]`. Components consume only these
+roles, so changing a palette no longer requires knowing every selector that
+uses it. Focus, selection/accent, warning, and NEW/danger remain separate roles
+even when a future palette maps some roles to nearby colors.
+
+`semantic-theme-tokens.spec.ts` rejects palette-specific component variables
+and snapshots the resolved reader/sidebar surfaces and state colors in both
+themes.

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -1,53 +1,24 @@
-/* Catppuccin Latte Theme */
+/* Semantic theme tokens. Components below never depend on palette names. */
 :root {
-  --latte-base: #eff1f5;
-  --latte-mantle: #e6e9ef;
-  --latte-crust: #dce0e8;
-  --latte-text: #4c4f69;
-  --latte-subtext0: #6c6f85;
-  --latte-subtext1: #555974;
-  --latte-overlay0: #5f637a;
-  --latte-surface0: #ccd0da;
-  --latte-surface1: #bcc0cc;
-  --latte-surface2: #acb0be;
-  --latte-rosewater: #dc8a78;
-  --latte-flamingo: #dd7878;
-  --latte-pink: #ea76cb;
-  --latte-mauve: #8839ef;
-  --latte-red: #d20f39;
-  --latte-maroon: #e64553;
-  --latte-peach: #fe640b;
-  --latte-yellow: #df8e1d;
-  --latte-green: #40a02b;
-  --latte-teal: #179299;
-  --latte-sky: #04a5e5;
-  --latte-sapphire: #209fb5;
-  --latte-blue: #1e66f5;
-  --latte-lavender: #7287fd;
-  --mocha-base: #1e1e2e;
-  --mocha-mantle: #181825;
-  --mocha-crust: #11111b;
-  --mocha-text: #cdd6f4;
-  --mocha-subtext0: #a6adc8;
-  --mocha-subtext1: #bac2de;
-  --mocha-overlay0: #a0a7c6;
-  --mocha-surface0: #313244;
-  --mocha-surface1: #45475a;
-  --mocha-surface2: #585b70;
-  --mocha-rosewater: #f5e0dc;
-  --mocha-flamingo: #f2cdcd;
-  --mocha-pink: #f5c2e7;
-  --mocha-mauve: #cba6f7;
-  --mocha-red: #f38ba8;
-  --mocha-maroon: #eba0ac;
-  --mocha-peach: #fab387;
-  --mocha-yellow: #f9e2af;
-  --mocha-green: #a6e3a1;
-  --mocha-teal: #94e2d5;
-  --mocha-sky: #89dceb;
-  --mocha-sapphire: #74c7ec;
-  --mocha-blue: #89b4fa;
-  --mocha-lavender: #b4befe;
+  --color-canvas: #eff1f5;
+  --color-surface: #e6e9ef;
+  --color-surface-muted: #dce0e8;
+  --color-text: #4c4f69;
+  --color-text-secondary: #555974;
+  --color-text-muted: #6c6f85;
+  --color-text-subtle: #5f637a;
+  --color-border: #ccd0da;
+  --color-border-strong: #bcc0cc;
+  --color-border-emphasis: #acb0be;
+  --color-accent: #8839ef;
+  --color-accent-hover: #7030d0;
+  --color-accent-strong: #6732ca;
+  --color-link: #1e66f5;
+  --color-focus: #1e66f5;
+  --color-success: #40a02b;
+  --color-warning: #df8e1d;
+  --color-danger: #d20f39;
+  --color-code-accent: #7287fd;
   --overlay-backdrop: rgba(76, 79, 105, 0.4);
   --elevated-surface: rgba(255, 255, 255, 0.64);
   --elevated-surface-strong: rgba(255, 255, 255, 0.68);
@@ -58,50 +29,43 @@
   --tooltip-text: #ffffff;
   --panel-shadow: 0 14px 32px rgba(76, 79, 105, 0.18);
   --sidebar-mobile-shadow: 0 24px 48px rgba(76, 79, 105, 0.2);
-  --accent-hover: #7030d0;
-  --accent-strong: #6732ca;
-  --badge-new-bg: var(--latte-red);
+  --badge-new-bg: var(--color-danger);
   --badge-new-fg: #ffffff;
-  --mobile-toggle-bg: var(--latte-mauve);
+  --mobile-toggle-bg: var(--color-accent);
   --mobile-toggle-fg: #ffffff;
   --content-heading-accent-soft: rgba(136, 57, 239, 0.32);
-  --content-heading-subtle: var(--latte-subtext1);
+  --content-heading-subtle: var(--color-text-secondary);
   --viewer-container-max-width: 1120px;
   --content-visual-max-width: 880px;
   --content-image-landscape-max-width: 880px;
   --content-image-square-max-width: 720px;
   --content-image-portrait-max-width: 560px;
   --content-image-radius: 8px;
-  --content-image-frame-bg: linear-gradient(180deg, var(--latte-base), var(--latte-mantle));
+  --content-image-frame-bg: linear-gradient(180deg, var(--color-canvas), var(--color-surface));
   --mermaid-wide-max-width: 820px;
   --mermaid-tall-max-height: 560px;
 }
 
 :root[data-theme="dark"] {
-  --latte-base: var(--mocha-base);
-  --latte-mantle: var(--mocha-mantle);
-  --latte-crust: var(--mocha-crust);
-  --latte-text: var(--mocha-text);
-  --latte-subtext0: var(--mocha-subtext0);
-  --latte-subtext1: var(--mocha-subtext1);
-  --latte-overlay0: var(--mocha-overlay0);
-  --latte-surface0: var(--mocha-surface0);
-  --latte-surface1: var(--mocha-surface1);
-  --latte-surface2: var(--mocha-surface2);
-  --latte-rosewater: var(--mocha-rosewater);
-  --latte-flamingo: var(--mocha-flamingo);
-  --latte-pink: var(--mocha-pink);
-  --latte-mauve: var(--mocha-mauve);
-  --latte-red: var(--mocha-red);
-  --latte-maroon: var(--mocha-maroon);
-  --latte-peach: var(--mocha-peach);
-  --latte-yellow: var(--mocha-yellow);
-  --latte-green: var(--mocha-green);
-  --latte-teal: var(--mocha-teal);
-  --latte-sky: var(--mocha-sky);
-  --latte-sapphire: var(--mocha-sapphire);
-  --latte-blue: var(--mocha-blue);
-  --latte-lavender: var(--mocha-lavender);
+  --color-canvas: #1e1e2e;
+  --color-surface: #181825;
+  --color-surface-muted: #11111b;
+  --color-text: #cdd6f4;
+  --color-text-secondary: #bac2de;
+  --color-text-muted: #a6adc8;
+  --color-text-subtle: #a0a7c6;
+  --color-border: #313244;
+  --color-border-strong: #45475a;
+  --color-border-emphasis: #585b70;
+  --color-accent: #cba6f7;
+  --color-accent-hover: #a985f6;
+  --color-accent-strong: #dfcbff;
+  --color-link: #89b4fa;
+  --color-focus: #89b4fa;
+  --color-success: #a6e3a1;
+  --color-warning: #f9e2af;
+  --color-danger: #f38ba8;
+  --color-code-accent: #b4befe;
   --overlay-backdrop: rgba(17, 17, 27, 0.6);
   --elevated-surface: rgba(49, 50, 68, 0.72);
   --elevated-surface-strong: rgba(69, 71, 90, 0.74);
@@ -109,17 +73,15 @@
   --elevated-inset-shadow: rgba(205, 214, 244, 0.14);
   --active-surface-bg: rgba(69, 71, 90, 0.52);
   --tooltip-bg: rgba(17, 17, 27, 0.95);
-  --tooltip-text: var(--mocha-text);
+  --tooltip-text: var(--color-text);
   --panel-shadow: 0 14px 32px rgba(0, 0, 0, 0.42);
   --sidebar-mobile-shadow: 0 24px 48px rgba(0, 0, 0, 0.45);
-  --accent-hover: #a985f6;
-  --accent-strong: #dfcbff;
-  --badge-new-bg: var(--mocha-red);
-  --badge-new-fg: var(--mocha-crust);
-  --mobile-toggle-bg: var(--mocha-mauve);
-  --mobile-toggle-fg: var(--mocha-crust);
+  --badge-new-bg: var(--color-danger);
+  --badge-new-fg: var(--color-surface-muted);
+  --mobile-toggle-bg: var(--color-accent);
+  --mobile-toggle-fg: var(--color-surface-muted);
   --content-heading-accent-soft: rgba(203, 166, 247, 0.34);
-  --content-heading-subtle: var(--mocha-subtext0);
+  --content-heading-subtle: var(--color-text-muted);
 }
 
 * {
@@ -136,8 +98,8 @@ body {
 }
 
 body {
-  background: var(--latte-base);
-  color: var(--latte-text);
+  background: var(--color-canvas);
+  color: var(--color-text);
   font-family:
     "Pretendard Variable", "Pretendard", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic",
     "Segoe UI", sans-serif;
@@ -168,9 +130,9 @@ body.menu-open {
   z-index: 220;
   padding: 10px 14px;
   border-radius: 8px;
-  border: 1px solid var(--latte-blue);
-  background: var(--latte-base);
-  color: var(--latte-text);
+  border: 1px solid var(--color-focus);
+  background: var(--color-canvas);
+  color: var(--color-text);
   font-weight: 600;
   transform: translateY(-180%);
   transition: transform 0.18s ease;
@@ -179,7 +141,7 @@ body.menu-open {
 .skip-link:focus,
 .skip-link:focus-visible {
   transform: translateY(0);
-  outline: 2px solid var(--latte-blue);
+  outline: 2px solid var(--color-focus);
   outline-offset: 2px;
 }
 
@@ -189,20 +151,20 @@ body.menu-open {
 }
 
 ::-webkit-scrollbar-track {
-  background: var(--latte-mantle);
+  background: var(--color-surface);
 }
 
 ::-webkit-scrollbar-thumb {
-  background: var(--latte-surface0);
+  background: var(--color-border);
   border-radius: 4px;
 }
 
 ::-webkit-scrollbar-thumb:hover {
-  background: var(--latte-surface1);
+  background: var(--color-border-strong);
 }
 
 a {
-  color: var(--latte-blue);
+  color: var(--color-link);
   text-decoration: none;
 }
 
@@ -269,7 +231,7 @@ a:hover {
   left: 50%;
   width: 1px;
   transform: translateX(-0.5px);
-  background: var(--latte-surface0);
+  background: var(--color-border);
 }
 
 .app-splitter::after {
@@ -287,7 +249,7 @@ a:hover {
 .app-splitter:hover::after,
 .app-splitter:focus-visible::after,
 .app-root.is-resizing .app-splitter::after {
-  background: rgba(30, 102, 245, 0.22);
+  background: color-mix(in srgb, var(--color-focus) 22%, transparent);
 }
 
 .app-splitter:focus-visible {
@@ -296,7 +258,7 @@ a:hover {
 
 /* Sidebar */
 .sidebar {
-  background: var(--latte-mantle);
+  background: var(--color-surface);
   border-right: 0;
   display: flex;
   flex-direction: column;
@@ -320,7 +282,7 @@ a:hover {
   position: relative;
   flex: 0 0 auto;
   padding: 24px 20px;
-  border-bottom: 1px solid var(--latte-surface0);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .sidebar-close {
@@ -330,9 +292,9 @@ a:hover {
   right: 14px;
   width: 36px;
   height: 36px;
-  border: 1px solid var(--latte-surface0);
-  background: var(--latte-base);
-  color: var(--latte-subtext1);
+  border: 1px solid var(--color-border);
+  background: var(--color-canvas);
+  color: var(--color-text-secondary);
   border-radius: 8px;
   cursor: pointer;
   align-items: center;
@@ -340,7 +302,7 @@ a:hover {
 }
 
 .sidebar-close:hover {
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .sidebar-title {
@@ -354,7 +316,7 @@ a:hover {
 }
 
 .icon-terminal {
-  color: var(--latte-mauve);
+  color: var(--color-accent);
   font-size: 20px;
 }
 
@@ -376,22 +338,22 @@ a:hover {
   font-weight: 650;
   line-height: 1;
   background: var(--elevated-surface);
-  border: 1px solid var(--latte-surface1);
+  border: 1px solid var(--color-border-strong);
   border-radius: 999px;
-  color: var(--latte-subtext0);
+  color: var(--color-text-muted);
   box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
 }
 
 .icon-branch {
   font-size: 13px;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
 }
 
 .branch-info {
   grid-column: 1 / -1;
   display: block;
   font-size: 0.75rem;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
 }
 
 .branch-pills {
@@ -403,10 +365,10 @@ a:hover {
 }
 
 .branch-pill {
-  border: 1px solid var(--latte-surface1);
+  border: 1px solid var(--color-border-strong);
   border-radius: 999px;
   background: var(--elevated-surface-strong);
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
   font-size: 0.8rem;
   font-weight: 700;
   line-height: 1.15;
@@ -424,32 +386,32 @@ a:hover {
 }
 
 .branch-pill:hover {
-  border-color: var(--latte-surface2);
+  border-color: var(--color-border-emphasis);
   background-color: var(--elevated-surface-hover);
-  color: var(--latte-text);
+  color: var(--color-text);
   transform: translateY(-1px);
 }
 
 .branch-pill:focus-visible {
-  outline: 2px solid var(--latte-blue);
+  outline: 2px solid var(--color-focus);
   outline-offset: 1px;
 }
 
 .branch-pill.is-active {
-  border-color: rgba(136, 57, 239, 0.45);
-  background: rgba(136, 57, 239, 0.14);
-  color: var(--accent-strong);
+  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  color: var(--color-accent-strong);
   box-shadow:
     0 1px 0 var(--elevated-inset-shadow) inset,
-    0 2px 6px rgba(136, 57, 239, 0.22);
+    0 2px 6px color-mix(in srgb, var(--color-accent) 22%, transparent);
 }
 
 /* Tree search */
 .sidebar-search {
   flex: 0 0 auto;
   padding: 14px 16px 10px;
-  border-bottom: 1px solid var(--latte-surface0);
-  background: color-mix(in srgb, var(--latte-mantle) 92%, var(--latte-base));
+  border-bottom: 1px solid var(--color-border);
+  background: color-mix(in srgb, var(--color-surface) 92%, var(--color-canvas));
 }
 
 .sidebar-search-box {
@@ -459,7 +421,7 @@ a:hover {
   gap: 6px;
   min-height: 40px;
   padding: 0 6px 0 11px;
-  border: 1px solid var(--latte-surface1);
+  border: 1px solid var(--color-border-strong);
   border-radius: 8px;
   background: var(--elevated-surface);
   box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
@@ -470,13 +432,13 @@ a:hover {
 }
 
 .sidebar-search-box:focus-within {
-  border-color: color-mix(in srgb, var(--latte-blue) 56%, var(--latte-surface1));
+  border-color: color-mix(in srgb, var(--color-focus) 56%, var(--color-border-strong));
   background: var(--elevated-surface-hover);
-  box-shadow: 0 0 0 3px color-mix(in srgb, var(--latte-blue) 18%, transparent);
+  box-shadow: 0 0 0 3px color-mix(in srgb, var(--color-focus) 18%, transparent);
 }
 
 .sidebar-search-icon {
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   font-size: 19px;
 }
 
@@ -486,13 +448,13 @@ a:hover {
   border: 0;
   outline: 0;
   background: transparent;
-  color: var(--latte-text);
+  color: var(--color-text);
   font: inherit;
   font-size: 0.88rem;
 }
 
 .tree-search-input::placeholder {
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
 }
 
 .tree-search-input::-webkit-search-decoration,
@@ -507,7 +469,7 @@ a:hover {
   border: 1px solid transparent;
   border-radius: 8px;
   background: transparent;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   display: inline-flex;
   align-items: center;
   justify-content: center;
@@ -520,14 +482,14 @@ a:hover {
 
 .tree-search-clear:hover,
 .tree-search-step:hover:not(:disabled) {
-  border-color: var(--latte-surface1);
+  border-color: var(--color-border-strong);
   background: var(--elevated-surface-hover);
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .tree-search-clear:focus-visible,
 .tree-search-step:focus-visible {
-  outline: 2px solid var(--latte-blue);
+  outline: 2px solid var(--color-focus);
   outline-offset: 1px;
 }
 
@@ -555,7 +517,7 @@ a:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   font-size: 0.75rem;
   font-weight: 650;
 }
@@ -579,10 +541,10 @@ a:hover {
   width: 100%;
   min-height: 96px;
   margin: 0;
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
-  background: color-mix(in srgb, var(--latte-mantle) 72%, transparent);
-  color: var(--latte-subtext1);
+  background: color-mix(in srgb, var(--color-surface) 72%, transparent);
+  color: var(--color-text-secondary);
   font-size: 0.78rem;
 }
 
@@ -607,10 +569,10 @@ a:hover {
 .tree-load-retry {
   width: 100%;
   min-height: 34px;
-  border: 1px solid var(--latte-surface1);
+  border: 1px solid var(--color-border-strong);
   border-radius: 7px;
-  background: var(--latte-base);
-  color: var(--latte-text);
+  background: var(--color-canvas);
+  color: var(--color-text);
   cursor: pointer;
   font: inherit;
   font-weight: 700;
@@ -618,7 +580,7 @@ a:hover {
 
 .tree-load-retry:focus-visible,
 .tree-load-fallback-links a:focus-visible {
-  outline: 2px solid var(--latte-blue);
+  outline: 2px solid var(--color-focus);
   outline-offset: 2px;
 }
 
@@ -635,32 +597,32 @@ a:hover {
   overflow: hidden;
   padding: 6px 8px;
   border-radius: 5px;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
   text-decoration: none;
   text-overflow: ellipsis;
   white-space: nowrap;
 }
 
 .tree-load-fallback-links a:hover {
-  background: var(--latte-surface0);
-  color: var(--latte-text);
+  background: var(--color-border);
+  color: var(--color-text);
 }
 
 .tree-root file-tree-container {
   --trees-bg-override: transparent;
-  --trees-bg-muted-override: color-mix(in srgb, var(--latte-surface0) 44%, transparent);
-  --trees-fg-override: var(--latte-subtext1);
-  --trees-fg-muted-override: var(--latte-overlay0);
-  --trees-accent-override: var(--latte-mauve);
-  --trees-border-color-override: var(--latte-surface0);
-  --trees-focus-ring-color-override: var(--latte-blue);
+  --trees-bg-muted-override: color-mix(in srgb, var(--color-border) 44%, transparent);
+  --trees-fg-override: var(--color-text-secondary);
+  --trees-fg-muted-override: var(--color-text-subtle);
+  --trees-accent-override: var(--color-accent);
+  --trees-border-color-override: var(--color-border);
+  --trees-focus-ring-color-override: var(--color-focus);
   --trees-focus-ring-width-override: 2px;
   --trees-focus-ring-offset-override: 1px;
   --trees-selected-bg-override: var(--active-surface-bg);
-  --trees-selected-fg-override: var(--latte-text);
+  --trees-selected-fg-override: var(--color-text);
   --trees-selected-focused-border-color-override: color-mix(
     in srgb,
-    var(--latte-mauve) 36%,
+    var(--color-accent) 36%,
     transparent
   );
   --trees-font-family-override: inherit;
@@ -674,12 +636,12 @@ a:hover {
   --trees-item-row-gap-override: 8px;
   --trees-level-gap-override: 10px;
   --trees-padding-inline-override: 0px;
-  --trees-file-icon-color-default: var(--latte-overlay0);
+  --trees-file-icon-color-default: var(--color-text-subtle);
   --trees-new-badge-bg: var(--badge-new-bg);
   --trees-new-badge-fg: var(--badge-new-fg);
-  --trees-prefix-badge-bg: color-mix(in srgb, var(--latte-mauve) 16%, transparent);
-  --trees-prefix-badge-fg: var(--accent-strong);
-  --trees-prefix-badge-border: color-mix(in srgb, var(--latte-mauve) 42%, transparent);
+  --trees-prefix-badge-bg: color-mix(in srgb, var(--color-accent) 16%, transparent);
+  --trees-prefix-badge-fg: var(--color-accent-strong);
+  --trees-prefix-badge-border: color-mix(in srgb, var(--color-accent) 42%, transparent);
   display: block;
   width: 100%;
   height: 100%;
@@ -691,15 +653,15 @@ a:hover {
   position: relative;
   flex: 0 0 auto;
   padding: 12px 16px;
-  background: var(--latte-crust);
-  border-top: 1px solid var(--latte-surface0);
+  background: var(--color-surface-muted);
+  border-top: 1px solid var(--color-border);
   display: flex;
   justify-content: space-between;
   align-items: center;
   gap: 12px;
   min-height: 57px;
   font-size: 0.75rem;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
 }
 
 .status-online {
@@ -713,7 +675,7 @@ a:hover {
   width: 8px;
   height: 8px;
   border-radius: 50%;
-  background: var(--latte-green);
+  background: var(--color-success);
   animation: pulse 2s infinite;
 }
 
@@ -742,7 +704,7 @@ a:hover {
   overflow: hidden;
   text-overflow: ellipsis;
   white-space: nowrap;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
 }
 
 .sidebar-footer-actions {
@@ -756,9 +718,9 @@ a:hover {
   width: 32px;
   height: 32px;
   border-radius: 8px;
-  border: 1px solid var(--latte-surface0);
-  background: var(--latte-base);
-  color: var(--latte-subtext1);
+  border: 1px solid var(--color-border);
+  background: var(--color-canvas);
+  color: var(--color-text-secondary);
   cursor: pointer;
   display: inline-flex;
   align-items: center;
@@ -766,7 +728,7 @@ a:hover {
 }
 
 .settings-toggle:hover {
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .settings-toggle .material-symbols-outlined {
@@ -778,8 +740,8 @@ a:hover {
   right: 12px;
   bottom: 52px;
   width: min(300px, calc(100vw - 24px));
-  background: var(--latte-base);
-  border: 1px solid var(--latte-surface0);
+  background: var(--color-canvas);
+  border: 1px solid var(--color-border);
   border-radius: 10px;
   box-shadow: var(--panel-shadow);
   padding: 12px;
@@ -790,7 +752,7 @@ a:hover {
   margin: 0 0 10px;
   font-size: 0.85rem;
   font-weight: 700;
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .settings-group {
@@ -801,7 +763,7 @@ a:hover {
 
 .settings-group legend {
   font-size: 0.75rem;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
   margin-bottom: 8px;
 }
 
@@ -810,7 +772,7 @@ a:hover {
   align-items: center;
   gap: 8px;
   font-size: 0.8rem;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
   padding: 6px 0;
 }
 
@@ -837,9 +799,9 @@ a:hover {
   align-items: center;
   min-height: 34px;
   border-radius: 8px;
-  border: 1px solid var(--latte-surface0);
-  background: var(--latte-mantle);
-  color: var(--latte-subtext1);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text-secondary);
   font-size: 0.78rem;
   font-weight: 600;
   cursor: pointer;
@@ -850,13 +812,13 @@ a:hover {
 }
 
 .settings-segment-option input:checked + span {
-  border-color: var(--latte-mauve);
-  background: rgba(136, 57, 239, 0.14);
-  color: var(--latte-text);
+  border-color: var(--color-accent);
+  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
+  color: var(--color-text);
 }
 
 .settings-segment-option input:focus-visible + span {
-  outline: 2px solid var(--latte-blue);
+  outline: 2px solid var(--color-focus);
   outline-offset: 1px;
 }
 
@@ -865,22 +827,22 @@ a:hover {
   width: 100%;
   min-height: 34px;
   border-radius: 8px;
-  border: 1px solid var(--latte-surface0);
-  background: var(--latte-mantle);
-  color: var(--latte-text);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
+  color: var(--color-text);
   font-size: 0.8rem;
   font-weight: 600;
   cursor: pointer;
 }
 
 .settings-close:hover {
-  background: var(--latte-base);
+  background: var(--color-canvas);
 }
 
 /* Viewer */
 .viewer {
   overflow-y: auto;
-  background: var(--latte-base);
+  background: var(--color-canvas);
   position: relative;
   min-width: 0;
 }
@@ -901,7 +863,7 @@ a:hover {
   padding: 0 16px;
   font-size: 0.9rem;
   font-weight: 600;
-  box-shadow: 0 10px 24px rgba(136, 57, 239, 0.25);
+  box-shadow: 0 10px 24px color-mix(in srgb, var(--color-accent) 25%, transparent);
   cursor: pointer;
 }
 
@@ -930,7 +892,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   font-family:
     ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   margin-bottom: 24px;
   flex-wrap: nowrap;
   max-width: 100%;
@@ -942,7 +904,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .breadcrumb-sep {
   font-size: 14px;
-  color: var(--latte-surface2);
+  color: var(--color-border-emphasis);
   flex: 0 0 auto;
 }
 
@@ -952,11 +914,11 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .breadcrumb-ellipsis {
   flex: 0 0 auto;
-  color: var(--latte-surface2);
+  color: var(--color-border-emphasis);
 }
 
 .breadcrumb-current {
-  color: var(--latte-mauve);
+  color: var(--color-accent);
   font-weight: 500;
   flex: 0 0 auto;
 }
@@ -965,13 +927,13 @@ body.mobile-toggle-left .mobile-menu-toggle {
   flex: 0 0 auto;
   margin-left: auto;
   font-size: 16px;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   cursor: help;
   padding-left: 8px;
 }
 
 .breadcrumb-info:hover {
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 /* Viewer header */
@@ -986,7 +948,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: 0;
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .viewer-meta {
@@ -998,7 +960,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   font-family:
     ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
 }
 
 .meta-item {
@@ -1009,22 +971,22 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .meta-item .material-symbols-outlined {
   font-size: 16px;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
 }
 
 .meta-prefix {
   font-size: 0.74rem;
   font-weight: 700;
   letter-spacing: 0;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
 }
 
 .meta-tags {
-  color: var(--latte-lavender);
+  color: var(--color-code-accent);
 }
 
 .meta-tags .material-symbols-outlined {
-  color: var(--latte-lavender);
+  color: var(--color-code-accent);
 }
 
 /* Viewer content */
@@ -1035,7 +997,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   max-width: none;
   margin: 0;
   text-wrap: pretty;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
 }
 
 .viewer-content > :first-child {
@@ -1046,7 +1008,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 .viewer-content h2,
 .viewer-content h3,
 .viewer-content h4 {
-  color: var(--latte-text);
+  color: var(--color-text);
   font-weight: 650;
   line-height: 1.33;
   letter-spacing: 0;
@@ -1063,7 +1025,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   margin-top: 2.8rem;
   margin-bottom: 1.1rem;
   padding-bottom: 0.4rem;
-  border-bottom: 1px solid var(--latte-surface0);
+  border-bottom: 1px solid var(--color-border);
 }
 
 .viewer-content h2 {
@@ -1102,11 +1064,11 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content strong {
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .viewer-content a {
-  color: var(--latte-blue);
+  color: var(--color-link);
 }
 
 .viewer-content ul,
@@ -1123,24 +1085,24 @@ body.mobile-toggle-left .mobile-menu-toggle {
   margin: 1.5rem 0;
   padding: 12px 16px;
   padding-left: 20px;
-  border-left: 4px solid var(--latte-mauve);
+  border-left: 4px solid var(--color-accent);
   background: rgba(230, 233, 239, 0.5);
   border-radius: 0 8px 8px 0;
   font-style: normal;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
 }
 
 /* Inline code */
 .viewer-content :not(pre) > code {
-  background: var(--latte-mantle);
-  border: 1px solid var(--latte-surface0);
+  background: var(--color-surface);
+  border: 1px solid var(--color-border);
   border-radius: 4px;
   padding: 2px 6px;
   font-family:
     ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
   font-size: 0.88em;
-  color: var(--latte-mauve);
+  color: var(--color-accent);
 }
 
 /* Code blocks */
@@ -1174,13 +1136,13 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .dot-red {
-  background: var(--latte-red);
+  background: var(--color-danger);
 }
 .dot-yellow {
-  background: var(--latte-yellow);
+  background: var(--color-warning);
 }
 .dot-green {
-  background: var(--latte-green);
+  background: var(--color-success);
 }
 
 .code-filename {
@@ -1216,7 +1178,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .code-copy.copied {
-  color: var(--latte-green);
+  color: var(--color-success);
 }
 
 .viewer-content .code-block pre {
@@ -1267,8 +1229,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
   margin-left: auto;
   margin-right: auto;
   border-radius: 12px;
-  border: 1px solid var(--latte-surface0);
-  background: linear-gradient(180deg, var(--latte-base), var(--latte-mantle));
+  border: 1px solid var(--color-border);
+  background: linear-gradient(180deg, var(--color-canvas), var(--color-surface));
   box-shadow: 0 3px 10px rgba(15, 23, 42, 0.08);
 }
 
@@ -1279,7 +1241,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   border-radius: 0;
   box-shadow: none;
   background: transparent !important;
-  color: var(--latte-subtext1);
+  color: var(--color-text-secondary);
   font-family:
     ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
     monospace;
@@ -1321,7 +1283,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   padding: 10px 12px;
   border: 1px solid rgba(244, 63, 94, 0.35);
   border-radius: 8px;
-  color: var(--latte-red);
+  color: var(--color-danger);
   background: rgba(244, 63, 94, 0.08);
   font-size: 0.84rem;
   line-height: 1.45;
@@ -1332,8 +1294,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
   margin: 1.5rem 0;
   padding: 0;
   border-radius: 8px;
-  border: 1px solid var(--latte-surface0);
-  background: var(--latte-mantle);
+  border: 1px solid var(--color-border);
+  background: var(--color-surface);
   overflow: hidden;
   box-shadow: 0 2px 8px rgba(0, 0, 0, 0.06);
 }
@@ -1358,16 +1320,16 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content th {
-  background: var(--latte-mantle);
+  background: var(--color-surface);
   font-weight: 600;
   text-align: left;
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .viewer-content th,
 .viewer-content td {
   padding: 12px 16px;
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
 }
 
 .viewer-content tr:hover {
@@ -1400,7 +1362,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   height: auto;
   margin: 0 auto;
   border-radius: var(--content-image-radius);
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
   background: var(--content-image-frame-bg);
 }
 
@@ -1416,7 +1378,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   width: min(100%, var(--content-image-landscape-max-width));
   overflow: hidden;
   border-radius: 12px;
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
   background: var(--content-image-frame-bg);
 }
 
@@ -1465,7 +1427,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 /* Horizontal rule */
 .viewer-content hr {
   border: none;
-  border-top: 1px solid var(--latte-surface0);
+  border-top: 1px solid var(--color-border);
   margin: 2rem 0;
 }
 
@@ -1475,19 +1437,19 @@ body.mobile-toggle-left .mobile-menu-toggle {
   gap: 16px;
   margin-top: 48px;
   padding-top: 32px;
-  border-top: 1px solid var(--latte-surface0);
+  border-top: 1px solid var(--color-border);
 }
 
 .viewer-backlinks {
   margin-top: 44px;
   padding-top: 28px;
-  border-top: 1px solid var(--latte-surface0);
+  border-top: 1px solid var(--color-border);
 }
 
 .backlinks-title {
   margin: 0 0 14px;
   font-size: 1.05rem;
-  color: var(--latte-subtext0);
+  color: var(--color-text-muted);
 }
 
 .backlinks-list {
@@ -1507,9 +1469,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
   align-items: center;
   gap: 8px;
   text-decoration: none;
-  color: var(--latte-text);
+  color: var(--color-text);
   padding: 8px 10px;
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--active-surface-bg);
   transition:
@@ -1518,18 +1480,18 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .backlink-link:hover {
-  border-color: var(--latte-mauve);
-  color: var(--latte-mauve);
+  border-color: var(--color-accent);
+  color: var(--color-accent);
 }
 
 .backlink-prefix {
   font-size: 0.72rem;
   font-weight: 700;
   letter-spacing: 0;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   padding: 1px 7px;
   border-radius: 999px;
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
 }
 
 .backlink-text {
@@ -1539,7 +1501,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 .nav-link {
   flex: 1;
   padding: 16px;
-  border: 1px solid var(--latte-surface0);
+  border: 1px solid var(--color-border);
   border-radius: 8px;
   background: var(--active-surface-bg);
   text-decoration: none;
@@ -1547,8 +1509,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .nav-link:hover {
-  border-color: var(--latte-mauve);
-  box-shadow: 0 2px 8px rgba(136, 57, 239, 0.1);
+  border-color: var(--color-accent);
+  box-shadow: 0 2px 8px color-mix(in srgb, var(--color-accent) 10%, transparent);
   text-decoration: none;
 }
 
@@ -1557,22 +1519,22 @@ body.mobile-toggle-left .mobile-menu-toggle {
   align-items: center;
   gap: 4px;
   font-size: 0.75rem;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   margin-bottom: 4px;
 }
 
 .nav-link:hover .nav-link-label {
-  color: var(--latte-mauve);
+  color: var(--color-accent);
 }
 
 .nav-link-title {
   font-size: 0.9rem;
   font-weight: 500;
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .nav-link:hover .nav-link-title {
-  color: var(--latte-mauve);
+  color: var(--color-accent);
 }
 
 .nav-link-next {
@@ -1585,7 +1547,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 /* Placeholder */
 .placeholder {
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
   font-style: italic;
 }
 
@@ -1597,24 +1559,24 @@ body.mobile-toggle-left .mobile-menu-toggle {
   align-items: center;
   justify-content: center;
   gap: 16px;
-  background: var(--latte-base);
-  color: var(--latte-text);
+  background: var(--color-canvas);
+  color: var(--color-text);
 }
 
 .not-found-icon .material-symbols-outlined {
   font-size: 64px;
-  color: var(--latte-overlay0);
+  color: var(--color-text-subtle);
 }
 
 .not-found h1 {
   font-size: 4rem;
   font-weight: 700;
   margin: 0;
-  color: var(--latte-text);
+  color: var(--color-text);
 }
 
 .not-found p {
-  color: var(--latte-subtext0);
+  color: var(--color-text-muted);
   margin: 0;
 }
 
@@ -1624,7 +1586,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   gap: 6px;
   margin-top: 8px;
   padding: 10px 20px;
-  background: var(--latte-mauve);
+  background: var(--color-accent);
   color: white;
   border-radius: 6px;
   font-weight: 500;
@@ -1633,7 +1595,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .not-found-link:hover {
-  background: var(--accent-hover);
+  background: var(--color-accent-hover);
   text-decoration: none;
 }
 
@@ -1662,7 +1624,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
     width: 70vw;
     min-width: var(--mobile-sidebar-min);
     max-width: var(--mobile-sidebar-max);
-    border-right: 1px solid var(--latte-surface0);
+    border-right: 1px solid var(--color-border);
     border-bottom: 0;
     box-shadow: var(--sidebar-mobile-shadow);
     transform: translateX(-102%);

--- a/tests/e2e/semantic-theme-tokens.spec.ts
+++ b/tests/e2e/semantic-theme-tokens.spec.ts
@@ -1,0 +1,95 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+
+const stylesheet = readFileSync("src/runtime/app.css", "utf8");
+
+test.describe("semantic theme tokens", () => {
+  test("components do not consume palette-specific variables", () => {
+    expect(stylesheet).not.toMatch(/--(?:latte|mocha)-/);
+    for (const token of [
+      "--color-canvas",
+      "--color-surface",
+      "--color-text",
+      "--color-border",
+      "--color-accent",
+      "--color-success",
+      "--color-danger",
+      "--color-focus",
+    ]) {
+      expect(stylesheet).toContain(token);
+    }
+  });
+
+  for (const theme of ["light", "dark"] as const) {
+    test(`${theme} theme maps semantic roles to a coherent surface snapshot`, async ({ page }) => {
+      await page.addInitScript((mode) => {
+        localStorage.setItem("fsblog.themeMode", mode);
+      }, theme);
+      await page.goto("/");
+
+      const snapshot = await page.evaluate(() => {
+        const root = getComputedStyle(document.documentElement);
+        const body = getComputedStyle(document.body);
+        const sidebar = getComputedStyle(document.querySelector(".sidebar")!);
+        const viewer = getComputedStyle(document.querySelector(".viewer")!);
+        const token = (name: string) => root.getPropertyValue(name).trim();
+        return {
+          appliedTheme: document.documentElement.dataset.theme,
+          canvas: token("--color-canvas"),
+          surface: token("--color-surface"),
+          text: token("--color-text"),
+          border: token("--color-border"),
+          accent: token("--color-accent"),
+          focus: token("--color-focus"),
+          success: token("--color-success"),
+          warning: token("--color-warning"),
+          danger: token("--color-danger"),
+          bodyBackground: body.backgroundColor,
+          bodyColor: body.color,
+          sidebarBackground: sidebar.backgroundColor,
+          viewerBackground: viewer.backgroundColor,
+        };
+      });
+
+      expect(snapshot).toEqual(
+        theme === "light"
+          ? {
+              appliedTheme: "light",
+              canvas: "#eff1f5",
+              surface: "#e6e9ef",
+              text: "#4c4f69",
+              border: "#ccd0da",
+              accent: "#8839ef",
+              focus: "#1e66f5",
+              success: "#40a02b",
+              warning: "#df8e1d",
+              danger: "#d20f39",
+              bodyBackground: "rgb(239, 241, 245)",
+              bodyColor: "rgb(76, 79, 105)",
+              sidebarBackground: "rgb(230, 233, 239)",
+              viewerBackground: "rgb(239, 241, 245)",
+            }
+          : {
+              appliedTheme: "dark",
+              canvas: "#1e1e2e",
+              surface: "#181825",
+              text: "#cdd6f4",
+              border: "#313244",
+              accent: "#cba6f7",
+              focus: "#89b4fa",
+              success: "#a6e3a1",
+              warning: "#f9e2af",
+              danger: "#f38ba8",
+              bodyBackground: "rgb(30, 30, 46)",
+              bodyColor: "rgb(205, 214, 244)",
+              sidebarBackground: "rgb(24, 24, 37)",
+              viewerBackground: "rgb(30, 30, 46)",
+            },
+      );
+
+      expect(
+        new Set([snapshot.focus, snapshot.accent, snapshot.warning, snapshot.danger]).size,
+      ).toBe(4);
+    });
+  }
+});

--- a/tests/e2e/semantic-theme-tokens.spec.ts
+++ b/tests/e2e/semantic-theme-tokens.spec.ts
@@ -1,5 +1,6 @@
 import { expect, test } from "@playwright/test";
 import { readFileSync } from "node:fs";
+import { waitForAppReady } from "./utils/app-ready";
 
 const stylesheet = readFileSync("src/runtime/app.css", "utf8");
 
@@ -26,6 +27,7 @@ test.describe("semantic theme tokens", () => {
         localStorage.setItem("fsblog.themeMode", mode);
       }, theme);
       await page.goto("/");
+      await waitForAppReady(page);
 
       const snapshot = await page.evaluate(() => {
         const root = getComputedStyle(document.documentElement);


### PR DESCRIPTION
## Summary
- replace palette-specific component variables with semantic canvas, surface, text, border, accent, state, link, and focus roles
- map light and dark Catppuccin values only at the theme boundary and remove unused palette variables
- keep focus, selected, warning, and NEW states distinct and make mixed selection colors theme-aware
- document the token contract and add resolved light/dark surface snapshots

## DnD
- [x] components consume semantic tokens rather than palette names
- [x] light and dark palettes are defined in one theme layer
- [x] focus, selected, warning, and NEW badge semantics remain distinct
- [x] unused palette variables are removed
- [x] both theme modes have regression snapshots

## Validation
- bun run lint:source
- bun run format:check
- bun run typecheck
- bun run test:unit (79 passed)
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size (CSS 30,119 raw / 6,272 gzip)
- bun run check:reproducible
- bun run test:e2e (89 passed)

Part of #37
Detailed acceptance criteria: #41
