### PR TITLE
feat: establish reader surface hierarchy

### DIFF
--- a/docs/solutions/20260719-reader-surface-typography.md
+++ b/docs/solutions/20260719-reader-surface-typography.md
@@ -1,0 +1,46 @@
+# Reader surface and typography hierarchy
+
+## Surface roles
+
+The shell uses two deliberately quiet component surfaces without a heavy
+divider:
+
+- `--surface-reader` gives the article a clear reading plane;
+- `--surface-navigation` keeps the sidebar visually secondary;
+- the desktop sidebar has no right border, while the existing one-pixel
+  splitter remains the resize affordance.
+
+Light mode uses a white reader over a soft gray navigation surface. Dark mode
+keeps the reader on the theme canvas and the navigation surface one step
+darker. Blockquotes and table hover rows derive from the theme surface instead
+of a light-only literal.
+
+## Type scale
+
+| Role             | Token                     | Desktop size | Use                                     |
+| ---------------- | ------------------------- | -----------: | --------------------------------------- |
+| Page title       | `--type-title`            |        40 px | Current document title                  |
+| Article body     | `--type-content`          |        17 px | Paragraphs, lists, quotes               |
+| Article headings | `--type-heading-1` … `-4` |     33–18 px | In-document hierarchy                   |
+| Navigation       | `--type-navigation`       |        14 px | Tree, search, backlinks, previous/next  |
+| Metadata         | `--type-metadata`         |        13 px | Breadcrumb, date, tags, branch controls |
+| Caption          | `--type-caption`          |        12 px | Prefixes and secondary labels           |
+
+Compact breakpoints override the same tokens rather than introducing a second
+unrelated scale. Article text uses the primary text role, while metadata and
+navigation use progressively quieter roles whose resolved light/dark contrast
+is regression-tested at WCAG AA's 4.5:1 threshold.
+
+## Font strategy
+
+Body text uses a `ui-sans-serif`/`system-ui` stack with platform Korean
+fallbacks. Code and metadata use `ui-monospace` with platform monospace
+fallbacks. EIAM declares no text `@font-face`, so article typography neither
+depends on an external font host nor swaps after a webfont download. The local
+SVG icon migration is tracked separately by issue #40.
+
+The visual changes also exposed that two animation-frame callbacks can still
+run before the browser records its first contentful paint. Deferred desktop
+tree loading now waits through the following frame, so dependency work starts
+after an actual paint boundary. The timing regression is exercised repeatedly
+in addition to the ordinary E2E suite.

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -19,6 +19,25 @@
   --color-warning: #df8e1d;
   --color-danger: #d20f39;
   --color-code-accent: #7287fd;
+  --surface-reader: #ffffff;
+  --surface-navigation: var(--color-surface);
+  --font-sans:
+    ui-sans-serif, system-ui, -apple-system, BlinkMacSystemFont, "Segoe UI", "Apple SD Gothic Neo",
+    "Malgun Gothic", sans-serif;
+  --font-mono:
+    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
+    monospace;
+  --type-title: 2.5rem;
+  --type-content: 1.0625rem;
+  --type-heading-1: 2.0625rem;
+  --type-heading-2: 1.625rem;
+  --type-heading-3: 1.3125rem;
+  --type-heading-4: 1.125rem;
+  --type-navigation: 0.875rem;
+  --type-metadata: 0.8125rem;
+  --type-caption: 0.75rem;
+  --leading-content: 1.78;
+  --leading-heading: 1.3;
   --overlay-backdrop: rgba(76, 79, 105, 0.4);
   --elevated-surface: rgba(255, 255, 255, 0.64);
   --elevated-surface-strong: rgba(255, 255, 255, 0.68);
@@ -66,6 +85,8 @@
   --color-warning: #f9e2af;
   --color-danger: #f38ba8;
   --color-code-accent: #b4befe;
+  --surface-reader: var(--color-canvas);
+  --surface-navigation: var(--color-surface);
   --overlay-backdrop: rgba(17, 17, 27, 0.6);
   --elevated-surface: rgba(49, 50, 68, 0.72);
   --elevated-surface-strong: rgba(69, 71, 90, 0.74);
@@ -100,9 +121,7 @@ body {
 body {
   background: var(--color-canvas);
   color: var(--color-text);
-  font-family:
-    "Pretendard Variable", "Pretendard", "Noto Sans KR", "Apple SD Gothic Neo", "Malgun Gothic",
-    "Segoe UI", sans-serif;
+  font-family: var(--font-sans);
   -webkit-font-smoothing: antialiased;
   overflow: hidden;
 }
@@ -258,7 +277,7 @@ a:hover {
 
 /* Sidebar */
 .sidebar {
-  background: var(--color-surface);
+  background: var(--surface-navigation);
   border-right: 0;
   display: flex;
   flex-direction: column;
@@ -307,7 +326,7 @@ a:hover {
 
 .sidebar-title {
   margin: 0;
-  font-size: 1.1rem;
+  font-size: 1.0625rem;
   font-weight: 700;
   letter-spacing: 0;
   display: flex;
@@ -352,7 +371,7 @@ a:hover {
 .branch-info {
   grid-column: 1 / -1;
   display: block;
-  font-size: 0.75rem;
+  font-size: var(--type-caption);
   color: var(--color-text-subtle);
 }
 
@@ -369,7 +388,7 @@ a:hover {
   border-radius: 999px;
   background: var(--elevated-surface-strong);
   color: var(--color-text-secondary);
-  font-size: 0.8rem;
+  font-size: var(--type-metadata);
   font-weight: 700;
   line-height: 1.15;
   letter-spacing: 0;
@@ -450,7 +469,7 @@ a:hover {
   background: transparent;
   color: var(--color-text);
   font: inherit;
-  font-size: 0.88rem;
+  font-size: var(--type-navigation);
 }
 
 .tree-search-input::placeholder {
@@ -626,7 +645,7 @@ a:hover {
     transparent
   );
   --trees-font-family-override: inherit;
-  --trees-font-size-override: 0.9rem;
+  --trees-font-size-override: var(--type-navigation);
   --trees-font-weight-regular-override: 450;
   --trees-font-weight-semibold-override: 700;
   --trees-border-radius-override: 6px;
@@ -660,7 +679,7 @@ a:hover {
   align-items: center;
   gap: 12px;
   min-height: 57px;
-  font-size: 0.75rem;
+  font-size: var(--type-caption);
   color: var(--color-text-secondary);
 }
 
@@ -696,9 +715,7 @@ a:hover {
 }
 
 .status-encoding {
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+  font-family: var(--font-mono);
   flex: 0 1 auto;
   min-width: 0;
   overflow: hidden;
@@ -750,7 +767,7 @@ a:hover {
 
 .sidebar-settings-title {
   margin: 0 0 10px;
-  font-size: 0.85rem;
+  font-size: var(--type-navigation);
   font-weight: 700;
   color: var(--color-text);
 }
@@ -842,7 +859,7 @@ a:hover {
 /* Viewer */
 .viewer {
   overflow-y: auto;
-  background: var(--color-canvas);
+  background: var(--surface-reader);
   position: relative;
   min-width: 0;
 }
@@ -861,7 +878,7 @@ a:hover {
   color: var(--mobile-toggle-fg);
   min-height: 48px;
   padding: 0 16px;
-  font-size: 0.9rem;
+  font-size: var(--type-navigation);
   font-weight: 600;
   box-shadow: 0 10px 24px color-mix(in srgb, var(--color-accent) 25%, transparent);
   cursor: pointer;
@@ -888,10 +905,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: 0.85rem;
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+  font-size: var(--type-metadata);
+  font-family: var(--font-mono);
   color: var(--color-text-subtle);
   margin-bottom: 24px;
   flex-wrap: nowrap;
@@ -944,7 +959,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .viewer-title {
   margin: 0 0 16px;
-  font-size: 2.5rem;
+  font-size: var(--type-title);
   font-weight: 700;
   line-height: 1.2;
   letter-spacing: 0;
@@ -956,10 +971,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
   align-items: center;
   gap: 16px;
   min-height: 22px;
-  font-size: 0.85rem;
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+  font-size: var(--type-metadata);
+  font-family: var(--font-mono);
   color: var(--color-text-secondary);
 }
 
@@ -975,7 +988,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .meta-prefix {
-  font-size: 0.74rem;
+  font-size: var(--type-caption);
   font-weight: 700;
   letter-spacing: 0;
   color: var(--color-text-secondary);
@@ -991,13 +1004,13 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 /* Viewer content */
 .viewer-content {
-  line-height: 1.82;
-  font-size: 1.02rem;
+  line-height: var(--leading-content);
+  font-size: var(--type-content);
   width: 100%;
   max-width: none;
   margin: 0;
   text-wrap: pretty;
-  color: var(--color-text-secondary);
+  color: var(--color-text);
 }
 
 .viewer-content > :first-child {
@@ -1010,7 +1023,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 .viewer-content h4 {
   color: var(--color-text);
   font-weight: 650;
-  line-height: 1.33;
+  line-height: var(--leading-heading);
   letter-spacing: 0;
   text-wrap: balance;
   margin-top: 2.2rem;
@@ -1019,7 +1032,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content h1 {
-  font-size: 2.08rem;
+  font-size: var(--type-heading-1);
   font-weight: 760;
   letter-spacing: 0;
   margin-top: 2.8rem;
@@ -1029,7 +1042,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content h2 {
-  font-size: 1.62rem;
+  font-size: var(--type-heading-2);
   margin-top: 2.6rem;
   margin-bottom: 1.04rem;
   padding: 0.1rem 0 0.18rem 0.55rem;
@@ -1037,14 +1050,14 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content h3 {
-  font-size: 1.34rem;
+  font-size: var(--type-heading-3);
   color: var(--content-heading-subtle);
   margin-top: 2.15rem;
   margin-bottom: 0.92rem;
 }
 
 .viewer-content h4 {
-  font-size: 1.14rem;
+  font-size: var(--type-heading-4);
   color: var(--content-heading-subtle);
   margin-top: 1.85rem;
   margin-bottom: 0.8rem;
@@ -1086,7 +1099,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   padding: 12px 16px;
   padding-left: 20px;
   border-left: 4px solid var(--color-accent);
-  background: rgba(230, 233, 239, 0.5);
+  background: color-mix(in srgb, var(--color-surface) 58%, transparent);
   border-radius: 0 8px 8px 0;
   font-style: normal;
   color: var(--color-text-secondary);
@@ -1098,9 +1111,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   border: 1px solid var(--color-border);
   border-radius: 4px;
   padding: 2px 6px;
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+  font-family: var(--font-mono);
   font-size: 0.88em;
   color: var(--color-accent);
 }
@@ -1147,10 +1158,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .code-filename {
   flex: 1;
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
-  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  font-size: var(--type-caption);
   color: #aeb7c2;
   text-align: center;
 }
@@ -1194,9 +1203,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   display: block;
   padding: 18px 20px;
   overflow-x: auto;
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+  font-family: var(--font-mono);
   font-size: 0.95rem;
   font-weight: 500;
   line-height: 1.72;
@@ -1242,10 +1249,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
   box-shadow: none;
   background: transparent !important;
   color: var(--color-text-secondary);
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
-  font-size: 0.9rem;
+  font-family: var(--font-mono);
+  font-size: var(--type-navigation);
   line-height: 1.6;
   white-space: pre-wrap;
   word-break: break-word;
@@ -1304,9 +1309,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   display: block;
   padding: 16px;
   overflow-x: auto;
-  font-family:
-    ui-monospace, "SFMono-Regular", Menlo, Monaco, Consolas, "Liberation Mono", "Courier New",
-    monospace;
+  font-family: var(--font-mono);
   font-size: 0.875rem;
   line-height: 1.6;
 }
@@ -1316,7 +1319,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   width: 100%;
   border-collapse: collapse;
   margin: 1.5rem 0;
-  font-size: 0.9rem;
+  font-size: var(--type-navigation);
 }
 
 .viewer-content th {
@@ -1333,7 +1336,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content tr:hover {
-  background: rgba(230, 233, 239, 0.5);
+  background: color-mix(in srgb, var(--color-surface) 58%, transparent);
 }
 
 /* Images */
@@ -1448,7 +1451,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .backlinks-title {
   margin: 0 0 14px;
-  font-size: 1.05rem;
+  font-size: var(--type-navigation);
   color: var(--color-text-muted);
 }
 
@@ -1485,7 +1488,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .backlink-prefix {
-  font-size: 0.72rem;
+  font-size: var(--type-caption);
   font-weight: 700;
   letter-spacing: 0;
   color: var(--color-text-subtle);
@@ -1495,7 +1498,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .backlink-text {
-  font-size: 0.9rem;
+  font-size: var(--type-navigation);
 }
 
 .nav-link {
@@ -1518,7 +1521,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   display: flex;
   align-items: center;
   gap: 4px;
-  font-size: 0.75rem;
+  font-size: var(--type-caption);
   color: var(--color-text-subtle);
   margin-bottom: 4px;
 }
@@ -1528,7 +1531,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .nav-link-title {
-  font-size: 0.9rem;
+  font-size: var(--type-navigation);
   font-weight: 500;
   color: var(--color-text);
 }
@@ -1559,7 +1562,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   align-items: center;
   justify-content: center;
   gap: 16px;
-  background: var(--color-canvas);
+  background: var(--surface-reader);
   color: var(--color-text);
 }
 
@@ -1674,8 +1677,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
     padding: 32px 24px 104px;
   }
 
-  .viewer-title {
-    font-size: 1.75rem;
+  .viewer {
+    --type-title: 1.75rem;
+    --type-content: 1.05rem;
   }
 
   .viewer-meta {
@@ -1684,7 +1688,6 @@ body.mobile-toggle-left .mobile-menu-toggle {
   }
 
   .viewer-content {
-    font-size: 1.05rem;
     line-height: 1.9;
   }
 
@@ -1744,22 +1747,16 @@ body.mobile-toggle-left .mobile-menu-toggle {
     padding: 22px clamp(16px, 5vw, 22px) 104px;
   }
 
+  .viewer {
+    --type-content: 1.01rem;
+    --type-heading-1: 1.82rem;
+    --type-heading-2: 1.42rem;
+    --type-heading-3: 1.22rem;
+  }
+
   .viewer-content {
-    font-size: 1.01rem;
     line-height: 1.88;
     max-width: none;
-  }
-
-  .viewer-content h1 {
-    font-size: 1.82rem;
-  }
-
-  .viewer-content h2 {
-    font-size: 1.42rem;
-  }
-
-  .viewer-content h3 {
-    font-size: 1.22rem;
   }
 
   .viewer-content table {

--- a/src/runtime/tree-controller.js
+++ b/src/runtime/tree-controller.js
@@ -763,29 +763,31 @@ export function createTreeController(options) {
     deferredFrame = windowRef.requestAnimationFrame(() => {
       deferredFrame = null;
       paintFrame = windowRef.requestAnimationFrame(() => {
-        paintFrame = null;
-        if (!events) {
-          return;
-        }
-        treeLoadAllowed = true;
-        windowRef.performance?.mark?.("eiam-first-content-paint-opportunity");
-        if (pendingTreeLoadReason) {
-          void requestLoad(pendingTreeLoadReason);
-          return;
-        }
-        if (isCompactLayout()) {
-          return;
-        }
-        const loadForDesktop = () => {
-          idleHandle = null;
-          idleFallbackTimer = null;
-          void requestLoad("desktop-idle");
-        };
-        if (typeof windowRef.requestIdleCallback === "function") {
-          idleHandle = windowRef.requestIdleCallback(loadForDesktop, { timeout: 500 });
-        } else {
-          idleFallbackTimer = windowRef.setTimeout(loadForDesktop, 0);
-        }
+        paintFrame = windowRef.requestAnimationFrame(() => {
+          paintFrame = null;
+          if (!events) {
+            return;
+          }
+          treeLoadAllowed = true;
+          windowRef.performance?.mark?.("eiam-first-content-paint-opportunity");
+          if (pendingTreeLoadReason) {
+            void requestLoad(pendingTreeLoadReason);
+            return;
+          }
+          if (isCompactLayout()) {
+            return;
+          }
+          const loadForDesktop = () => {
+            idleHandle = null;
+            idleFallbackTimer = null;
+            void requestLoad("desktop-idle");
+          };
+          if (typeof windowRef.requestIdleCallback === "function") {
+            idleHandle = windowRef.requestIdleCallback(loadForDesktop, { timeout: 500 });
+          } else {
+            idleFallbackTimer = windowRef.setTimeout(loadForDesktop, 0);
+          }
+        });
       });
     });
   };

--- a/tests/e2e/reader-surface-typography.spec.ts
+++ b/tests/e2e/reader-surface-typography.spec.ts
@@ -1,0 +1,105 @@
+import { expect, test } from "@playwright/test";
+import { readFileSync } from "node:fs";
+import { waitForAppReady } from "./utils/app-ready";
+
+const stylesheet = readFileSync("src/runtime/app.css", "utf8");
+
+function channelToLinear(channel: number): number {
+  const value = channel / 255;
+  return value <= 0.04045 ? value / 12.92 : ((value + 0.055) / 1.055) ** 2.4;
+}
+
+function luminance(color: string): number {
+  const channels = color
+    .match(/[\d.]+/g)
+    ?.slice(0, 3)
+    .map(Number);
+  if (!channels || channels.length !== 3) {
+    throw new Error(`Unsupported computed color: ${color}`);
+  }
+  const [red, green, blue] = channels.map(channelToLinear);
+  return red * 0.2126 + green * 0.7152 + blue * 0.0722;
+}
+
+function contrastRatio(foreground: string, background: string): number {
+  const lighter = Math.max(luminance(foreground), luminance(background));
+  const darker = Math.min(luminance(foreground), luminance(background));
+  return (lighter + 0.05) / (darker + 0.05);
+}
+
+test.describe("reader surface and typography hierarchy", () => {
+  test("uses a system text stack and a documented type scale without text webfonts", () => {
+    expect(stylesheet).toMatch(/--font-sans:\s+ui-sans-serif,\s*system-ui/);
+    expect(stylesheet).toMatch(/--font-mono:\s+ui-monospace/);
+    expect(stylesheet).not.toMatch(/Pretendard|Noto Sans KR|@font-face/i);
+    for (const token of [
+      "--type-title",
+      "--type-content",
+      "--type-heading-1",
+      "--type-navigation",
+      "--type-metadata",
+      "--type-caption",
+    ]) {
+      expect(stylesheet).toContain(token);
+    }
+  });
+
+  for (const theme of ["light", "dark"] as const) {
+    test(`${theme} keeps reader/navigation hierarchy and AA text contrast`, async ({ page }) => {
+      await page.addInitScript((mode) => {
+        localStorage.setItem("fsblog.themeMode", mode);
+      }, theme);
+      await page.goto("/");
+      await waitForAppReady(page);
+
+      const styles = await page.evaluate(() => {
+        const read = (selector: string) => getComputedStyle(document.querySelector(selector)!);
+        const reader = read(".viewer");
+        const sidebar = read(".sidebar");
+        const title = read(".viewer-title");
+        const content = read(".viewer-content");
+        const metadata = read(".viewer-meta");
+        const navigation = read(".tree-search-input");
+        const sidebarTitle = read(".sidebar-title");
+        return {
+          readerBackground: reader.backgroundColor,
+          sidebarBackground: sidebar.backgroundColor,
+          sidebarBorderWidth: sidebar.borderRightWidth,
+          fontFamily: getComputedStyle(document.body).fontFamily,
+          titleSize: title.fontSize,
+          contentSize: content.fontSize,
+          metadataSize: metadata.fontSize,
+          navigationSize: navigation.fontSize,
+          contentColor: content.color,
+          metadataColor: metadata.color,
+          navigationColor: navigation.color,
+          sidebarTitleColor: sidebarTitle.color,
+        };
+      });
+
+      expect(styles.readerBackground).not.toBe(styles.sidebarBackground);
+      expect(styles.sidebarBorderWidth).toBe("0px");
+      expect(styles.fontFamily).toContain("system-ui");
+      expect({
+        title: styles.titleSize,
+        content: styles.contentSize,
+        metadata: styles.metadataSize,
+        navigation: styles.navigationSize,
+      }).toEqual({
+        title: "40px",
+        content: "17px",
+        metadata: "13px",
+        navigation: "14px",
+      });
+
+      for (const [foreground, background] of [
+        [styles.contentColor, styles.readerBackground],
+        [styles.metadataColor, styles.readerBackground],
+        [styles.navigationColor, styles.sidebarBackground],
+        [styles.sidebarTitleColor, styles.sidebarBackground],
+      ]) {
+        expect(contrastRatio(foreground, background)).toBeGreaterThanOrEqual(4.5);
+      }
+    });
+  }
+});

--- a/tests/e2e/semantic-theme-tokens.spec.ts
+++ b/tests/e2e/semantic-theme-tokens.spec.ts
@@ -69,7 +69,7 @@ test.describe("semantic theme tokens", () => {
               bodyBackground: "rgb(239, 241, 245)",
               bodyColor: "rgb(76, 79, 105)",
               sidebarBackground: "rgb(230, 233, 239)",
-              viewerBackground: "rgb(239, 241, 245)",
+              viewerBackground: "rgb(255, 255, 255)",
             }
           : {
               appliedTheme: "dark",


### PR DESCRIPTION
## Summary
- separate a calm reader surface from the quieter navigation surface without a heavy desktop border
- replace unavailable Pretendard/Noto assumptions with system UI and monospace stacks that do not download text webfonts
- define and document one responsive title/body/heading/navigation/metadata/caption type scale
- verify resolved light/dark text contrast at WCAG AA 4.5:1 and keep theme-aware quote/table surfaces
- wait through an actual paint boundary before allowing deferred desktop tree loading

## DnD
- [x] reader and navigation regions are distinguishable without heavy borders
- [x] title, body, metadata, and navigation levels have a documented type scale
- [x] text typography has no webfont swap or external font availability dependency
- [x] light and dark text roles meet AA contrast in computed-style tests
- [x] responsive reader/sidebar behavior remains coherent
- [x] deferred tree work remains after FCP under repeated timing verification

## Validation
- bun run typecheck
- bun run lint:source
- bun run format:check
- bun run test:unit (79 passed)
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size (app JS 42,601 raw / 14,831 gzip; CSS 30,573 raw / 6,440 gzip)
- bun run check:reproducible (18 files stable)
- bunx playwright test tests/e2e/deferred-tree-runtime.spec.ts --repeat-each=20 (40 passed)
- bun run test:e2e (92 passed)

Part of #37
Detailed acceptance criteria: #39
