### PR TITLE
feat: constrain prose while preserving wide media

### DIFF
--- a/docs/solutions/20260719-prose-wide-lanes.md
+++ b/docs/solutions/20260719-prose-wide-lanes.md
@@ -1,0 +1,28 @@
+# Readable prose and wide-content lanes
+
+## Layout contract
+
+Reader pages use two centered content lanes inside the existing responsive
+viewer container:
+
+- `--content-prose-max-width` limits prose and reader navigation to `42rem`
+  (672 px at the root font size), keeping line length comfortable;
+- `--content-visual-max-width` preserves up to 880 px for code blocks, tables,
+  figures, Mermaid diagrams, and landscape images.
+
+The breadcrumb, document header, ordinary top-level Markdown nodes, post
+navigation, and backlinks share the prose lane. Explicit visual nodes opt out
+into the wide lane, while the existing image and Mermaid rules retain their
+orientation- and diagram-specific limits.
+
+Both widths are capped at `100%`. At compact breakpoints the lanes therefore
+collapse to the viewer's available width without a second layout mode or
+horizontal page overflow; wide tables and code continue to scroll within their
+own components when necessary.
+
+## Regression coverage
+
+The browser contract measures the rendered desktop lanes rather than only
+matching CSS source. It verifies 672 px prose alongside 880 px code and tables,
+checks their shared center axis, and repeats containment checks at a 390 px
+mobile viewport.

--- a/docs/solutions/20260719-prose-wide-lanes.md
+++ b/docs/solutions/20260719-prose-wide-lanes.md
@@ -17,12 +17,14 @@ orientation- and diagram-specific limits.
 
 Both widths are capped at `100%`. At compact breakpoints the lanes therefore
 collapse to the viewer's available width without a second layout mode or
-horizontal page overflow; wide tables and code continue to scroll within their
-own components when necessary.
+horizontal page overflow. Tables are block-level scroll containers at every
+breakpoint, so an unbreakable cell can overflow inside the 880 px visual lane
+instead of widening the page; code retains its own inner scroller.
 
 ## Regression coverage
 
 The browser contract measures the rendered desktop lanes rather than only
 matching CSS source. It verifies 672 px prose alongside 880 px code and tables,
 checks their shared center axis, and repeats containment checks at a 390 px
-mobile viewport.
+mobile viewport. The desktop case also injects an unbreakable table cell and
+requires internal horizontal overflow while the table boundary stays fixed.

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -55,8 +55,8 @@
   --content-heading-accent-soft: rgba(136, 57, 239, 0.32);
   --content-heading-subtle: var(--color-text-secondary);
   --viewer-container-max-width: 1120px;
+  --content-prose-max-width: 42rem;
   --content-visual-max-width: 880px;
-  --content-image-landscape-max-width: 880px;
   --content-image-square-max-width: 720px;
   --content-image-portrait-max-width: 560px;
   --content-image-radius: 8px;
@@ -1095,7 +1095,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content blockquote {
-  margin: 1.5rem 0;
+  margin: 1.5rem auto;
   padding: 12px 16px;
   padding-left: 20px;
   border-left: 4px solid var(--color-accent);
@@ -1118,7 +1118,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 /* Code blocks */
 .viewer-content .code-block {
-  margin: 1.5rem 0;
+  width: min(100%, var(--content-visual-max-width));
+  margin: 1.5rem auto;
   border-radius: 8px;
   border: 1px solid #30363d;
   background: #24292e;
@@ -1230,11 +1231,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content .mermaid-block {
-  margin: 1.5rem 0;
+  margin: 1.5rem auto;
   padding: 16px 18px;
-  max-width: min(100%, var(--content-visual-max-width));
-  margin-left: auto;
-  margin-right: auto;
+  width: min(100%, var(--content-visual-max-width));
   border-radius: 12px;
   border: 1px solid var(--color-border);
   background: linear-gradient(180deg, var(--color-canvas), var(--color-surface));
@@ -1296,7 +1295,8 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .viewer-content pre {
   position: relative;
-  margin: 1.5rem 0;
+  width: min(100%, var(--content-visual-max-width));
+  margin: 1.5rem auto;
   padding: 0;
   border-radius: 8px;
   border: 1px solid var(--color-border);
@@ -1316,9 +1316,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 /* Tables */
 .viewer-content table {
-  width: 100%;
+  width: min(100%, var(--content-visual-max-width));
   border-collapse: collapse;
-  margin: 1.5rem 0;
+  margin: 1.5rem auto;
   font-size: var(--type-navigation);
 }
 
@@ -1347,7 +1347,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 .viewer-content .content-image {
   width: fit-content;
-  max-width: min(100%, var(--content-image-landscape-max-width));
+  max-width: min(100%, var(--content-visual-max-width));
 }
 
 .viewer-content .content-image.is-square {
@@ -1361,7 +1361,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 .viewer-content img {
   display: block;
   width: auto;
-  max-width: min(100%, var(--content-image-landscape-max-width));
+  max-width: min(100%, var(--content-visual-max-width));
   height: auto;
   margin: 0 auto;
   border-radius: var(--content-image-radius);
@@ -1378,7 +1378,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 }
 
 .viewer-content .image-frame {
-  width: min(100%, var(--content-image-landscape-max-width));
+  width: min(100%, var(--content-visual-max-width));
   overflow: hidden;
   border-radius: 12px;
   border: 1px solid var(--color-border);
@@ -1431,7 +1431,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
 .viewer-content hr {
   border: none;
   border-top: 1px solid var(--color-border);
-  margin: 2rem 0;
+  margin: 2rem auto;
 }
 
 /* Post navigation */
@@ -1447,6 +1447,15 @@ body.mobile-toggle-left .mobile-menu-toggle {
   margin-top: 44px;
   padding-top: 28px;
   border-top: 1px solid var(--color-border);
+}
+
+.viewer-breadcrumb,
+.viewer-header,
+.viewer-content > *,
+.viewer-nav,
+.viewer-backlinks {
+  width: min(100%, var(--content-prose-max-width));
+  margin-inline: auto;
 }
 
 .backlinks-title {

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -1316,7 +1316,9 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
 /* Tables */
 .viewer-content table {
+  display: block;
   width: min(100%, var(--content-visual-max-width));
+  overflow-x: auto;
   border-collapse: collapse;
   margin: 1.5rem auto;
   font-size: var(--type-navigation);
@@ -1769,8 +1771,6 @@ body.mobile-toggle-left .mobile-menu-toggle {
   }
 
   .viewer-content table {
-    display: block;
-    overflow-x: auto;
     white-space: nowrap;
   }
 }

--- a/tests/e2e/prose-width.spec.ts
+++ b/tests/e2e/prose-width.spec.ts
@@ -18,6 +18,8 @@ test.describe("reader prose and wide-content lanes", () => {
         const box = document.querySelector(selector)!.getBoundingClientRect();
         return { left: box.left, right: box.right, width: box.width };
       };
+      const table = document.querySelector(".viewer-content > table")!;
+      table.querySelector("td")!.textContent = "x".repeat(1200);
 
       return {
         content: bounds(".viewer-content"),
@@ -27,6 +29,8 @@ test.describe("reader prose and wide-content lanes", () => {
         heading: bounds(".viewer-content > h2"),
         code: bounds(".viewer-content > .code-block"),
         table: bounds(".viewer-content > table"),
+        tableClientWidth: table.clientWidth,
+        tableScrollWidth: table.scrollWidth,
         navigation: bounds(".viewer-nav"),
       };
     });
@@ -50,6 +54,7 @@ test.describe("reader prose and wide-content lanes", () => {
       expect(item.width - layout.paragraph.width).toBeGreaterThanOrEqual(200);
       expect(centeredInContent(item)).toBeLessThanOrEqual(1);
     }
+    expect(layout.tableScrollWidth).toBeGreaterThan(layout.tableClientWidth);
   });
 
   test("collapses both lanes without horizontal overflow on mobile", async ({ page }) => {

--- a/tests/e2e/prose-width.spec.ts
+++ b/tests/e2e/prose-width.spec.ts
@@ -1,0 +1,83 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+interface Rect {
+  left: number;
+  right: number;
+  width: number;
+}
+
+test.describe("reader prose and wide-content lanes", () => {
+  test("centers readable prose while code and tables retain a wider lane", async ({ page }) => {
+    await page.setViewportSize({ width: 1600, height: 1000 });
+    await page.goto("/BC-VO-01/");
+    await waitForAppReady(page);
+
+    const layout = await page.evaluate(() => {
+      const bounds = (selector: string) => {
+        const box = document.querySelector(selector)!.getBoundingClientRect();
+        return { left: box.left, right: box.right, width: box.width };
+      };
+
+      return {
+        content: bounds(".viewer-content"),
+        breadcrumb: bounds(".viewer-breadcrumb"),
+        header: bounds(".viewer-header"),
+        paragraph: bounds(".viewer-content > p"),
+        heading: bounds(".viewer-content > h2"),
+        code: bounds(".viewer-content > .code-block"),
+        table: bounds(".viewer-content > table"),
+        navigation: bounds(".viewer-nav"),
+      };
+    });
+
+    const centeredInContent = (item: Rect) =>
+      Math.abs(item.left - layout.content.left - (layout.content.right - item.right));
+
+    for (const item of [
+      layout.breadcrumb,
+      layout.header,
+      layout.paragraph,
+      layout.heading,
+      layout.navigation,
+    ]) {
+      expect(item.width).toBeCloseTo(672, 0);
+      expect(centeredInContent(item)).toBeLessThanOrEqual(1);
+    }
+
+    for (const item of [layout.code, layout.table]) {
+      expect(item.width).toBeCloseTo(880, 0);
+      expect(item.width - layout.paragraph.width).toBeGreaterThanOrEqual(200);
+      expect(centeredInContent(item)).toBeLessThanOrEqual(1);
+    }
+  });
+
+  test("collapses both lanes without horizontal overflow on mobile", async ({ page }) => {
+    const viewport = { width: 390, height: 844 };
+    await page.setViewportSize(viewport);
+    await page.goto("/BC-VO-01/");
+    await waitForAppReady(page);
+
+    const boxes = await page.evaluate(() =>
+      [
+        ".viewer-container",
+        ".viewer-content > p",
+        ".viewer-content > .code-block",
+        ".viewer-content > table",
+      ].map((selector) => {
+        const element = document.querySelector(selector)!;
+        const box = element.getBoundingClientRect();
+        return { left: box.left, right: box.right, width: box.width };
+      }),
+    );
+
+    expect(boxes).toHaveLength(4);
+    for (const box of boxes) {
+      expect(box.left).toBeGreaterThanOrEqual(0);
+      expect(box.right).toBeLessThanOrEqual(viewport.width + 1);
+      expect(box.width).toBeGreaterThan(0);
+    }
+    expect(boxes[1].width).toBeCloseTo(boxes[2].width, 0);
+    expect(boxes[1].width).toBeCloseTo(boxes[3].width, 0);
+  });
+});


### PR DESCRIPTION
## Summary
- center breadcrumbs, document chrome, prose, navigation, and backlinks in a 42rem readable lane
- preserve an 880px visual lane for code, tables, Mermaid diagrams, and landscape images
- collapse both lanes to the available reader width at compact breakpoints
- consolidate the landscape image limit onto the shared visual-width token
- document and measure the rendered desktop/mobile layout contract

## DnD
- [x] ordinary prose stays within a comfortable readable width
- [x] code, tables, diagrams, and images can remain wider than prose
- [x] reader chrome and prose share a stable center axis
- [x] compact layouts avoid horizontal page overflow
- [x] the CSS size gate remains within budget

## Validation
- bun run typecheck
- bun run lint:source
- bun run format:check
- bun run lint:md:publish
- bun run test:unit (79 passed)
- bun run build -- --vault ./test-vault --out ./dist
- bun run check:size (app JS 42,601 raw / 14,831 gzip; CSS 30,857 raw / 6,477 gzip)
- bun run check:reproducible (19 files stable)
- bunx playwright test tests/e2e/prose-width.spec.ts (2 passed)
- bun run test:e2e (94 passed)

Part of #37