### PR TITLE
feat: simplify sidebar chrome and branch control

### DIFF
--- a/README.md
+++ b/README.md
@@ -502,7 +502,7 @@ Main behaviors:
 - `Recent` virtual folder
 - optional pinned virtual folder
 - prefix/title file labels without visible `.md` extensions, plus NEW badges when `ui.newWithinDays` matches
-- branch pills in the sidebar
+- a compact native branch selector in the sidebar
 - active document selection synced between the tree, browser history, and document viewer
 - model-level tree search with clear and previous/next match controls
 - direct-link loading from route HTML

--- a/docs/checklists/e2e-review-checklist.md
+++ b/docs/checklists/e2e-review-checklist.md
@@ -1,22 +1,26 @@
 # E2E Review Checklist
 
 ## 원칙
+
 - [ ] UI 문구 완전일치보다 상태/route 기반 assertion을 우선한다.
 - [ ] 기본 브랜치 값은 문자열 상수 하드코딩 없이 manifest에서 동적으로 읽는다.
 - [ ] 테스트 실패 메시지는 원인 추적이 가능하도록 명시적으로 작성한다.
 
 ## Prefix/Backlinks/Branch 전이
+
 - [ ] prefix route 이동 후 URL과 제목이 함께 일치한다.
 - [ ] backlinks 클릭 후 기대 route로 이동한다.
-- [ ] 자동 브랜치 전환 후 활성 pill(`.branch-pill.is-active`)이 기대 브랜치를 가리킨다.
+- [ ] 자동 브랜치 전환 후 `#sidebar-branch-select` 값이 기대 브랜치를 가리킨다.
 - [ ] 전환 후 nav target(`data-route`)이 현재 브랜치 가시 문서 기준과 일치한다.
 
 ## Mermaid Runtime
+
 - [ ] Mermaid 활성화 시 `pre.mermaid`가 실제 렌더 결과(SVG)로 치환된다.
 - [ ] Mermaid 비활성화 시 원본 코드 블록이 유지되고 안내 메시지가 노출된다.
 - [ ] Mermaid CDN 로드 실패 시 오류 메시지가 노출되고 페이지가 정상 동작한다.
 - [ ] Mermaid 블록 일부가 파싱 실패해도 실패 블록만 오류 표시되고 다른 Mermaid 블록 렌더링은 유지된다.
 
 ## 검증 커맨드
+
 - [ ] `bun run test:e2e`
 - [ ] `bun run build -- --vault ./test-vault --out ./dist`

--- a/docs/solutions/20260719-purposeful-sidebar-chrome.md
+++ b/docs/solutions/20260719-purposeful-sidebar-chrome.md
@@ -1,0 +1,43 @@
+# Purposeful sidebar chrome
+
+## Persistent elements
+
+Every persistent sidebar element has one user-facing purpose:
+
+| Element             | Purpose                                                                                   |
+| ------------------- | ----------------------------------------------------------------------------------------- |
+| Site title          | Identifies the generated knowledge base                                                   |
+| Branch selector     | Scopes navigation to one content branch; the default option is identified in its label    |
+| Search field        | Filters the document tree; result count and stepping controls appear only during a search |
+| Folder chevrons     | Expose hierarchy and expansion state                                                      |
+| Prefix text         | Preserves the document's stable public identifier without pill decoration                 |
+| `NEW` marker        | Communicates actual recency derived from document dates                                   |
+| Settings button     | Keeps theme and mobile menu-position preferences available                                |
+| Mobile close button | Exits the modal navigation panel                                                          |
+
+The terminal glyph, branch badge and pills, `publish: true` copy, animated
+`Online` status, and static `UTF-8` label did not represent actionable or live
+state, so they are removed. A compact bottom toolbar retains only the purposeful
+settings action and provides a stable light-DOM endpoint for the mobile focus
+loop after the shadow-DOM tree.
+
+## Branch and tree behavior
+
+Branch selection uses a labeled native `<select>`. It retains browser keyboard
+behavior, exposes the current value directly to assistive technology, and
+requires one control regardless of branch count. Runtime-driven and automatic
+branch changes update the same control and the existing persisted branch key.
+
+Document rows reclaim horizontal space in three ways: horizontal tree and row
+padding decrease, generic file icons are visually suppressed while folder
+chevrons remain, and prefixes become compact monospace text instead of bordered
+pills. Full prefix/title text remains available through the row title and the
+existing overflow tooltip behavior.
+
+## Regression coverage
+
+Browser coverage verifies native keyboard branch switching and persistence,
+the absence of static chrome, conditional search controls, inline prefixes,
+and settings availability. Responsive tests additionally verify that file
+icons are suppressed, the tighter row padding is applied, and long labels stay
+inside the tree without overlapping `NEW` decorations.

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -300,129 +300,103 @@ a:hover {
 .sidebar-header {
   position: relative;
   flex: 0 0 auto;
-  padding: 24px 20px;
+  padding: 18px 16px 14px;
   border-bottom: 1px solid var(--color-border);
 }
 
-.sidebar-close {
-  display: none;
-  position: absolute;
-  top: 18px;
-  right: 14px;
+.sidebar-heading {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sidebar-title {
+  flex: 1 1 auto;
+  min-width: 0;
+  margin: 0;
+  overflow: hidden;
+  color: var(--color-text);
+  font-size: 1.0625rem;
+  font-weight: 700;
+  letter-spacing: 0;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+}
+
+.sidebar-close,
+.settings-toggle {
+  flex: 0 0 auto;
   width: 36px;
   height: 36px;
   border: 1px solid var(--color-border);
-  background: var(--color-canvas);
-  color: var(--color-text-secondary);
   border-radius: 8px;
+  background: transparent;
+  color: var(--color-text-secondary);
   cursor: pointer;
   align-items: center;
   justify-content: center;
 }
 
-.sidebar-close:hover {
-  color: var(--color-text);
+.sidebar-close {
+  display: none;
 }
 
-.sidebar-title {
-  margin: 0;
-  font-size: 1.0625rem;
-  font-weight: 700;
-  letter-spacing: 0;
-  display: flex;
-  align-items: center;
-  gap: 8px;
-}
-
-.icon-terminal {
-  color: var(--color-accent);
-  font-size: 20px;
-}
-
-.sidebar-branch {
-  display: grid;
-  grid-template-columns: auto 1fr;
-  align-items: center;
-  column-gap: 8px;
-  row-gap: 10px;
-  margin-top: 12px;
-}
-
-.branch-badge {
+.settings-toggle {
   display: inline-flex;
-  align-items: center;
-  gap: 5px;
-  padding: 6px 12px;
-  font-size: 0.8rem;
-  font-weight: 650;
-  line-height: 1;
-  background: var(--elevated-surface);
-  border: 1px solid var(--color-border-strong);
-  border-radius: 999px;
-  color: var(--color-text-muted);
-  box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
 }
 
-.icon-branch {
-  font-size: 13px;
-  color: var(--color-text-subtle);
-}
-
-.branch-info {
-  grid-column: 1 / -1;
-  display: block;
-  font-size: var(--type-caption);
-  color: var(--color-text-subtle);
-}
-
-.branch-pills {
-  display: flex;
-  flex-wrap: wrap;
-  align-items: center;
-  gap: 8px;
-  min-width: 0;
-}
-
-.branch-pill {
-  border: 1px solid var(--color-border-strong);
-  border-radius: 999px;
-  background: var(--elevated-surface-strong);
-  color: var(--color-text-secondary);
-  font-size: var(--type-metadata);
-  font-weight: 700;
-  line-height: 1.15;
-  letter-spacing: 0;
-  padding: 7px 14px;
-  cursor: pointer;
-  white-space: nowrap;
-  box-shadow: 0 1px 0 var(--elevated-inset-shadow) inset;
-  transition:
-    border-color 0.15s ease,
-    box-shadow 0.15s ease,
-    background-color 0.15s ease,
-    color 0.15s ease,
-    transform 0.12s ease;
-}
-
-.branch-pill:hover {
-  border-color: var(--color-border-emphasis);
-  background-color: var(--elevated-surface-hover);
+.sidebar-close:hover,
+.settings-toggle:hover {
+  background: var(--elevated-surface-hover);
   color: var(--color-text);
-  transform: translateY(-1px);
 }
 
-.branch-pill:focus-visible {
+.sidebar-close:focus-visible,
+.settings-toggle:focus-visible {
   outline: 2px solid var(--color-focus);
   outline-offset: 1px;
 }
 
-.branch-pill.is-active {
-  border-color: color-mix(in srgb, var(--color-accent) 45%, transparent);
-  background: color-mix(in srgb, var(--color-accent) 14%, transparent);
-  color: var(--color-accent-strong);
-  box-shadow:
-    0 1px 0 var(--elevated-inset-shadow) inset,
-    0 2px 6px color-mix(in srgb, var(--color-accent) 22%, transparent);
+.sidebar-branch {
+  display: grid;
+  grid-template-columns: auto minmax(0, 1fr);
+  align-items: center;
+  gap: 8px;
+  margin-top: 12px;
+}
+
+.branch-label {
+  color: var(--color-text-subtle);
+  font-size: var(--type-metadata);
+  font-weight: 650;
+}
+
+.branch-select {
+  width: 100%;
+  min-width: 0;
+  min-height: 34px;
+  padding: 0 8px;
+  border: 1px solid var(--color-border-strong);
+  border-radius: 7px;
+  background: var(--elevated-surface);
+  color: var(--color-text);
+  font-family: var(--font-mono);
+  font-size: var(--type-metadata);
+  cursor: pointer;
+}
+
+.branch-select:hover {
+  border-color: var(--color-border-emphasis);
+}
+
+.branch-select:focus-visible {
+  outline: 2px solid var(--color-focus);
+  outline-offset: 1px;
+}
+
+.branch-select:disabled {
+  cursor: default;
+  opacity: 0.7;
 }
 
 /* Tree search */
@@ -531,6 +505,10 @@ a:hover {
   margin-top: 7px;
 }
 
+.sidebar-search-actions[hidden] {
+  display: none;
+}
+
 .tree-search-count {
   min-width: 0;
   overflow: hidden;
@@ -551,7 +529,7 @@ a:hover {
   flex: 1 1 auto;
   min-height: 0;
   overflow: hidden;
-  padding: 12px 12px 24px;
+  padding: 8px 8px 16px;
 }
 
 .tree-load-status,
@@ -651,112 +629,39 @@ a:hover {
   --trees-border-radius-override: 6px;
   --trees-gap-override: 2px;
   --trees-item-margin-x-override: 0px;
-  --trees-item-padding-x-override: 12px;
-  --trees-item-row-gap-override: 8px;
+  --trees-item-padding-x-override: 8px;
+  --trees-item-row-gap-override: 6px;
   --trees-level-gap-override: 10px;
   --trees-padding-inline-override: 0px;
   --trees-file-icon-color-default: var(--color-text-subtle);
   --trees-new-badge-bg: var(--badge-new-bg);
   --trees-new-badge-fg: var(--badge-new-fg);
-  --trees-prefix-badge-bg: color-mix(in srgb, var(--color-accent) 16%, transparent);
-  --trees-prefix-badge-fg: var(--color-accent-strong);
-  --trees-prefix-badge-border: color-mix(in srgb, var(--color-accent) 42%, transparent);
   display: block;
   width: 100%;
   height: 100%;
   min-height: 0;
 }
 
-/* Sidebar footer */
-.sidebar-footer {
-  position: relative;
-  flex: 0 0 auto;
-  padding: 12px 16px;
-  background: var(--color-surface-muted);
-  border-top: 1px solid var(--color-border);
-  display: flex;
-  justify-content: space-between;
-  align-items: center;
-  gap: 12px;
-  min-height: 57px;
-  font-size: var(--type-caption);
-  color: var(--color-text-secondary);
-}
-
-.status-online {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  min-width: 0;
-}
-
-.status-dot {
-  width: 8px;
-  height: 8px;
-  border-radius: 50%;
-  background: var(--color-success);
-  animation: pulse 2s infinite;
-}
-
-@media (prefers-reduced-motion: reduce) {
-  .status-dot {
-    animation: none;
-  }
-}
-
-@keyframes pulse {
-  0%,
-  100% {
-    opacity: 1;
-  }
-  50% {
-    opacity: 0.5;
-  }
-}
-
-.status-encoding {
-  font-family: var(--font-mono);
-  flex: 0 1 auto;
-  min-width: 0;
-  overflow: hidden;
-  text-overflow: ellipsis;
-  white-space: nowrap;
-  color: var(--color-text-secondary);
-}
-
-.sidebar-footer-actions {
-  display: flex;
-  align-items: center;
-  flex: 0 0 auto;
-  gap: 8px;
-}
-
-.settings-toggle {
-  width: 32px;
-  height: 32px;
-  border-radius: 8px;
-  border: 1px solid var(--color-border);
-  background: var(--color-canvas);
-  color: var(--color-text-secondary);
-  cursor: pointer;
-  display: inline-flex;
-  align-items: center;
-  justify-content: center;
-}
-
-.settings-toggle:hover {
-  color: var(--color-text);
-}
-
 .settings-toggle .material-symbols-outlined {
   font-size: 18px;
+}
+
+.sidebar-tools {
+  position: relative;
+  display: flex;
+  flex: 0 0 auto;
+  justify-content: flex-end;
+  padding: 6px 10px;
+  border-top: 1px solid var(--color-border);
 }
 
 .sidebar-settings {
   position: absolute;
   right: 12px;
-  bottom: 52px;
+  bottom: calc(100% + 8px);
   width: min(300px, calc(100vw - 24px));
+  max-height: calc(100dvh - 70px);
+  overflow: auto;
   background: var(--color-canvas);
   border: 1px solid var(--color-border);
   border-radius: 10px;
@@ -1668,19 +1573,11 @@ body.mobile-toggle-left .mobile-menu-toggle {
   }
 
   .sidebar-header {
-    padding: 18px 18px 16px;
-  }
-
-  .sidebar-title {
-    padding-right: 42px;
+    padding: 16px 14px 12px;
   }
 
   .sidebar-search {
     padding: 12px 14px 9px;
-  }
-
-  .tree-root {
-    padding: 10px 10px 18px;
   }
 
   .viewer-container {
@@ -1719,20 +1616,11 @@ body.mobile-toggle-left .mobile-menu-toggle {
   }
 
   .sidebar-header {
-    padding: 16px 16px 14px;
+    padding: 14px 12px 12px;
   }
 
   .sidebar-branch {
-    row-gap: 8px;
     margin-top: 10px;
-  }
-
-  .branch-pills {
-    gap: 6px;
-  }
-
-  .branch-pill {
-    padding: 6px 10px;
   }
 
   .sidebar-search {
@@ -1746,11 +1634,6 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
   .tree-root {
     padding: 8px 8px 14px;
-  }
-
-  .sidebar-footer {
-    min-height: 52px;
-    padding: 10px 12px;
   }
 
   .viewer-container {
@@ -1786,20 +1669,12 @@ body.mobile-toggle-left .mobile-menu-toggle {
   }
 
   .sidebar-branch {
-    row-gap: 6px;
+    gap: 6px;
     margin-top: 8px;
   }
 
-  .branch-badge {
-    padding: 5px 9px;
-  }
-
-  .branch-pill {
-    padding: 5px 9px;
-  }
-
-  .branch-info {
-    font-size: 0.7rem;
+  .branch-select {
+    min-height: 32px;
   }
 
   .sidebar-search {
@@ -1819,11 +1694,5 @@ body.mobile-toggle-left .mobile-menu-toggle {
 
   .tree-root {
     padding-bottom: 10px;
-  }
-
-  .sidebar-footer {
-    min-height: 48px;
-    padding-top: 8px;
-    padding-bottom: 8px;
   }
 }

--- a/src/runtime/tree-controller.js
+++ b/src/runtime/tree-controller.js
@@ -81,7 +81,7 @@ function decorateTreeLabels(host, documentRef) {
     label.className = "tree-item-label";
     if (prefix) {
       const prefixBadge = documentRef.createElement("span");
-      prefixBadge.className = "tree-item-prefix-badge";
+      prefixBadge.className = "tree-item-prefix";
       prefixBadge.textContent = prefix;
       label.appendChild(prefixBadge);
     }
@@ -202,8 +202,10 @@ export function createTreeController(options) {
     documentRef.getElementById("tree-search-next")
   );
   const treeSearchCount = documentRef.getElementById("tree-search-count");
-  const sidebarBranchPills = documentRef.getElementById("sidebar-branch-pills");
-  const sidebarBranchInfo = documentRef.getElementById("sidebar-branch-info");
+  const sidebarSearchActions = documentRef.getElementById("sidebar-search-actions");
+  const sidebarBranchSelect = /** @type {HTMLSelectElement | null} */ (
+    documentRef.getElementById("sidebar-branch-select")
+  );
   /** @type {EventScope | null} */
   let events = null;
   /** @type {FileTree | null} */
@@ -235,36 +237,23 @@ export function createTreeController(options) {
     documentRef.documentElement?.setAttribute(TREE_RUNTIME_STATE_ATTR, state);
   };
 
-  const renderBranchPills = () => {
-    if (!sidebarBranchPills) {
+  const renderBranchOptions = () => {
+    if (!sidebarBranchSelect) {
       return;
     }
-    sidebarBranchPills.replaceChildren();
+    sidebarBranchSelect.replaceChildren();
     for (const branch of navigation.availableBranches) {
-      const pill = documentRef.createElement("button");
-      pill.type = "button";
-      pill.className = "branch-pill";
-      pill.dataset.branch = branch;
-      pill.textContent = branch;
-      pill.setAttribute("aria-pressed", "false");
-      sidebarBranchPills.appendChild(pill);
+      const option = documentRef.createElement("option");
+      option.value = branch;
+      option.textContent = branch === navigation.defaultBranch ? `${branch} (default)` : branch;
+      sidebarBranchSelect.appendChild(option);
     }
+    sidebarBranchSelect.disabled = navigation.availableBranches.length < 2;
   };
 
-  const updateBranchInfo = () => {
-    if (sidebarBranchInfo) {
-      sidebarBranchInfo.textContent =
-        navigation.activeBranch === navigation.defaultBranch
-          ? `publish: true · ${navigation.activeBranch} + unclassified`
-          : `publish: true · ${navigation.activeBranch} only`;
-    }
-    for (const pill of sidebarBranchPills?.querySelectorAll(".branch-pill") ?? []) {
-      if (!(pill instanceof windowRef.HTMLElement)) {
-        continue;
-      }
-      const isActive = pill.dataset.branch === navigation.activeBranch;
-      pill.classList.toggle("is-active", isActive);
-      pill.setAttribute("aria-pressed", String(isActive));
+  const updateBranchControl = () => {
+    if (sidebarBranchSelect) {
+      sidebarBranchSelect.value = navigation.activeBranch;
     }
   };
 
@@ -284,6 +273,9 @@ export function createTreeController(options) {
     }
     if (treeSearchCount) {
       treeSearchCount.textContent = hasSearch ? `${matchCount}개 일치` : "";
+    }
+    if (sidebarSearchActions) {
+      sidebarSearchActions.hidden = !hasSearch;
     }
   };
 
@@ -682,7 +674,7 @@ export function createTreeController(options) {
   /** @param {string} branch */
   const handleBranchChange = (branch) => {
     storage.setItem(BRANCH_KEY, branch);
-    updateBranchInfo();
+    updateBranchControl();
     if (treeRuntime) {
       renderTree();
     }
@@ -704,17 +696,8 @@ export function createTreeController(options) {
     return true;
   };
 
-  /** @param {Event} event */
-  const handleBranchPillClick = (event) => {
-    const target = event.target;
-    if (!(target instanceof windowRef.Element)) {
-      return;
-    }
-    const pill = target.closest(".branch-pill");
-    if (!(pill instanceof windowRef.HTMLElement) || !sidebarBranchPills?.contains(pill)) {
-      return;
-    }
-    void setActiveBranch(pill.dataset.branch);
+  const handleBranchSelectChange = () => {
+    void setActiveBranch(sidebarBranchSelect?.value);
   };
 
   const handleSearchFocus = () => {
@@ -818,7 +801,7 @@ export function createTreeController(options) {
         return;
       }
       events = createEventScope();
-      events.listen(sidebarBranchPills, "click", handleBranchPillClick);
+      events.listen(sidebarBranchSelect, "change", handleBranchSelectChange);
       events.listen(treeSearchInput, "focus", handleSearchFocus);
       events.listen(treeSearchInput, "input", handleSearchInput);
       events.listen(treeSearchInput, "keydown", handleSearchKeydown);
@@ -828,8 +811,8 @@ export function createTreeController(options) {
       });
       events.listen(treeSearchPrev, "click", () => moveTreeSearchFocus(-1));
       events.listen(treeSearchNext, "click", () => moveTreeSearchFocus(1));
-      renderBranchPills();
-      updateBranchInfo();
+      renderBranchOptions();
+      updateBranchControl();
       updateTreeSearchControls();
       if (treeRuntime) {
         renderTree();

--- a/src/runtime/tree-runtime.js
+++ b/src/runtime/tree-runtime.js
@@ -38,28 +38,28 @@ const TREE_UNSAFE_CSS = `
   white-space: nowrap;
 }
 
+[data-type='item'][data-item-type='file'] > [data-item-section='icon'] {
+  display: none;
+}
+
 .tree-item-label {
   display: inline-flex;
   align-items: center;
-  gap: 7px;
+  gap: 5px;
   min-width: 0;
   max-width: 100%;
   overflow: hidden;
 }
 
-.tree-item-prefix-badge {
+.tree-item-prefix {
   flex: 0 0 auto;
   max-width: 6.5rem;
   overflow: hidden;
-  padding: 2px 6px;
-  border: 1px solid var(--trees-prefix-badge-border, rgba(203, 166, 247, 0.38));
-  border-radius: 999px;
-  background: var(--trees-prefix-badge-bg, rgba(203, 166, 247, 0.14));
-  color: var(--trees-prefix-badge-fg, currentColor);
+  color: var(--trees-fg-muted, currentColor);
+  font-family: var(--font-mono, monospace);
   font-size: 0.66rem;
-  font-weight: 800;
+  font-weight: 700;
   line-height: 1.15;
-  letter-spacing: 0.02em;
   text-overflow: ellipsis;
   white-space: nowrap;
 }

--- a/src/template.ts
+++ b/src/template.ts
@@ -248,20 +248,16 @@ ${headMeta}
       <div id="sidebar-overlay" class="sidebar-overlay" aria-hidden="true" hidden></div>
       <aside id="sidebar-panel" class="sidebar" role="complementary" aria-label="문서 탐색기 패널">
         <div class="sidebar-header">
-          <h1 class="sidebar-title">
-            <span class="material-symbols-outlined icon-terminal">terminal</span>
-            ${escapeHtmlAttribute(appTitle)}
-          </h1>
-          <button id="sidebar-close" class="sidebar-close" type="button" aria-label="탐색기 닫기">
-            <span class="material-symbols-outlined">close</span>
-          </button>
-          <div class="sidebar-branch">
-            <span class="branch-badge" aria-hidden="true">
-              <span class="material-symbols-outlined icon-branch">call_split</span>branch
-            </span>
-            <div id="sidebar-branch-pills" class="branch-pills" role="group" aria-label="브랜치 선택"></div>
-            <span id="sidebar-branch-info" class="branch-info">publish: true</span>
+          <div class="sidebar-heading">
+            <h1 class="sidebar-title">${escapeHtmlAttribute(appTitle)}</h1>
+            <button id="sidebar-close" class="sidebar-close" type="button" aria-label="탐색기 닫기">
+              <span class="material-symbols-outlined">close</span>
+            </button>
           </div>
+          <label class="sidebar-branch" for="sidebar-branch-select">
+            <span class="branch-label">Branch</span>
+            <select id="sidebar-branch-select" class="branch-select"></select>
+          </label>
         </div>
         <div class="sidebar-search">
           <div class="sidebar-search-box">
@@ -279,7 +275,7 @@ ${headMeta}
               <span class="material-symbols-outlined">close</span>
             </button>
           </div>
-          <div class="sidebar-search-actions" aria-live="polite">
+          <div id="sidebar-search-actions" class="sidebar-search-actions" aria-live="polite" hidden>
             <span id="tree-search-count" class="tree-search-count"></span>
             <div class="tree-search-nav">
               <button id="tree-search-prev" class="tree-search-step" type="button" aria-label="이전 검색 결과" title="이전 검색 결과" disabled>
@@ -292,24 +288,17 @@ ${headMeta}
           </div>
         </div>
         <nav id="tree-root" class="tree-root" aria-label="문서 탐색기" tabindex="0"></nav>
-        <div class="sidebar-footer">
-          <div class="status-online">
-            <span class="status-dot"></span>
-            <span>Online</span>
-          </div>
-          <div class="sidebar-footer-actions">
-            <div class="status-encoding">UTF-8</div>
-            <button
-              id="settings-toggle"
-              class="settings-toggle"
-              type="button"
-              aria-controls="sidebar-settings"
-              aria-expanded="false"
-              aria-label="탐색기 설정 열기"
-            >
-              <span class="material-symbols-outlined">tune</span>
-            </button>
-          </div>
+        <div class="sidebar-tools">
+          <button
+            id="settings-toggle"
+            class="settings-toggle"
+            type="button"
+            aria-controls="sidebar-settings"
+            aria-expanded="false"
+            aria-label="탐색기 설정 열기"
+          >
+            <span class="material-symbols-outlined">tune</span>
+          </button>
           <section id="sidebar-settings" class="sidebar-settings" hidden aria-label="탐색기 설정">
             <p class="sidebar-settings-title">탐색기 설정</p>
             <fieldset class="settings-group">

--- a/tests/e2e/mobile-sidebar-focus-trap.spec.ts
+++ b/tests/e2e/mobile-sidebar-focus-trap.spec.ts
@@ -20,26 +20,38 @@ test.describe("모바일 사이드바 포커스 트랩", () => {
     await expect(sidebar).toHaveAttribute("aria-modal", "true");
     await expect(viewer).toHaveAttribute("aria-hidden", "true");
 
+    const tabHistory: string[] = [];
     for (let i = 0; i < 30; i += 1) {
       await page.keyboard.press("Tab");
-      const insideSidebar = await page.evaluate(() => {
+      const focusState = await page.evaluate(() => {
         const active = document.activeElement;
         const panel = document.getElementById("sidebar-panel");
-        return Boolean(active && panel && panel.contains(active));
+        return {
+          id: active?.id ?? "",
+          inside: Boolean(active && panel && panel.contains(active)),
+          tag: active?.tagName ?? "",
+        };
       });
-      expect(insideSidebar).toBe(true);
+      tabHistory.push(`${focusState.tag}#${focusState.id}`);
+      expect(focusState.inside, `Tab ${i + 1}: ${tabHistory.join(" → ")}`).toBe(true);
     }
 
     for (let i = 0; i < 30; i += 1) {
       await page.keyboard.down("Shift");
       await page.keyboard.press("Tab");
       await page.keyboard.up("Shift");
-      const insideSidebar = await page.evaluate(() => {
+      const focusState = await page.evaluate(() => {
         const active = document.activeElement;
         const panel = document.getElementById("sidebar-panel");
-        return Boolean(active && panel && panel.contains(active));
+        return {
+          id: active?.id ?? "",
+          inside: Boolean(active && panel && panel.contains(active)),
+          tag: active?.tagName ?? "",
+        };
       });
-      expect(insideSidebar).toBe(true);
+      expect(focusState.inside, `Shift+Tab ${i + 1}: ${focusState.tag}#${focusState.id}`).toBe(
+        true,
+      );
     }
 
     await page.keyboard.press("Escape");

--- a/tests/e2e/prefix-backlinks-branch.spec.ts
+++ b/tests/e2e/prefix-backlinks-branch.spec.ts
@@ -20,10 +20,8 @@ test.describe("prefix 라우팅/백링크/자동 브랜치 전환", () => {
     }
 
     await expect(page.locator("#viewer-title")).toHaveText("About");
-    await expect(page.locator("#sidebar-branch-pills .branch-pill").first()).toBeVisible();
-    await expect(
-      page.locator(`.branch-pill.is-active[data-branch="${manifest.defaultBranch}"]`),
-    ).toBeVisible();
+    await expect(page.locator("#sidebar-branch-select")).toBeVisible();
+    await expect(page.locator("#sidebar-branch-select")).toHaveValue(manifest.defaultBranch);
 
     const nextToSetupGuide = page.locator(`#viewer-nav .nav-link[data-route="${nextRoute}"]`);
     await expect(nextToSetupGuide).toBeVisible();
@@ -57,10 +55,8 @@ test.describe("prefix 라우팅/백링크/자동 브랜치 전환", () => {
 
     await expect(page).toHaveURL(/\/BC-VO-00\/$/);
     await expect(page.locator("#viewer-title")).toHaveText("About");
-    await expect(page.locator("#sidebar-branch-pills .branch-pill").first()).toBeVisible();
-    await expect(
-      page.locator(`.branch-pill.is-active[data-branch="${manifest.defaultBranch}"]`),
-    ).toBeVisible();
+    await expect(page.locator("#sidebar-branch-select")).toBeVisible();
+    await expect(page.locator("#sidebar-branch-select")).toHaveValue(manifest.defaultBranch);
     await expect(page.locator(`#viewer-nav .nav-link[data-route="${nextRoute}"]`)).toBeVisible();
   });
 });

--- a/tests/e2e/responsive-sidebar-layout.spec.ts
+++ b/tests/e2e/responsive-sidebar-layout.spec.ts
@@ -197,16 +197,15 @@ test.describe("responsive Trees sidebar layout", () => {
       const header = await getRect(page, ".sidebar-header");
       const search = await getRect(page, ".sidebar-search");
       const tree = await getRect(page, "#tree-root");
-      const footer = await getRect(page, ".sidebar-footer");
+      const tools = await getRect(page, ".sidebar-tools");
       const sidebar = await getRect(page, "#sidebar-panel");
 
       expect(header.top).toBeGreaterThanOrEqual(sidebar.top);
       expect(search.top).toBeGreaterThanOrEqual(header.bottom - 1);
       expect(tree.top).toBeGreaterThanOrEqual(search.bottom - 1);
-      expect(footer.top).toBeGreaterThanOrEqual(tree.bottom - 1);
-      expect(footer.bottom).toBeLessThanOrEqual(Math.min(sidebar.bottom, viewport.height) + 1);
+      expect(tools.top).toBeGreaterThanOrEqual(tree.bottom - 1);
+      expect(tools.bottom).toBeLessThanOrEqual(Math.min(sidebar.bottom, viewport.height) + 1);
       expect(tree.height).toBeGreaterThan(80);
-      expect(footer.top).toBeGreaterThanOrEqual(tree.top + 80);
 
       const rowState = await page.locator("#tree-root").evaluate(() => {
         const host = document.querySelector("#tree-root file-tree-container");
@@ -224,7 +223,14 @@ test.describe("responsive Trees sidebar layout", () => {
         const rowRect = firstRow?.getBoundingClientRect();
         const contentRect = content?.getBoundingClientRect();
         const decorationRect = decoration?.getBoundingClientRect();
+        const fileIcon = firstRow?.querySelector(
+          '[data-item-section="icon"]',
+        ) as HTMLElement | null;
         return {
+          fileIconDisplay: fileIcon ? getComputedStyle(fileIcon).display : "missing",
+          itemPadding: host
+            ? getComputedStyle(host).getPropertyValue("--trees-item-padding-x-override")
+            : "",
           path: firstRow?.dataset.itemPath ?? "",
           text: firstRow?.textContent ?? "",
           rowWithinTree:
@@ -239,6 +245,8 @@ test.describe("responsive Trees sidebar layout", () => {
 
       expect(rowState.path).not.toContain(".md");
       expect(rowState.text).not.toContain(".md");
+      expect(rowState.fileIconDisplay).toBe("none");
+      expect(rowState.itemPadding.trim()).toBe("8px");
       expect(rowState.rowWithinTree).toBe(true);
       expect(rowState.lanesDoNotOverlap).toBe(true);
 

--- a/tests/e2e/runtime-controller-lifecycle.spec.ts
+++ b/tests/e2e/runtime-controller-lifecycle.spec.ts
@@ -117,9 +117,6 @@ class FakeElement extends FakeTarget {
   querySelectorAll(selector: string): FakeElement[] {
     const descendants = this.children.flatMap((child) => [child, ...child.querySelectorAll("*")]);
     if (selector === "*") return descendants;
-    if (selector === ".branch-pill") {
-      return descendants.filter((child) => child.className.split(/\s+/).includes("branch-pill"));
-    }
     return [];
   }
 
@@ -378,14 +375,14 @@ test.describe("runtime controller module contracts", () => {
   test("tree controller lifecycle은 branch UI와 search listener를 소유한다", () => {
     const documentRef = createFakeDocument();
     const windowRef = createFakeWindow();
-    const pills = documentRef.register("sidebar-branch-pills");
-    const branchInfo = documentRef.register("sidebar-branch-info");
+    const branchSelect = documentRef.register("sidebar-branch-select");
     documentRef.register("tree-root");
     const search = documentRef.register("tree-search-input");
     documentRef.register("tree-search-clear");
     documentRef.register("tree-search-prev");
     documentRef.register("tree-search-next");
     documentRef.register("tree-search-count");
+    const searchActions = documentRef.register("sidebar-search-actions");
     const navigation = {
       activeBranch: "dev",
       availableBranches: ["dev", "main"],
@@ -417,14 +414,19 @@ test.describe("runtime controller module contracts", () => {
 
     controller.setup();
     controller.setup();
-    expect(pills.children).toHaveLength(2);
-    expect(pills.listenerCount("click")).toBe(1);
+    expect(branchSelect.children).toHaveLength(2);
+    expect(branchSelect.children.map((option) => option.textContent)).toEqual([
+      "dev (default)",
+      "main",
+    ]);
+    expect(branchSelect.value).toBe("dev");
+    expect(branchSelect.listenerCount("change")).toBe(1);
     expect(search.listenerCount("input")).toBe(1);
-    expect(branchInfo.textContent).toContain("dev + unclassified");
+    expect(searchActions.hidden).toBe(true);
 
     controller.destroy();
     controller.destroy();
-    expect(pills.listenerCount("click")).toBe(0);
+    expect(branchSelect.listenerCount("change")).toBe(0);
     expect(search.listenerCount("input")).toBe(0);
   });
 

--- a/tests/e2e/sidebar-chrome.spec.ts
+++ b/tests/e2e/sidebar-chrome.spec.ts
@@ -1,0 +1,68 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
+import { getInitialManifest } from "./utils/manifest";
+
+test.describe("purposeful sidebar chrome", () => {
+  test("uses one keyboard-accessible branch control and removes static status chrome", async ({
+    page,
+  }) => {
+    await page.goto("/BC-VO-00/");
+    await waitForAppReady(page);
+    await waitForTreeReady(page);
+    const manifest = await getInitialManifest(page);
+
+    const branchSelect = page.getByRole("combobox", { name: "Branch" });
+    await expect(branchSelect).toBeVisible();
+    await expect(branchSelect).toHaveValue(manifest.defaultBranch);
+    await expect(branchSelect.locator("option")).toHaveCount(2);
+    await expect(branchSelect.locator("option").first()).toContainText("(default)");
+
+    for (const removedChrome of [
+      ".icon-terminal",
+      ".branch-badge",
+      ".branch-pill",
+      ".status-online",
+      ".status-encoding",
+      ".sidebar-footer",
+    ]) {
+      await expect(page.locator(removedChrome)).toHaveCount(0);
+    }
+
+    await branchSelect.focus();
+    await branchSelect.press("End");
+    await expect(branchSelect).toHaveValue("main");
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("fsblog.branch")))
+      .toBe("main");
+
+    await branchSelect.focus();
+    await branchSelect.press("Home");
+    await expect(branchSelect).toHaveValue(manifest.defaultBranch);
+    await expect
+      .poll(() => page.evaluate(() => localStorage.getItem("fsblog.branch")))
+      .toBe(manifest.defaultBranch);
+  });
+
+  test("keeps purposeful search, prefix, and settings affordances available", async ({ page }) => {
+    await page.goto("/BC-VO-00/");
+    await waitForAppReady(page);
+    await waitForTreeReady(page);
+
+    const searchActions = page.locator("#sidebar-search-actions");
+    await expect(searchActions).toBeHidden();
+    await page.locator("#tree-search-input").fill("About");
+    await expect(searchActions).toBeVisible();
+    await expect(page.locator("#tree-search-count")).toContainText("개 일치");
+
+    const prefix = page.locator("#tree-root .tree-item-prefix").first();
+    await expect(prefix).toBeVisible();
+    await expect(page.locator("#tree-root .tree-item-prefix-badge")).toHaveCount(0);
+
+    const settingsToggle = page.getByRole("button", { name: "탐색기 설정 열기" });
+    await expect(settingsToggle).toBeVisible();
+    await settingsToggle.click();
+    await expect(page.locator("#sidebar-settings")).toBeVisible();
+    await page.locator("#settings-close").click();
+    await expect(page.locator("#sidebar-settings")).toBeHidden();
+  });
+});


### PR DESCRIPTION
## Summary

- replace branch badges and pills with one labeled native branch selector
- remove decorative terminal, publish, Online, and UTF-8 chrome while retaining settings
- reclaim tree-label width with tighter spacing, hidden generic file icons, and inline prefixes
- preserve mobile focus containment and conditionally show search controls

## DnD checklist

- [x] Every persistent element has a documented user-facing purpose
- [x] Branch selection is discoverable and keyboard accessible
- [x] Static/non-meaningful status indicators are removed
- [x] Document labels gain horizontal space
- [x] Branch and settings controls remain available
- [x] Desktop and mobile screenshots were visually reviewed
- [x] Focus, lifecycle, responsive, prefix, and icon regressions are covered

## Validation

- `npm run typecheck`
- `npm run lint:js`
- `npm run format:check`
- `npm run lint:md:publish`
- `npm run test:unit` (79 passed)
- affected E2E specs (16 passed)
- mobile focus trap repeated 5 times (5 passed)
- full E2E suite (96 passed)
- production build and size budget
  - app: 42,124 B raw / 14,693 B gzip
  - tree: 210,836 B raw / 58,557 B gzip
  - CSS: 28,839 B raw / 6,111 B gzip
  - total JS: 252,960 B raw / 73,250 B gzip
- reproducibility check (18 files; stable digest `94d871e460ef`)

Part of #37. Detailed acceptance criteria: #38.
