### PR TITLE
feat: replace icon font with local SVG sprite

### DIFF
--- a/README.md
+++ b/README.md
@@ -497,6 +497,8 @@ Main behaviors:
 
 - searchable sidebar tree rendered by the exact-pinned vanilla `@pierre/trees`
   runtime with a five-symbol generic icon sprite
+- shell and code-block icons rendered from a local inline SVG sprite, without
+  Google Fonts or font ligatures
 - tree dependency loading deferred until after the first content paint on
   desktop, and until sidebar/search interaction on compact layouts
 - `Recent` virtual folder

--- a/docs/solutions/20260719-local-svg-icon-system.md
+++ b/docs/solutions/20260719-local-svg-icon-system.md
@@ -12,6 +12,10 @@ bundle's shared view renderer from embedding a second copy of every SVG path.
 The existing deferred file tree keeps its own five-symbol sprite because it is
 loaded and rendered inside the tree component's shadow root.
 
+The content hash includes a renderer version salt. The SVG migration bumps that
+version so an incremental build upgrades cached code-block fragments instead of
+reusing the former font-ligature markup beside the new CSS and copy controller.
+
 ## Accessibility contract
 
 - Every app icon is decorative and carries `aria-hidden="true"` and
@@ -49,4 +53,5 @@ Unit coverage fixes the symbol inventory and budgets the sprite at 3,700 raw /
 750 gzip bytes. Browser coverage disables JavaScript, verifies a non-zero icon
 box, rejects Google Fonts requests and ligature text, validates decorative SVG
 semantics, checks accessible names for interactive controls, and exercises the
-copy-to-check feedback state.
+copy-to-check feedback state. A build regression seeds a legacy content hash
+and fragment, then verifies that the renderer version forces a clean upgrade.

--- a/docs/solutions/20260719-local-svg-icon-system.md
+++ b/docs/solutions/20260719-local-svg-icon-system.md
@@ -1,0 +1,52 @@
+# Local SVG icon system
+
+## Decision
+
+The generated shell, shared view chrome, 404 page, and rendered code blocks use
+one inline SVG sprite with 14 purpose-specific symbols. Each visible icon is a
+small `<svg><use href="#eiam-icon-*">` reference, so icons are available in the
+server-rendered HTML before the application JavaScript runs.
+
+The sprite data lives separately from the icon renderer. This keeps the browser
+bundle's shared view renderer from embedding a second copy of every SVG path.
+The existing deferred file tree keeps its own five-symbol sprite because it is
+loaded and rendered inside the tree component's shadow root.
+
+## Accessibility contract
+
+- Every app icon is decorative and carries `aria-hidden="true"` and
+  `focusable="false"`.
+- Icon-only buttons retain an `aria-label`; controls with visible text keep that
+  text as their accessible name.
+- The code-copy button changes both its SVG reference and accessible label from
+  `Copy code` to `Copied`, then restores both after the feedback interval.
+- The icon sprite precedes all `<use>` elements in the body and needs neither a
+  font ligature nor JavaScript to render.
+
+## Payload comparison
+
+Measured on 2026-07-19 with the stylesheet URL previously emitted by EIAM and a
+Chrome user agent:
+
+| Payload                                      | Raw response bytes | Gzip/encoded bytes |
+| -------------------------------------------- | -----------------: | -----------------: |
+| Google Material Symbols stylesheet           |                688 |                  — |
+| Google Material Symbols variable WOFF2       |          1,125,924 |          1,125,924 |
+| Previous external total                      |          1,126,612 |                  — |
+| EIAM 14-symbol inline sprite                  |              3,331 |                626 |
+
+The local sprite is 99.7% smaller than the previous external response bodies
+even without HTML compression (99.94% smaller when comparing the sprite's gzip
+size). It also removes two third-party origins, their preconnects, the async
+stylesheet request, the font request, and icon-font flash. Repeated `<use>`
+markup remains part of each route HTML, while the former font could be cached
+between pages; the comparison therefore records both the standalone sprite and
+network-request tradeoff rather than treating caching as free transfer.
+
+## Regression coverage
+
+Unit coverage fixes the symbol inventory and budgets the sprite at 3,700 raw /
+750 gzip bytes. Browser coverage disables JavaScript, verifies a non-zero icon
+box, rejects Google Fonts requests and ligature text, validates decorative SVG
+semantics, checks accessible names for interactive controls, and exercises the
+copy-to-check feedback state.

--- a/src/build/content.ts
+++ b/src/build/content.ts
@@ -6,6 +6,9 @@ import type { OutputWriteContext, RenderDocumentsResult, WikiLookup } from "./co
 import { buildWikiResolutionSignature, createWikiResolver } from "./source";
 import { toContentFileName } from "./shared";
 
+// Bump whenever renderer-owned HTML changes in a way that is incompatible with cached fragments.
+export const CONTENT_RENDERER_VERSION = "content-html-v2";
+
 export async function renderDocuments(
   docs: DocRecord[],
   options: BuildOptions,
@@ -23,6 +26,7 @@ export async function renderDocuments(
     const wikiSignature = options.wikilinks ? buildWikiResolutionSignature(doc, wikiLookup) : "";
     const sourceHash = makeHash(
       [
+        CONTENT_RENDERER_VERSION,
         doc.rawHash,
         doc.route,
         options.shikiTheme,

--- a/src/icon-sprite.ts
+++ b/src/icon-sprite.ts
@@ -1,0 +1,46 @@
+export function renderAppIconSprite(): string {
+  return `<svg class="app-icon-sprite" data-app-icon-sprite aria-hidden="true" focusable="false" width="0" height="0">
+  <symbol id="eiam-icon-arrow-left" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m15 18-6-6 6-6"></path><path d="M9 12h10"></path>
+  </symbol>
+  <symbol id="eiam-icon-arrow-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m9 18 6-6-6-6"></path><path d="M5 12h10"></path>
+  </symbol>
+  <symbol id="eiam-icon-calendar" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="3" y="5" width="18" height="16" rx="2"></rect><path d="M16 3v4M8 3v4M3 10h18"></path>
+  </symbol>
+  <symbol id="eiam-icon-check" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m5 12 4 4L19 6"></path>
+  </symbol>
+  <symbol id="eiam-icon-chevron-down" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m6 9 6 6 6-6"></path>
+  </symbol>
+  <symbol id="eiam-icon-chevron-right" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m9 18 6-6-6-6"></path>
+  </symbol>
+  <symbol id="eiam-icon-chevron-up" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m6 15 6-6 6 6"></path>
+  </symbol>
+  <symbol id="eiam-icon-close" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <path d="M6 6 18 18M18 6 6 18"></path>
+  </symbol>
+  <symbol id="eiam-icon-copy" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <rect x="8" y="8" width="12" height="12" rx="2"></rect><path d="M16 8V6a2 2 0 0 0-2-2H6a2 2 0 0 0-2 2v8a2 2 0 0 0 2 2h2"></path>
+  </symbol>
+  <symbol id="eiam-icon-folder-off" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M3 7.5V18a2 2 0 0 0 2 2h13.5M3.5 5.5A2 2 0 0 1 5 5h5l2 2h7a2 2 0 0 1 2 2v8.5M3 3l18 18"></path>
+  </symbol>
+  <symbol id="eiam-icon-home" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="m3 11 9-8 9 8"></path><path d="M5 10v10h14V10M9 20v-6h6v6"></path>
+  </symbol>
+  <symbol id="eiam-icon-menu" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <path d="M4 7h16M4 12h16M4 17h16"></path>
+  </symbol>
+  <symbol id="eiam-icon-search" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round">
+    <circle cx="11" cy="11" r="7"></circle><path d="m16 16 4 4"></path>
+  </symbol>
+  <symbol id="eiam-icon-settings" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round">
+    <path d="M4 7h6M14 7h6M4 17h10M18 17h2"></path><circle cx="12" cy="7" r="2"></circle><circle cx="16" cy="17" r="2"></circle>
+  </symbol>
+</svg>`;
+}

--- a/src/icons.ts
+++ b/src/icons.ts
@@ -1,0 +1,23 @@
+export const APP_ICON_NAMES = [
+  "arrow-left",
+  "arrow-right",
+  "calendar",
+  "check",
+  "chevron-down",
+  "chevron-right",
+  "chevron-up",
+  "close",
+  "copy",
+  "folder-off",
+  "home",
+  "menu",
+  "search",
+  "settings",
+] as const;
+
+export type AppIconName = (typeof APP_ICON_NAMES)[number];
+
+export function renderAppIcon(name: AppIconName, className = ""): string {
+  const classes = className ? `app-icon ${className}` : "app-icon";
+  return `<svg class="${classes}" aria-hidden="true" focusable="false"><use href="#eiam-icon-${name}"></use></svg>`;
+}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -8,6 +8,7 @@ import jsonLanguage from "@shikijs/langs/json";
 import markdownLanguage from "@shikijs/langs/markdown";
 import typescriptLanguage from "@shikijs/langs/typescript";
 import githubDarkTheme from "@shikijs/themes/github-dark";
+import { APP_ICON_NAMES, renderAppIcon } from "./icons";
 import type { BuildOptions, WikiResolver } from "./types";
 import { isRemoteUrl } from "./utils";
 
@@ -37,6 +38,7 @@ const DEFAULT_SHIKI_LANGUAGES: LanguageInput[] = [
   javascriptLanguage,
 ];
 const SAFE_COLOR_VALUE = /^#[0-9a-f]{3,8}$/i;
+const SAFE_APP_ICON_HREFS = new Set(APP_ICON_NAMES.map((name) => `#eiam-icon-${name}`));
 const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
   allowedTags: [
     "p",
@@ -82,6 +84,8 @@ const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
     "dd",
     "abbr",
     "time",
+    "svg",
+    "use",
   ],
   allowedAttributes: {
     "*": ["class"],
@@ -94,9 +98,11 @@ const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
     ol: ["start"],
     pre: ["tabindex", "style"],
     span: ["style"],
+    svg: ["aria-hidden", "focusable"],
     td: ["colspan", "rowspan"],
     th: ["colspan", "rowspan", "scope"],
     time: ["datetime"],
+    use: ["href"],
   },
   allowedStyles: {
     pre: {
@@ -115,6 +121,9 @@ const SAFE_HTML_OPTIONS: sanitizeHtml.IOptions = {
   allowProtocolRelative: false,
   disallowedTagsMode: "discard",
   enforceHtmlBoundary: false,
+  exclusiveFilter(frame) {
+    return frame.tag === "use" && !SAFE_APP_ICON_HREFS.has(frame.attribs.href ?? "");
+  },
   nestingLimit: 100,
   nonTextTags: ["script", "style", "textarea", "option", "noscript", "xmp"],
   transformTags: {
@@ -398,8 +407,8 @@ function createMarkdownIt(highlighter: HighlighterCore, theme: string, gfm: bool
         <span class="dot dot-green"></span>
       </div>
       <span class="code-filename">${fileName ? escapeHtmlAttr(fileName) : lang}</span>
-      <button class="code-copy" title="Copy code" data-code="${escapeHtmlAttr(token.content)}">
-        <span class="material-symbols-outlined">content_copy</span>
+      <button class="code-copy" type="button" title="Copy code" aria-label="Copy code" data-code="${escapeHtmlAttr(token.content)}">
+        ${renderAppIcon("copy")}
       </button>
     </div>`;
 

--- a/src/runtime/app.css
+++ b/src/runtime/app.css
@@ -191,26 +191,22 @@ a:hover {
   text-decoration: underline;
 }
 
-.material-symbols-outlined {
-  font-family: "Material Symbols Outlined", "Material Icons", sans-serif;
-  font-style: normal;
-  font-weight: 400;
-  letter-spacing: 0;
-  text-transform: none;
-  white-space: nowrap;
-  word-wrap: normal;
-  direction: ltr;
-  font-feature-settings: "liga";
-  -webkit-font-feature-settings: "liga";
+.app-icon-sprite {
+  position: absolute;
+  width: 0;
+  height: 0;
+  overflow: hidden;
+  pointer-events: none;
+}
+
+.app-icon {
   display: inline-flex;
-  align-items: center;
-  justify-content: center;
-  min-width: 1em;
-  min-height: 1em;
+  width: 1em;
+  height: 1em;
   flex: 0 0 auto;
   font-size: 20px;
-  line-height: 1;
   vertical-align: middle;
+  pointer-events: none;
 }
 
 /* Layout */
@@ -491,8 +487,8 @@ a:hover {
   opacity: 0.42;
 }
 
-.tree-search-clear .material-symbols-outlined,
-.tree-search-step .material-symbols-outlined {
+.tree-search-clear .app-icon,
+.tree-search-step .app-icon {
   font-size: 18px;
 }
 
@@ -642,7 +638,7 @@ a:hover {
   min-height: 0;
 }
 
-.settings-toggle .material-symbols-outlined {
+.settings-toggle .app-icon {
   font-size: 18px;
 }
 
@@ -789,7 +785,7 @@ a:hover {
   cursor: pointer;
 }
 
-.mobile-menu-toggle .material-symbols-outlined {
+.mobile-menu-toggle .app-icon {
   font-size: 20px;
 }
 
@@ -887,7 +883,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   gap: 4px;
 }
 
-.meta-item .material-symbols-outlined {
+.meta-item .app-icon {
   font-size: 16px;
   color: var(--color-text-subtle);
 }
@@ -903,7 +899,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   color: var(--color-code-accent);
 }
 
-.meta-tags .material-symbols-outlined {
+.meta-tags .app-icon {
   color: var(--color-code-accent);
 }
 
@@ -1088,7 +1084,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   background: rgba(240, 246, 252, 0.14);
 }
 
-.code-copy .material-symbols-outlined {
+.code-copy .app-icon {
   font-size: 16px;
 }
 
@@ -1482,7 +1478,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   color: var(--color-text);
 }
 
-.not-found-icon .material-symbols-outlined {
+.not-found-icon .app-icon {
   font-size: 64px;
   color: var(--color-text-subtle);
 }
@@ -1518,7 +1514,7 @@ body.mobile-toggle-left .mobile-menu-toggle {
   text-decoration: none;
 }
 
-.not-found-link .material-symbols-outlined {
+.not-found-link .app-icon {
   font-size: 18px;
 }
 

--- a/src/runtime/content-enhancement-controller.js
+++ b/src/runtime/content-enhancement-controller.js
@@ -240,16 +240,20 @@ export function createContentEnhancementController(options) {
       }
       await clipboard.writeText(code);
       button.classList.add("copied");
-      const icon = button.querySelector(".material-symbols-outlined");
-      if (icon instanceof windowRef.HTMLElement) {
-        icon.textContent = "check";
+      button.setAttribute("aria-label", "Copied");
+      button.setAttribute("title", "Copied");
+      const iconUse = button.querySelector(".app-icon use");
+      if (iconUse instanceof windowRef.Element) {
+        iconUse.setAttribute("href", "#eiam-icon-check");
       }
       const timer = windowRef.setTimeout(() => {
         resetTimers.delete(timer);
         button.classList.remove("copied");
-        const nextIcon = button.querySelector(".material-symbols-outlined");
-        if (nextIcon instanceof windowRef.HTMLElement) {
-          nextIcon.textContent = "content_copy";
+        button.setAttribute("aria-label", "Copy code");
+        button.setAttribute("title", "Copy code");
+        const nextIconUse = button.querySelector(".app-icon use");
+        if (nextIconUse instanceof windowRef.Element) {
+          nextIconUse.setAttribute("href", "#eiam-icon-copy");
         }
       }, 2000);
       resetTimers.add(timer);

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,5 +1,7 @@
 import { escapeHtmlAttribute } from "./seo";
 import { DEFAULT_SITE_TITLE } from "./defaults";
+import { renderAppIconSprite } from "./icon-sprite";
+import { renderAppIcon } from "./icons";
 import type { Manifest } from "./types";
 import { toViewPathWithBase } from "./view-contract";
 
@@ -213,8 +215,6 @@ export function renderAppShellHtml(
   const headMeta = renderHeadMeta(meta);
   const initialViewScript = renderInitialViewScript(initialView);
   const runtimeBootstrapScript = renderRuntimeBootstrapScript(manifest, assets);
-  const symbolFontStylesheet =
-    "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
   const appTitle =
     typeof manifest?.siteTitle === "string" && manifest.siteTitle.trim().length > 0
       ? manifest.siteTitle.trim()
@@ -234,14 +234,10 @@ export function renderAppShellHtml(
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
 ${headMeta}
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" as="style" href="${escapeHtmlAttribute(symbolFontStylesheet)}" />
-    <link rel="stylesheet" href="${escapeHtmlAttribute(symbolFontStylesheet)}" media="print" onload="this.media='all'" />
-    <noscript><link rel="stylesheet" href="${escapeHtmlAttribute(symbolFontStylesheet)}" /></noscript>
     <link rel="stylesheet" href="${escapeHtmlAttribute(assets.cssHref)}" />
   </head>
   <body>
+    ${renderAppIconSprite()}
     <a class="skip-link" href="#viewer-panel">본문으로 건너뛰기</a>
     <div id="a11y-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
     <div class="app-root">
@@ -251,7 +247,7 @@ ${headMeta}
           <div class="sidebar-heading">
             <h1 class="sidebar-title">${escapeHtmlAttribute(appTitle)}</h1>
             <button id="sidebar-close" class="sidebar-close" type="button" aria-label="탐색기 닫기">
-              <span class="material-symbols-outlined">close</span>
+              ${renderAppIcon("close")}
             </button>
           </div>
           <label class="sidebar-branch" for="sidebar-branch-select">
@@ -261,7 +257,7 @@ ${headMeta}
         </div>
         <div class="sidebar-search">
           <div class="sidebar-search-box">
-            <span class="material-symbols-outlined sidebar-search-icon" aria-hidden="true">search</span>
+            ${renderAppIcon("search", "sidebar-search-icon")}
             <input
               id="tree-search-input"
               class="tree-search-input"
@@ -272,17 +268,17 @@ ${headMeta}
               placeholder="Search"
             />
             <button id="tree-search-clear" class="tree-search-clear" type="button" aria-label="검색 지우기" title="검색 지우기" hidden>
-              <span class="material-symbols-outlined">close</span>
+              ${renderAppIcon("close")}
             </button>
           </div>
           <div id="sidebar-search-actions" class="sidebar-search-actions" aria-live="polite" hidden>
             <span id="tree-search-count" class="tree-search-count"></span>
             <div class="tree-search-nav">
               <button id="tree-search-prev" class="tree-search-step" type="button" aria-label="이전 검색 결과" title="이전 검색 결과" disabled>
-                <span class="material-symbols-outlined">keyboard_arrow_up</span>
+                ${renderAppIcon("chevron-up")}
               </button>
               <button id="tree-search-next" class="tree-search-step" type="button" aria-label="다음 검색 결과" title="다음 검색 결과" disabled>
-                <span class="material-symbols-outlined">keyboard_arrow_down</span>
+                ${renderAppIcon("chevron-down")}
               </button>
             </div>
           </div>
@@ -297,7 +293,7 @@ ${headMeta}
             aria-expanded="false"
             aria-label="탐색기 설정 열기"
           >
-            <span class="material-symbols-outlined">tune</span>
+            ${renderAppIcon("settings")}
           </button>
           <section id="sidebar-settings" class="sidebar-settings" hidden aria-label="탐색기 설정">
             <p class="sidebar-settings-title">탐색기 설정</p>
@@ -351,7 +347,7 @@ ${headMeta}
           aria-expanded="false"
           aria-label="탐색기 열기"
         >
-          <span class="material-symbols-outlined">menu</span>
+          ${renderAppIcon("menu")}
           <span>Files</span>
         </button>
         <div class="viewer-container">
@@ -380,31 +376,24 @@ export function render404Html(
   homeHref = "/",
   siteTitle = DEFAULT_SITE_TITLE,
 ): string {
-  const symbolFontStylesheet =
-    "https://fonts.googleapis.com/css2?family=Material+Symbols+Outlined:wght,FILL@100..700,0..1&display=swap";
-
   return `<!doctype html>
 <html lang="ko">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
     <title>404 - ${escapeHtmlAttribute(siteTitle.trim() || DEFAULT_SITE_TITLE)}</title>
-    <link rel="preconnect" href="https://fonts.googleapis.com" />
-    <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin />
-    <link rel="preload" as="style" href="${escapeHtmlAttribute(symbolFontStylesheet)}" />
-    <link rel="stylesheet" href="${escapeHtmlAttribute(symbolFontStylesheet)}" media="print" onload="this.media='all'" />
-    <noscript><link rel="stylesheet" href="${escapeHtmlAttribute(symbolFontStylesheet)}" /></noscript>
     <link rel="stylesheet" href="${escapeHtmlAttribute(assets.cssHref)}" />
   </head>
   <body>
+    ${renderAppIconSprite()}
     <main class="not-found">
       <div class="not-found-icon">
-        <span class="material-symbols-outlined">folder_off</span>
+        ${renderAppIcon("folder-off")}
       </div>
       <h1>404</h1>
       <p>요청한 문서를 찾을 수 없습니다.</p>
       <a href="${escapeHtmlAttribute(homeHref)}" class="not-found-link">
-        <span class="material-symbols-outlined">home</span>
+        ${renderAppIcon("home")}
         홈으로 이동
       </a>
     </main>

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_BRANCH, DEFAULT_SITE_TITLE } from "./defaults";
+import { renderAppIcon } from "./icons";
 
 export interface ViewBacklinkContract {
   route?: unknown;
@@ -280,7 +281,7 @@ function renderBreadcrumb(model: ViewChromeModel["breadcrumb"]): string {
         ? `<span class="breadcrumb-current" aria-current="page">${escapeViewText(item.label)}</span>`
         : `<span class="breadcrumb-item">${escapeViewText(item.label)}</span>`,
     )
-    .join('<span class="material-symbols-outlined breadcrumb-sep">chevron_right</span>');
+    .join(renderAppIcon("chevron-right", "breadcrumb-sep"));
 }
 
 export function renderViewBreadcrumb(route: unknown): string {
@@ -294,7 +295,7 @@ function renderMeta(model: ViewChromeModel["meta"]): string {
   }
   if (model.createdAt) {
     items.push(
-      `<span class="meta-item"><span class="material-symbols-outlined">calendar_today</span>${escapeViewText(model.createdAt)}</span>`,
+      `<span class="meta-item">${renderAppIcon("calendar")}${escapeViewText(model.createdAt)}</span>`,
     );
   }
   if (model.tags.length > 0) {
@@ -306,9 +307,9 @@ function renderMeta(model: ViewChromeModel["meta"]): string {
 
 function renderNavLink(link: ViewLinkModel, direction: "previous" | "next"): string {
   if (direction === "previous") {
-    return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label"><span class="material-symbols-outlined">arrow_back</span>Previous</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
+    return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">${renderAppIcon("arrow-left")}Previous</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
   }
-  return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">Next<span class="material-symbols-outlined">arrow_forward</span></div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
+  return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">Next${renderAppIcon("arrow-right")}</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
 }
 
 function renderNavigation(model: ViewChromeModel["navigation"]): string {

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -4,6 +4,7 @@ import fs from "node:fs";
 import os from "node:os";
 import path from "node:path";
 import { expect, test } from "@playwright/test";
+import { CONTENT_RENDERER_VERSION } from "../../src/build/content";
 
 interface CliResult {
   status: number | null;
@@ -316,6 +317,95 @@ ALPHA
       expect(afterConfig["manifest.json"]).not.toBe(afterContent["manifest.json"]);
       expect(afterConfig["index.html"]).not.toBe(afterContent["index.html"]);
       expect(afterConfig[contentPath!]).toBe(afterContent[contentPath!]);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("content renderer version은 기존 Markdown fragment cache를 무효화한다", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-content-renderer-version-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const sourcePath = path.join(vaultDir, "icon-cache.md");
+
+    try {
+      writeText(
+        sourcePath,
+        `---
+publish: true
+prefix: CACHE-ICON
+category_path: cache/icons
+title: Cached icon markup
+---
+
+\`\`\`text
+cached code
+\`\`\`
+`,
+      );
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+
+      const manifest = readManifest(outDir) as ManifestDocIndex<{
+        route: string;
+        contentUrl: string;
+      }>;
+      const docId = manifest.docIds[0];
+      const contentRelPath = manifest.docsById[docId].contentUrl.replace(/^\/+/, "");
+      const contentPath = path.join(outDir, contentRelPath);
+      const cachePath = findOnlyCacheIndexPath(workDir);
+      const cache = JSON.parse(fs.readFileSync(cachePath, "utf8")) as {
+        sources: Record<string, { rawHash: string }>;
+        docs: Record<string, { hash: string; route: string; relPath: string }>;
+        outputHashes: Record<string, string>;
+      };
+      const sourceHashInputs = [
+        cache.sources["icon-cache.md"].rawHash,
+        "/CACHE-ICON/",
+        "github-dark",
+        "omit-local",
+        "wikilinks-on",
+        "safe-html-v1",
+        "",
+      ];
+      const legacyHash = crypto
+        .createHash("sha1")
+        .update(sourceHashInputs.join("::"))
+        .digest("hex");
+      const versionedHash = crypto
+        .createHash("sha1")
+        .update([CONTENT_RENDERER_VERSION, ...sourceHashInputs].join("::"))
+        .digest("hex");
+
+      expect(cache.docs[docId].hash).toBe(versionedHash);
+      expect(versionedHash).not.toBe(legacyHash);
+
+      cache.docs[docId].hash = legacyHash;
+      cache.outputHashes[contentRelPath] = legacyHash;
+      fs.writeFileSync(cachePath, `${JSON.stringify(cache, null, 2)}\n`, "utf8");
+      writeText(
+        contentPath,
+        '<div class="code-block"><button class="code-copy"><span class="material-symbols-outlined">content_copy</span></button></div>',
+      );
+
+      const upgradedBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+      ]);
+      expect(upgradedBuild.status, upgradedBuild.output).toBe(0);
+      expect(upgradedBuild.output).toContain("total=1 rendered=1 skipped=0");
+      const upgradedContent = fs.readFileSync(contentPath, "utf8");
+      const upgradedRoute = fs.readFileSync(path.join(outDir, "CACHE-ICON", "index.html"), "utf8");
+      for (const rendered of [upgradedContent, upgradedRoute]) {
+        expect(rendered).toContain('href="#eiam-icon-copy"');
+        expect(rendered).not.toContain("material-symbols-outlined");
+        expect(rendered).not.toContain("content_copy");
+      }
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/e2e/local-icon-system.spec.ts
+++ b/tests/e2e/local-icon-system.spec.ts
@@ -1,0 +1,109 @@
+import { expect, test } from "@playwright/test";
+import { waitForAppReady } from "./utils/app-ready";
+
+test.describe("local SVG icon system", () => {
+  test("renders SSR icons without JavaScript or third-party font requests", async ({
+    baseURL,
+    browser,
+  }) => {
+    if (!baseURL) {
+      throw new Error("Playwright baseURL is required");
+    }
+
+    const context = await browser.newContext({ javaScriptEnabled: false });
+    const page = await context.newPage();
+    const externalIconRequests: string[] = [];
+    page.on("request", (request) => {
+      const hostname = new URL(request.url()).hostname;
+      if (hostname === "fonts.googleapis.com" || hostname === "fonts.gstatic.com") {
+        externalIconRequests.push(request.url());
+      }
+    });
+
+    try {
+      await page.goto(`${baseURL}/BC-VO-02/`);
+
+      const searchIcon = page.locator(".sidebar-search-icon");
+      await expect(searchIcon).toBeVisible();
+      const bounds = await searchIcon.boundingBox();
+      expect(bounds?.width ?? 0).toBeGreaterThan(0);
+      expect(bounds?.height ?? 0).toBeGreaterThan(0);
+      await expect(page.locator(".material-symbols-outlined")).toHaveCount(0);
+
+      const state = await page.evaluate(() => {
+        const sprite = document.querySelector("[data-app-icon-sprite]");
+        const icons = Array.from(document.querySelectorAll("svg.app-icon"));
+        return {
+          iconCount: icons.length,
+          hiddenFromAssistiveTechnology: icons.every(
+            (icon) =>
+              icon.getAttribute("aria-hidden") === "true" &&
+              icon.getAttribute("focusable") === "false",
+          ),
+          localReferencesOnly: icons.every((icon) =>
+            icon.querySelector("use")?.getAttribute("href")?.startsWith("#eiam-icon-"),
+          ),
+          spriteBeforeFirstIcon:
+            sprite instanceof SVGElement &&
+            icons[0] instanceof SVGElement &&
+            Boolean(sprite.compareDocumentPosition(icons[0]) & Node.DOCUMENT_POSITION_FOLLOWING),
+          hasLigatureText: icons.some((icon) => (icon.textContent ?? "").trim().length > 0),
+        };
+      });
+
+      expect(state.iconCount).toBeGreaterThan(0);
+      expect(state.hiddenFromAssistiveTechnology).toBe(true);
+      expect(state.localReferencesOnly).toBe(true);
+      expect(state.spriteBeforeFirstIcon).toBe(true);
+      expect(state.hasLigatureText).toBe(false);
+      expect(externalIconRequests).toEqual([]);
+    } finally {
+      await context.close();
+    }
+  });
+
+  test("keeps icon controls named and exposes copy feedback without ligatures", async ({
+    baseURL,
+    context,
+    page,
+  }) => {
+    if (!baseURL) {
+      throw new Error("Playwright baseURL is required");
+    }
+
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(baseURL).origin,
+    });
+    await page.goto("/BC-VO-02/");
+    await waitForAppReady(page);
+
+    const iconControls = page.locator("button:has(svg.app-icon), a:has(svg.app-icon)");
+    const controlCount = await iconControls.count();
+    expect(controlCount).toBeGreaterThan(0);
+    const unnamedControls = await iconControls.evaluateAll((controls) =>
+      controls
+        .filter((control) => {
+          const explicitName = control.getAttribute("aria-label")?.trim() ?? "";
+          const visibleText = (control.textContent ?? "").trim();
+          return explicitName.length === 0 && visibleText.length === 0;
+        })
+        .map((control) => control.outerHTML),
+    );
+    expect(unnamedControls).toEqual([]);
+
+    const visibleIconControls = page.locator(
+      "button:has(svg.app-icon):visible, a:has(svg.app-icon):visible",
+    );
+    for (let index = 0; index < (await visibleIconControls.count()); index += 1) {
+      await expect(visibleIconControls.nth(index)).toHaveAccessibleName(/.+/);
+    }
+
+    const copyButton = page.locator(".code-copy").first();
+    await expect(copyButton).toHaveAccessibleName("Copy code");
+    await expect(copyButton.locator("use")).toHaveAttribute("href", "#eiam-icon-copy");
+    await copyButton.click();
+    await expect(copyButton).toHaveAccessibleName("Copied");
+    await expect(copyButton.locator("use")).toHaveAttribute("href", "#eiam-icon-check");
+    await expect(copyButton).toHaveClass(/copied/);
+  });
+});

--- a/tests/unit/icons.test.ts
+++ b/tests/unit/icons.test.ts
@@ -1,0 +1,33 @@
+import { gzipSync } from "node:zlib";
+import { describe, expect, test } from "bun:test";
+import { renderAppIconSprite } from "../../src/icon-sprite";
+import { APP_ICON_NAMES, renderAppIcon } from "../../src/icons";
+import { render404Html, renderAppShellHtml } from "../../src/template";
+
+describe("local app icon system", () => {
+  test("ships one bounded symbol for every supported icon", () => {
+    const sprite = renderAppIconSprite();
+    const symbolIds = Array.from(sprite.matchAll(/<symbol id="([^"]+)"/g), (match) => match[1]);
+
+    expect(symbolIds).toEqual(APP_ICON_NAMES.map((name) => `eiam-icon-${name}`));
+    expect(Buffer.byteLength(sprite)).toBeLessThanOrEqual(3_700);
+    expect(gzipSync(sprite).byteLength).toBeLessThanOrEqual(750);
+
+    for (const name of APP_ICON_NAMES) {
+      expect(renderAppIcon(name)).toBe(
+        `<svg class="app-icon" aria-hidden="true" focusable="false"><use href="#eiam-icon-${name}"></use></svg>`,
+      );
+    }
+  });
+
+  test("generated shells contain the sprite before use and no icon-font dependency", () => {
+    for (const html of [renderAppShellHtml(), render404Html()]) {
+      expect(html).toContain("data-app-icon-sprite");
+      expect(html.indexOf("data-app-icon-sprite")).toBeLessThan(html.indexOf('app-icon"'));
+      expect(html).not.toContain("fonts.googleapis.com");
+      expect(html).not.toContain("fonts.gstatic.com");
+      expect(html).not.toContain("Material Symbols");
+      expect(html).not.toContain("material-symbols-outlined");
+    }
+  });
+});

--- a/tests/unit/sanitization.test.ts
+++ b/tests/unit/sanitization.test.ts
@@ -25,4 +25,14 @@ describe("rendered Markdown sanitization", () => {
     const authored = '<span onclick="trusted()">trusted vault</span>';
     expect(sanitizeMarkdownHtml(authored, true)).toBe(authored);
   });
+
+  test("keeps only local application icon references", () => {
+    const safeIcon =
+      '<svg class="app-icon" aria-hidden="true" focusable="false"><use href="#eiam-icon-copy"></use></svg>';
+    const unsafeIcons =
+      '<svg class="app-icon"><use href="https://example.test/icons.svg#copy"></use><use href="#unknown-icon"></use></svg>';
+
+    expect(sanitizeMarkdownHtml(safeIcon)).toBe(safeIcon);
+    expect(sanitizeMarkdownHtml(unsafeIcons)).toBe('<svg class="app-icon"></svg>');
+  });
 });


### PR DESCRIPTION
## Summary

- replace Google Material Symbols loading with a 14-symbol inline SVG sprite
- render shell, shared view, 404, and code-copy icons before JavaScript without ligatures
- keep decorative SVGs out of the accessibility tree and preserve control names/copy feedback
- restrict sanitized Markdown SVG references to known local app symbols
- version the content-renderer hash so incremental upgrades replace cached ligature markup
- document measured payload and cache/network tradeoffs

## DnD checklist

- [x] Generated pages make no Google Fonts request for icons
- [x] Icons render before JavaScript and without font ligatures
- [x] Decorative icons are hidden from assistive technology
- [x] Interactive controls retain accessible names
- [x] Final payload is measured against the former font approach
- [x] Legacy rendered-content caches upgrade automatically
- [x] Desktop and 404 renders were visually reviewed

## Payload

- previous Google CSS + variable WOFF2 response bodies: 1,126,612 B
- local 14-symbol sprite: 3,331 B raw / 626 B gzip
- reduction: 99.7% raw (99.94% using sprite gzip size)

## Validation

- `bun run typecheck`
- `bun run lint:source`
- `bun run format:check`
- `bun run lint:md:publish`
- `bun run test:unit` (82 passed)
- affected icon/view/runtime E2E specs (29 passed)
- legacy content-cache upgrade regression (1 passed)
- `bun run test:e2e` (99 passed)
- production build and size budget
  - app: 42,258 B raw / 14,756 B gzip
  - tree: 210,836 B raw / 58,557 B gzip
  - CSS: 28,461 B raw / 6,034 B gzip
  - total JS: 253,094 B raw / 73,313 B gzip
- reproducibility check (19 files; stable digest `a3b109cd4ddc`)

Part of #37. Detailed acceptance criteria: #40.
