### PR TITLE
feat: make UI locale configurable

### DIFF
--- a/README.md
+++ b/README.md
@@ -219,7 +219,7 @@ Key points:
 
 CI enforces raw and gzip budgets for the generated runtime assets. After a
 sample build, run `bun run check:size` to apply the same limits locally. The
-critical app JavaScript is limited to 45,000 raw / 15,000 gzip bytes, the
+critical app JavaScript is limited to 50,000 raw / 17,000 gzip bytes, the
 deferred tree chunk to 220,000 raw / 60,000 gzip bytes, and their combined
 payload to 260,000 raw / 78,000 gzip bytes. CSS is limited to 31,000 raw /
 7,000 gzip bytes.
@@ -259,6 +259,7 @@ export default {
     categoryPath: "announcements",
   },
   ui: {
+    locale: "ko",
     newWithinDays: 7,
     recentLimit: 5,
   },
@@ -305,6 +306,9 @@ export default {
 - `pinnedMenu`: optional virtual folder shown above `Recent`.
 - `pinnedMenu.sourceDir`: optional legacy file-path prefix matcher.
 - `pinnedMenu.categoryPath`: optional category-path prefix matcher for the sidebar virtual folder.
+- `ui.locale`: built-in UI language and emitted HTML `lang`; supports `"ko"` (default) and
+  `"en"`. Unsupported config values fail validation. Runtime payloads or partial catalogs that
+  omit a supported translation fall back to Korean deterministically.
 - `ui.newWithinDays`: threshold for NEW badge.
 - `ui.recentLimit`: number of items in `Recent`.
 - `markdown.wikilinks`: enable or disable wikilink resolution.
@@ -314,6 +318,11 @@ export default {
 - `markdown.highlight.theme`: Shiki theme.
 - `markdown.mermaid.*`: Mermaid runtime settings.
 - `seo.*`: canonical URL, social metadata, sitemap, robots, and path-base behavior.
+
+`ui.locale` controls application copy and accessibility names. `seo.locale` remains an independent
+Open Graph locale such as `"en_US"`; setting one does not implicitly set the other. Published date
+labels use the fixed, locale-neutral `YYYY-MM-DD HH:mm` format in UTC so server-rendered and client
+rendered chrome remain byte-identical.
 
 Config modules are treated as untrusted runtime input. Every supported field is validated and
 normalized before `build`, `dev`, or `clean` can create, modify, or remove output/cache paths. An

--- a/docs/solutions/20260719-configurable-ui-locale.md
+++ b/docs/solutions/20260719-configurable-ui-locale.md
@@ -1,0 +1,55 @@
+# Configurable UI locale
+
+## Decision
+
+`ui.locale` accepts `"ko"` and `"en"`, with Korean as the backward-compatible
+default. The resolved locale is carried through build options and the manifest,
+sets `lang` on both application and 404 HTML, and selects one shared message
+catalog for server-rendered and client-rendered UI.
+
+The catalog owns built-in visible copy and accessibility names across the shell,
+view navigation, virtual `Recent` folder, Markdown fallbacks and code-copy control,
+tree loading states, navigation announcements, manifest errors, and Mermaid
+fallbacks. Content titles, branch names, and authored Markdown remain user data
+and are not translated.
+
+`seo.locale` stays independent because its Open Graph values commonly use forms
+such as `en_US`; it does not select interface copy or HTML language.
+
+## Fallback and cache contract
+
+Configuration rejects values outside the two supported locales. At runtime,
+legacy or malformed manifests fall back to Korean. Message resolution also
+merges a selected catalog over the complete Korean catalog, so a missing entry
+has a deterministic Korean result rather than an empty label or exception.
+
+Rendered Markdown contains locale-sensitive code-copy and omitted-image text.
+The content renderer version is therefore bumped and the locale is part of each
+content source hash. Switching locale invalidates cached fragments without
+requiring a clean build.
+
+## Date format
+
+Document metadata intentionally retains `YYYY-MM-DD HH:mm` in UTC. This fixed,
+locale-neutral representation keeps SSR and client navigation byte-identical and
+avoids output differences based on the builder or browser timezone.
+
+## Regression coverage
+
+Unit coverage checks complete Korean and English catalogs, pluralized English
+search counts, unknown-locale fallback, missing-entry fallback, config validation,
+and manifest migration. Browser coverage performs `en → ko → en` incremental
+builds, verifies localized content fragments and cache invalidation, then exercises
+English branch/search controls, copy feedback, client navigation, announcements,
+backlinks, and the JavaScript-independent 404 page.
+
+## Runtime payload
+
+On the standard five-document fixture, the critical application bundle moves
+from 42,258 raw / 14,756 gzip bytes to 48,086 raw / 16,616 gzip bytes. The
+5,828 raw / 1,860 gzip byte increase contains both complete catalogs and the
+shared fallback resolver; runtime assets stay identical between locale builds.
+The app-specific guardrail is adjusted to 50,000 raw / 17,000 gzip bytes while
+the stricter combined JavaScript budget remains unchanged at 260,000 raw /
+78,000 gzip bytes. The measured combined payload is 258,922 raw / 75,173 gzip
+bytes.

--- a/scripts/check-output-size.ts
+++ b/scripts/check-output-size.ts
@@ -24,7 +24,7 @@ interface SizeBudget {
 }
 
 const BUDGETS: Record<AssetKind, SizeBudget> = {
-  "app-js": { raw: 45_000, gzip: 15_000 },
+  "app-js": { raw: 50_000, gzip: 17_000 },
   "tree-js": { raw: 220_000, gzip: 60_000 },
   css: { raw: 31_000, gzip: 7_000 },
 };

--- a/src/build/content.ts
+++ b/src/build/content.ts
@@ -7,7 +7,7 @@ import { buildWikiResolutionSignature, createWikiResolver } from "./source";
 import { toContentFileName } from "./shared";
 
 // Bump whenever renderer-owned HTML changes in a way that is incompatible with cached fragments.
-export const CONTENT_RENDERER_VERSION = "content-html-v2";
+export const CONTENT_RENDERER_VERSION = "content-html-v3";
 
 export async function renderDocuments(
   docs: DocRecord[],
@@ -30,6 +30,7 @@ export async function renderDocuments(
         doc.rawHash,
         doc.route,
         options.shikiTheme,
+        options.locale,
         options.imagePolicy,
         options.wikilinks ? "wikilinks-on" : "wikilinks-off",
         options.allowUnsafeHtml ? "unsafe-html-v1" : "safe-html-v1",

--- a/src/build/graph.ts
+++ b/src/build/graph.ts
@@ -1,5 +1,6 @@
 import type { BuildOptions, DocRecord, FileNode, FolderNode, Manifest, TreeNode } from "../types";
 import { DEFAULT_BRANCH } from "../defaults";
+import { getUiMessages } from "../i18n";
 import { filterViewDocsByBranch, pickViewHomeRoute } from "../view-contract";
 import type { DocumentGraphResult, WikiLookup } from "./contracts";
 import { buildBacklinksByDocId, createWikiLookup } from "./source";
@@ -104,6 +105,7 @@ function buildPinnedMenuFolder(docs: DocRecord[], options: BuildOptions): Folder
 }
 
 function buildTree(docs: DocRecord[], options: BuildOptions): TreeNode[] {
+  const messages = getUiMessages(options.locale);
   const root: FolderNode = {
     type: "folder",
     name: "root",
@@ -148,7 +150,7 @@ function buildTree(docs: DocRecord[], options: BuildOptions): TreeNode[] {
 
   const recentFolder: FolderNode = {
     type: "folder",
-    name: "Recent",
+    name: messages.recentFolder,
     path: "__virtual__/recent",
     virtual: true,
     children: recentChildren,
@@ -217,6 +219,7 @@ function buildManifest(
     schemaVersion: 2,
     siteTitle: resolveSiteTitle(options),
     pathBase: options.seo?.pathBase ?? "",
+    locale: options.locale,
     defaultBranch: options.defaultBranch,
     mermaid: options.mermaid,
     layout: options.layout,

--- a/src/build/output.ts
+++ b/src/build/output.ts
@@ -467,6 +467,7 @@ function buildInitialView(
   manifestDocById: Map<string, Manifest["docsById"][string]>,
   pathBase: string,
   defaultBranch: string,
+  locale: BuildOptions["locale"],
 ): AppShellInitialView {
   const manifestDoc = manifestDocById.get(doc.id);
   const activeBranch =
@@ -477,6 +478,7 @@ function buildInitialView(
     doc: { ...doc, backlinks: manifestDoc?.backlinks ?? [] },
     docs: visibleDocs,
     pathBase,
+    locale,
   });
   return {
     route: doc.route,
@@ -514,6 +516,7 @@ async function writeShellPages(
         manifestDocById,
         pathBase,
         manifest.defaultBranch,
+        options.locale,
       )
     : null;
   const shell = renderAppShellHtml(
@@ -531,6 +534,7 @@ async function writeShellPages(
       buildAppShellAssetsForOutput("404.html", runtimeAssets),
       toViewPathWithBase("/", pathBase),
       resolveSiteTitle(options),
+      options.locale,
     ),
   );
 
@@ -543,6 +547,7 @@ async function writeShellPages(
       manifestDocById,
       pathBase,
       manifest.defaultBranch,
+      options.locale,
     );
     await writeOutputIfChanged(
       context,

--- a/src/config.ts
+++ b/src/config.ts
@@ -2,6 +2,7 @@ import path from "node:path";
 import { pathToFileURL } from "node:url";
 import { OUTPUT_MARKER_FILE_NAME } from "./build/shared";
 import { DEFAULT_RUNTIME_CONFIG } from "./defaults";
+import { SUPPORTED_UI_LOCALES, type UiLocale } from "./i18n";
 import { normalizeSeoConfig } from "./seo";
 import type { BuildOptions, PinnedMenuOption, UserConfig, UserSeoConfig } from "./types";
 
@@ -23,6 +24,7 @@ const DEFAULTS = {
   exclude: [".obsidian/**"],
   newWithinDays: 7,
   recentLimit: 5,
+  locale: DEFAULT_RUNTIME_CONFIG.locale,
   wikilinks: true,
   imagePolicy: "omit-local" as const,
   gfm: true,
@@ -446,9 +448,27 @@ function normalizeUiConfig(
   warn: ConfigWarningHandler,
 ): NonNullable<UserConfig["ui"]> {
   const ui = requireRecord(raw, "ui");
-  warnUnknownFields(ui, ["newWithinDays", "recentLimit"], "ui", "[config]", warn);
+  warnUnknownFields(ui, ["locale", "newWithinDays", "recentLimit"], "ui", "[config]", warn);
+
+  const locale = optionalString(ui, "locale", "ui.locale", {
+    trim: true,
+    allowEmpty: false,
+  });
+  const normalizedLocale = locale?.toLowerCase();
+  if (
+    normalizedLocale !== undefined &&
+    !SUPPORTED_UI_LOCALES.includes(normalizedLocale as UiLocale)
+  ) {
+    invalidValue(
+      "[config]",
+      "ui.locale",
+      `one of ${SUPPORTED_UI_LOCALES.map((value) => JSON.stringify(value)).join(", ")}`,
+      locale,
+    );
+  }
 
   return {
+    locale: normalizedLocale as UiLocale | undefined,
     newWithinDays: optionalInteger(ui, "newWithinDays", "ui.newWithinDays", 0),
     recentLimit: optionalInteger(ui, "recentLimit", "ui.recentLimit", 1),
   };
@@ -710,6 +730,7 @@ export function resolveBuildOptions(
     staticPaths,
     newWithinDays,
     recentLimit,
+    locale: config.ui?.locale ?? DEFAULTS.locale,
     defaultBranch: config.defaultBranch ?? DEFAULTS.defaultBranch,
     siteTitle,
     pinnedMenu: resolvedPinnedMenu,

--- a/src/defaults.ts
+++ b/src/defaults.ts
@@ -1,3 +1,5 @@
+import { DEFAULT_UI_LOCALE } from "./i18n";
+
 export interface RuntimeLayoutConfig {
   compactBreakpointPx: number;
   desktopSidebarDefaultPx: number;
@@ -32,6 +34,7 @@ export const DEFAULT_RUNTIME_LAYOUT: Readonly<RuntimeLayoutConfig> = Object.free
 export const DEFAULT_RUNTIME_CONFIG = Object.freeze({
   defaultBranch: DEFAULT_BRANCH,
   siteTitle: DEFAULT_SITE_TITLE,
+  locale: DEFAULT_UI_LOCALE,
   mermaid: DEFAULT_MERMAID_CONFIG,
   layout: DEFAULT_RUNTIME_LAYOUT,
 });

--- a/src/i18n.ts
+++ b/src/i18n.ts
@@ -1,0 +1,241 @@
+export const SUPPORTED_UI_LOCALES = ["ko", "en"] as const;
+
+export type UiLocale = (typeof SUPPORTED_UI_LOCALES)[number];
+
+export const DEFAULT_UI_LOCALE: UiLocale = "ko";
+
+export interface UiMessages {
+  defaultDescription: string;
+  selectDocumentTitle: string;
+  selectDocumentBody: string;
+  skipToContent: string;
+  documentExplorerPanel: string;
+  closeExplorer: string;
+  branchLabel: string;
+  searchDocuments: string;
+  searchPlaceholder: string;
+  clearSearch: string;
+  previousSearchResult: string;
+  nextSearchResult: string;
+  documentExplorer: string;
+  openExplorerSettings: string;
+  explorerSettings: string;
+  menuButtonPosition: string;
+  bottomRight: string;
+  bottomLeft: string;
+  theme: string;
+  selectTheme: string;
+  lightTheme: string;
+  systemTheme: string;
+  darkTheme: string;
+  close: string;
+  resizeExplorer: string;
+  openExplorer: string;
+  files: string;
+  path: string;
+  referencingDocuments: string;
+  documentNavigation: string;
+  notFoundMessage: string;
+  goHome: string;
+  previous: string;
+  next: string;
+  backlinks: string;
+  recentFolder: string;
+  copyCode: string;
+  copied: string;
+  imageOmitted: (label: string) => string;
+  branchDefault: (branch: string) => string;
+  searchMatches: (count: number) => string;
+  newBadge: string;
+  newDocument: string;
+  open: string;
+  treeLoading: string;
+  simpleDocumentExplorer: string;
+  treeLoadFailed: string;
+  retryExplorer: string;
+  treeFallbackAnnouncement: string;
+  navigationComplete: (title: string) => string;
+  missingDocumentTitle: string;
+  missingRouteBody: string;
+  missingRouteAnnouncement: string;
+  contentLoadFailedBody: string;
+  contentLoadFailedAnnouncement: (title: string) => string;
+  initializationFailed: (detail: string) => string;
+  manifestLoadFailed: (status: number) => string;
+  unsupportedManifest: string;
+  mermaidLibraryLoadFailed: (url: string) => string;
+  mermaidDisabled: string;
+  mermaidApiUnavailable: string;
+  mermaidRenderFailed: (detail: string) => string;
+}
+
+export type UiMessageCatalog = Readonly<Record<UiLocale, Partial<UiMessages>>>;
+
+const koreanMessages = Object.freeze({
+  defaultDescription: "마크다운 탐색기 UI를 제공하는 파일 시스템 스타일 정적 블로그입니다.",
+  selectDocumentTitle: "문서를 선택하세요",
+  selectDocumentBody: "왼쪽 탐색기에서 문서를 선택하세요.",
+  skipToContent: "본문으로 건너뛰기",
+  documentExplorerPanel: "문서 탐색기 패널",
+  closeExplorer: "탐색기 닫기",
+  branchLabel: "브랜치",
+  searchDocuments: "문서 검색",
+  searchPlaceholder: "검색",
+  clearSearch: "검색 지우기",
+  previousSearchResult: "이전 검색 결과",
+  nextSearchResult: "다음 검색 결과",
+  documentExplorer: "문서 탐색기",
+  openExplorerSettings: "탐색기 설정 열기",
+  explorerSettings: "탐색기 설정",
+  menuButtonPosition: "메뉴 버튼 위치",
+  bottomRight: "오른쪽 하단",
+  bottomLeft: "왼쪽 하단",
+  theme: "테마",
+  selectTheme: "테마 선택",
+  lightTheme: "밝게",
+  systemTheme: "시스템",
+  darkTheme: "어둡게",
+  close: "닫기",
+  resizeExplorer: "탐색기 너비 조절",
+  openExplorer: "탐색기 열기",
+  files: "파일",
+  path: "경로",
+  referencingDocuments: "문서를 참조한 링크",
+  documentNavigation: "문서 이전/다음 탐색",
+  notFoundMessage: "요청한 문서를 찾을 수 없습니다.",
+  goHome: "홈으로 이동",
+  previous: "이전",
+  next: "다음",
+  backlinks: "역링크",
+  recentFolder: "최근 문서",
+  copyCode: "코드 복사",
+  copied: "복사됨",
+  imageOmitted: (label) => `(이미지 생략: ${label})`,
+  branchDefault: (branch) => `${branch} (기본값)`,
+  searchMatches: (count) => `${count}개 일치`,
+  newBadge: "NEW",
+  newDocument: "새 문서",
+  open: "열기",
+  treeLoading: "문서 탐색기를 불러오는 중입니다.",
+  simpleDocumentExplorer: "간이 문서 탐색기",
+  treeLoadFailed: "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.",
+  retryExplorer: "탐색기 다시 불러오기",
+  treeFallbackAnnouncement:
+    "문서 트리를 불러오지 못했습니다. 간이 링크 탐색기를 사용할 수 있습니다.",
+  navigationComplete: (title) => `탐색 완료: ${title} 문서를 열었습니다.`,
+  missingDocumentTitle: "문서를 찾을 수 없습니다",
+  missingRouteBody: "요청한 경로에 해당하는 문서가 없습니다.",
+  missingRouteAnnouncement: "탐색 실패: 요청한 문서를 찾을 수 없습니다.",
+  contentLoadFailedBody: "본문을 불러오지 못했습니다.",
+  contentLoadFailedAnnouncement: (title) => `탐색 실패: ${title} 문서를 불러오지 못했습니다.`,
+  initializationFailed: (detail) => `초기화 실패: ${detail}`,
+  manifestLoadFailed: (status) => `매니페스트를 불러오지 못했습니다: ${status}`,
+  unsupportedManifest: "지원하는 매니페스트 형식을 불러오지 못했습니다.",
+  mermaidLibraryLoadFailed: (url) => `Mermaid 라이브러리 로드 실패: ${url}`,
+  mermaidDisabled: "Mermaid 렌더링이 비활성화되어 코드 블록을 그대로 표시합니다.",
+  mermaidApiUnavailable: "Mermaid 렌더러 API가 존재하지 않습니다.",
+  mermaidRenderFailed: (detail) => `Mermaid 렌더링 실패: ${detail}`,
+} satisfies UiMessages);
+
+const englishMessages = Object.freeze({
+  defaultDescription: "A file-system style static blog with a Markdown explorer UI.",
+  selectDocumentTitle: "Select a document",
+  selectDocumentBody: "Select a document from the explorer on the left.",
+  skipToContent: "Skip to content",
+  documentExplorerPanel: "Document explorer panel",
+  closeExplorer: "Close explorer",
+  branchLabel: "Branch",
+  searchDocuments: "Search documents",
+  searchPlaceholder: "Search",
+  clearSearch: "Clear search",
+  previousSearchResult: "Previous search result",
+  nextSearchResult: "Next search result",
+  documentExplorer: "Document explorer",
+  openExplorerSettings: "Open explorer settings",
+  explorerSettings: "Explorer settings",
+  menuButtonPosition: "Menu button position",
+  bottomRight: "Bottom right",
+  bottomLeft: "Bottom left",
+  theme: "Theme",
+  selectTheme: "Select theme",
+  lightTheme: "Light",
+  systemTheme: "System",
+  darkTheme: "Dark",
+  close: "Close",
+  resizeExplorer: "Resize explorer",
+  openExplorer: "Open explorer",
+  files: "Files",
+  path: "Path",
+  referencingDocuments: "Links to this document",
+  documentNavigation: "Previous and next documents",
+  notFoundMessage: "The requested document could not be found.",
+  goHome: "Go home",
+  previous: "Previous",
+  next: "Next",
+  backlinks: "Backlinks",
+  recentFolder: "Recent",
+  copyCode: "Copy code",
+  copied: "Copied",
+  imageOmitted: (label) => `(image omitted: ${label})`,
+  branchDefault: (branch) => `${branch} (default)`,
+  searchMatches: (count) => `${count} ${count === 1 ? "match" : "matches"}`,
+  newBadge: "NEW",
+  newDocument: "New document",
+  open: "Open",
+  treeLoading: "Loading the document explorer.",
+  simpleDocumentExplorer: "Simple document explorer",
+  treeLoadFailed: "The document tree could not be loaded. Continue with the links below.",
+  retryExplorer: "Reload explorer",
+  treeFallbackAnnouncement:
+    "The document tree could not be loaded. A simple link explorer is available.",
+  navigationComplete: (title) => `Navigation complete: opened ${title}.`,
+  missingDocumentTitle: "Document not found",
+  missingRouteBody: "No document exists at the requested path.",
+  missingRouteAnnouncement: "Navigation failed: the requested document could not be found.",
+  contentLoadFailedBody: "The document body could not be loaded.",
+  contentLoadFailedAnnouncement: (title) => `Navigation failed: could not load ${title}.`,
+  initializationFailed: (detail) => `Initialization failed: ${detail}`,
+  manifestLoadFailed: (status) => `Failed to load the manifest: ${status}`,
+  unsupportedManifest: "Failed to load a supported manifest schema.",
+  mermaidLibraryLoadFailed: (url) => `Failed to load the Mermaid library: ${url}`,
+  mermaidDisabled: "Mermaid rendering is disabled, so the code block is shown as-is.",
+  mermaidApiUnavailable: "The Mermaid renderer API is unavailable.",
+  mermaidRenderFailed: (detail) => `Mermaid rendering failed: ${detail}`,
+} satisfies UiMessages);
+
+export const UI_MESSAGE_CATALOG: UiMessageCatalog = Object.freeze({
+  ko: koreanMessages,
+  en: englishMessages,
+});
+
+export function normalizeUiLocale(value: unknown): UiLocale {
+  if (typeof value !== "string") {
+    return DEFAULT_UI_LOCALE;
+  }
+  const normalized = value.trim().toLowerCase();
+  return normalized === "en" || normalized === "ko" ? normalized : DEFAULT_UI_LOCALE;
+}
+
+function resolveMessages(locale: UiLocale, catalog: UiMessageCatalog): UiMessages {
+  const selected = catalog[locale];
+  const entries = Object.entries(koreanMessages).map(([key, fallback]) => {
+    const candidate = selected?.[key as keyof UiMessages];
+    return [key, typeof candidate === typeof fallback ? candidate : fallback];
+  });
+  return Object.freeze(Object.fromEntries(entries)) as unknown as UiMessages;
+}
+
+const resolvedDefaultCatalog = Object.freeze({
+  ko: resolveMessages("ko", UI_MESSAGE_CATALOG),
+  en: resolveMessages("en", UI_MESSAGE_CATALOG),
+});
+
+export function getUiMessages(
+  locale: unknown = DEFAULT_UI_LOCALE,
+  catalog: UiMessageCatalog = UI_MESSAGE_CATALOG,
+): UiMessages {
+  const normalized = normalizeUiLocale(locale);
+  return catalog === UI_MESSAGE_CATALOG
+    ? resolvedDefaultCatalog[normalized]
+    : resolveMessages(normalized, catalog);
+}

--- a/src/markdown.ts
+++ b/src/markdown.ts
@@ -9,6 +9,7 @@ import markdownLanguage from "@shikijs/langs/markdown";
 import typescriptLanguage from "@shikijs/langs/typescript";
 import githubDarkTheme from "@shikijs/themes/github-dark";
 import { APP_ICON_NAMES, renderAppIcon } from "./icons";
+import { getUiMessages, type UiMessages } from "./i18n";
 import type { BuildOptions, WikiResolver } from "./types";
 import { isRemoteUrl } from "./utils";
 
@@ -183,6 +184,7 @@ function preprocessMarkdown(
   resolver: WikiResolver,
   imagePolicy: BuildOptions["imagePolicy"],
   wikilinks: boolean,
+  messages: UiMessages,
 ): {
   markdown: string;
   warnings: string[];
@@ -193,7 +195,7 @@ function preprocessMarkdown(
     const { target, label } = parseWikiInner(inner);
     if (imagePolicy === "omit-local") {
       warnings.push(`Local image omitted: ${target}`);
-      return `*(image omitted: ${label ?? target})*`;
+      return `*${messages.imageOmitted(escapeMarkdownLabel(label ?? target))}*`;
     }
     return `![${escapeMarkdownLabel(label ?? target)}](${target})`;
   });
@@ -206,7 +208,7 @@ function preprocessMarkdown(
       return full;
     }
     warnings.push(`Local image omitted: ${src.trim()}`);
-    return `*(image omitted: ${alt || src.trim()})*`;
+    return `*${messages.imageOmitted(escapeMarkdownLabel(alt || src.trim()))}*`;
   });
 
   if (wikilinks) {
@@ -354,7 +356,12 @@ function isStandaloneImageParagraph(tokens: RuleTokens, idx: number): boolean {
   return children.length === 1 && children[0]?.type === "image";
 }
 
-function createMarkdownIt(highlighter: HighlighterCore, theme: string, gfm: boolean): MarkdownIt {
+function createMarkdownIt(
+  highlighter: HighlighterCore,
+  theme: string,
+  gfm: boolean,
+  messages: UiMessages,
+): MarkdownIt {
   const md = new MarkdownIt({
     // Parse raw HTML so the configured sanitizer can apply one policy to generated and authored markup.
     html: true,
@@ -407,7 +414,7 @@ function createMarkdownIt(highlighter: HighlighterCore, theme: string, gfm: bool
         <span class="dot dot-green"></span>
       </div>
       <span class="code-filename">${fileName ? escapeHtmlAttr(fileName) : lang}</span>
-      <button class="code-copy" type="button" title="Copy code" aria-label="Copy code" data-code="${escapeHtmlAttr(token.content)}">
+      <button class="code-copy" type="button" title="${escapeHtmlAttr(messages.copyCode)}" aria-label="${escapeHtmlAttr(messages.copyCode)}" data-code="${escapeHtmlAttr(token.content)}">
         ${renderAppIcon("copy")}
       </button>
     </div>`;
@@ -495,6 +502,7 @@ function createMarkdownIt(highlighter: HighlighterCore, theme: string, gfm: bool
 }
 
 export async function createMarkdownRenderer(options: BuildOptions): Promise<MarkdownRenderer> {
+  const messages = getUiMessages(options.locale);
   const theme = await loadShikiTheme(options.shikiTheme);
   const highlighter = await createHighlighterCore({
     themes: [theme],
@@ -505,7 +513,7 @@ export async function createMarkdownRenderer(options: BuildOptions): Promise<Mar
   const unavailableLanguages = new Set<string>();
   let languageLoadQueue = Promise.resolve();
 
-  const md = createMarkdownIt(highlighter, theme.name ?? options.shikiTheme, options.gfm);
+  const md = createMarkdownIt(highlighter, theme.name ?? options.shikiTheme, options.gfm, messages);
   if (options.allowUnsafeHtml) {
     console.warn(
       "[security] markdown.allowUnsafeHtml=true disables rendered HTML sanitization. Only use trusted vault content.",
@@ -519,6 +527,7 @@ export async function createMarkdownRenderer(options: BuildOptions): Promise<Mar
         resolver,
         options.imagePolicy,
         options.wikilinks,
+        messages,
       );
       const languageLoad = languageLoadQueue.then(() =>
         loadFenceLanguages(highlighter, loadedLanguages, unavailableLanguages, preprocessed),

--- a/src/runtime/app.js
+++ b/src/runtime/app.js
@@ -15,10 +15,12 @@ import {
   renderViewBreadcrumb,
   renderViewChrome,
 } from "../view-contract.ts";
+import { getUiMessages } from "../i18n.ts";
 
 const BRANCH_KEY = "fsblog.branch";
 const APP_READY_STATE_ATTR = "data-app-ready";
 const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
+let appMessages = getUiMessages(globalThis.document?.documentElement?.lang);
 
 /**
  * @typedef {import("./contracts").A11yAnnouncer} A11yAnnouncer
@@ -111,6 +113,7 @@ async function start() {
   setRuntimeState(TREE_RUNTIME_STATE_ATTR, "idle");
 
   const bootstrap = await loadRuntimeBootstrap();
+  appMessages = getUiMessages(bootstrap.manifest.locale);
   const elements = collectViewerElements();
   const announcer = createA11yAnnouncer(document.getElementById("a11y-status"));
   const navigation = createNavigationState(bootstrap.manifest, {
@@ -125,10 +128,13 @@ async function start() {
     closeSettings: () => settingsController.close(),
     requestTreeLoad: (reason) => treeController?.requestLoad(reason) ?? Promise.resolve(false),
   });
-  const mermaidController = createMermaidController(resolveMermaidConfig(bootstrap.manifest));
+  const mermaidController = createMermaidController(resolveMermaidConfig(bootstrap.manifest), {
+    messages: appMessages,
+  });
   const enhancementController = createContentEnhancementController({
     root: elements.content,
     mermaidController,
+    messages: appMessages,
   });
 
   const contentController = createContentController({
@@ -137,9 +143,10 @@ async function start() {
     initialViewData: bootstrap.initialViewData,
     pathBase: bootstrap.pathBase,
     siteTitle: bootstrap.siteTitle,
+    messages: appMessages,
     renderers: {
       breadcrumb: renderViewBreadcrumb,
-      chrome: renderViewChrome,
+      chrome: (options) => renderViewChrome({ ...options, locale: bootstrap.manifest.locale }),
       documentTitle: composeViewDocumentTitle,
     },
     lifecycle: {
@@ -169,6 +176,7 @@ async function start() {
     treeModuleUrl: bootstrap.treeModuleUrl,
     navigate: (route, push) => contentController.navigate(route, push),
     announce: (message) => announcer.announce(message),
+    messages: appMessages,
     isCompactLayout: () => layoutController.isCompact(),
   });
 
@@ -209,7 +217,7 @@ start().catch((error) => {
     content.replaceChildren();
     const placeholder = document.createElement("p");
     placeholder.className = "placeholder";
-    placeholder.textContent = `초기화 실패: ${message}`;
+    placeholder.textContent = appMessages.initializationFailed(message);
     content.appendChild(placeholder);
   }
   console.error(error);

--- a/src/runtime/content-controller.js
+++ b/src/runtime/content-controller.js
@@ -1,4 +1,5 @@
 import { toPathWithBase } from "./navigation-state.js";
+import { getUiMessages } from "../i18n.ts";
 
 /** @typedef {import("./contracts").ContentController} ContentController */
 /** @typedef {import("./contracts").ContentLifecycle} ContentLifecycle */
@@ -7,6 +8,7 @@ import { toPathWithBase } from "./navigation-state.js";
 /** @typedef {import("./contracts").NavigationState} NavigationState */
 /** @typedef {import("./contracts").RuntimeManifestDoc} RuntimeManifestDoc */
 /** @typedef {import("./contracts").ViewerElements} ViewerElements */
+/** @typedef {import("../i18n").UiMessages} UiMessages */
 
 /**
  * @param {Element | null | undefined} element
@@ -29,6 +31,20 @@ function setText(element, value) {
 }
 
 /**
+ * @param {Element | null | undefined} element
+ * @param {string} value
+ */
+function setPlaceholder(element, value) {
+  if (!element) {
+    return;
+  }
+  const paragraph = element.ownerDocument.createElement("p");
+  paragraph.className = "placeholder";
+  paragraph.textContent = value;
+  element.replaceChildren(paragraph);
+}
+
+/**
  * @param {{
  *   navigation: NavigationState;
  *   elements: ViewerElements;
@@ -36,6 +52,7 @@ function setText(element, value) {
  *   pathBase: string;
  *   siteTitle: string;
  *   renderers: ContentRenderers;
+ *   messages?: UiMessages;
  *   lifecycle?: ContentLifecycle;
  *   fetchContent?: (url: string) => Promise<Response>;
  *   historyApi?: Pick<History, "pushState"> | null;
@@ -52,6 +69,7 @@ export function createContentController(options) {
     pathBase,
     siteTitle,
     renderers,
+    messages = getUiMessages(),
     lifecycle = {},
     fetchContent = (url) => fetch(url),
     historyApi = globalThis.history,
@@ -98,7 +116,7 @@ export function createContentController(options) {
     await lifecycle.enhanceContent?.(elements.content);
     setPageTitle(renderers.documentTitle(doc.title, siteTitle));
     elements.viewer?.scrollTo?.(0, 0);
-    lifecycle.announce?.(`탐색 완료: ${doc.title} 문서를 열었습니다.`);
+    lifecycle.announce?.(messages.navigationComplete(doc.title));
   };
 
   /**
@@ -109,12 +127,12 @@ export function createContentController(options) {
     navigation.setCurrentDocId("");
     lifecycle.onMissingSelection?.();
     setHtml(elements.breadcrumb, renderers.breadcrumb(route));
-    setText(elements.title, "문서를 찾을 수 없습니다");
+    setText(elements.title, messages.missingDocumentTitle);
     setHtml(elements.meta, "");
-    setHtml(elements.content, '<p class="placeholder">요청한 경로에 해당하는 문서가 없습니다.</p>');
+    setPlaceholder(elements.content, messages.missingRouteBody);
     updateBacklinks("");
     setHtml(elements.nav, "");
-    lifecycle.announce?.("탐색 실패: 요청한 문서를 찾을 수 없습니다.");
+    lifecycle.announce?.(messages.missingRouteAnnouncement);
     if (push) {
       historyApi?.pushState?.(null, "", toPathWithBase(route, pathBase));
     }
@@ -158,10 +176,10 @@ export function createContentController(options) {
 
     const response = await fetchContent(toPathWithBase(resolved.doc.contentUrl, pathBase));
     if (!response.ok) {
-      setHtml(elements.content, '<p class="placeholder">본문을 불러오지 못했습니다.</p>');
+      setPlaceholder(elements.content, messages.contentLoadFailedBody);
       updateBacklinks("");
       setHtml(elements.nav, "");
-      lifecycle.announce?.(`탐색 실패: ${resolved.doc.title} 문서를 불러오지 못했습니다.`);
+      lifecycle.announce?.(messages.contentLoadFailedAnnouncement(resolved.doc.title));
       return false;
     }
 

--- a/src/runtime/content-enhancement-controller.js
+++ b/src/runtime/content-enhancement-controller.js
@@ -1,4 +1,5 @@
 import { createEventScope } from "./controller-lifecycle.js";
+import { getUiMessages } from "../i18n.ts";
 
 const CONTENT_IMAGE_LANDSCAPE_CLASS = "is-landscape";
 const CONTENT_IMAGE_PORTRAIT_CLASS = "is-portrait";
@@ -10,6 +11,7 @@ const CONTENT_IMAGE_PORTRAIT_THRESHOLD = 0.9;
 /** @typedef {import("./contracts").EventScope} EventScope */
 /** @typedef {import("./contracts").MermaidController} MermaidController */
 /** @typedef {import("./contracts").RuntimeWindow} RuntimeWindow */
+/** @typedef {import("../i18n").UiMessages} UiMessages */
 
 /** @type {Map<string, Promise<ImageDimensions | null>>} */
 const contentImageDimensionCache = new Map();
@@ -202,13 +204,14 @@ export function enhanceContentImages(root, windowRef = globalThis.window) {
 }
 
 /**
- * @param {{ root: HTMLElement | null; mermaidController: MermaidController; clipboard?: Pick<Clipboard, "writeText">; windowRef?: RuntimeWindow }} options
+ * @param {{ root: HTMLElement | null; mermaidController: MermaidController; messages?: UiMessages; clipboard?: Pick<Clipboard, "writeText">; windowRef?: RuntimeWindow }} options
  * @returns {ContentEnhancementController}
  */
 export function createContentEnhancementController(options) {
   const {
     root,
     mermaidController,
+    messages = getUiMessages(),
     clipboard = globalThis.navigator?.clipboard,
     windowRef = globalThis.window,
   } = options;
@@ -240,8 +243,8 @@ export function createContentEnhancementController(options) {
       }
       await clipboard.writeText(code);
       button.classList.add("copied");
-      button.setAttribute("aria-label", "Copied");
-      button.setAttribute("title", "Copied");
+      button.setAttribute("aria-label", messages.copied);
+      button.setAttribute("title", messages.copied);
       const iconUse = button.querySelector(".app-icon use");
       if (iconUse instanceof windowRef.Element) {
         iconUse.setAttribute("href", "#eiam-icon-check");
@@ -249,8 +252,8 @@ export function createContentEnhancementController(options) {
       const timer = windowRef.setTimeout(() => {
         resetTimers.delete(timer);
         button.classList.remove("copied");
-        button.setAttribute("aria-label", "Copy code");
-        button.setAttribute("title", "Copy code");
+        button.setAttribute("aria-label", messages.copyCode);
+        button.setAttribute("title", messages.copyCode);
         const nextIconUse = button.querySelector(".app-icon use");
         if (nextIconUse instanceof windowRef.Element) {
           nextIconUse.setAttribute("href", "#eiam-icon-copy");

--- a/src/runtime/contracts.ts
+++ b/src/runtime/contracts.ts
@@ -1,4 +1,5 @@
 import type { Manifest, ManifestDoc } from "../types";
+import type { UiMessages } from "../i18n";
 import type { RenderedViewChrome } from "../view-contract";
 
 export type RuntimeManifest = Manifest;
@@ -216,6 +217,7 @@ export interface TreeControllerOptions {
   treeModuleUrl: string;
   navigate: (route: string, push: boolean) => Promise<boolean>;
   announce?: (message: string) => void;
+  messages?: UiMessages;
   isCompactLayout?: () => boolean;
   documentRef?: Document;
   windowRef?: RuntimeWindow;

--- a/src/runtime/manifest-adapter.js
+++ b/src/runtime/manifest-adapter.js
@@ -1,3 +1,5 @@
+import { normalizeUiLocale } from "../i18n.ts";
+
 const CURRENT_SCHEMA_VERSION = 2;
 
 /** @typedef {import("./contracts").RuntimeManifest} RuntimeManifest */
@@ -115,6 +117,7 @@ export function normalizeManifestPayload(value) {
     /** @type {unknown} */ ({
       ...manifest,
       schemaVersion: CURRENT_SCHEMA_VERSION,
+      locale: normalizeUiLocale(value.locale),
       ...normalizedDocs,
     })
   );

--- a/src/runtime/mermaid-controller.js
+++ b/src/runtime/mermaid-controller.js
@@ -1,4 +1,5 @@
 import { DEFAULT_MERMAID_CONFIG } from "../defaults.ts";
+import { getUiMessages } from "../i18n.ts";
 
 const MERMAID_SELECTOR = "pre.mermaid";
 const MERMAID_ERROR_CLASS = "mermaid-render-error";
@@ -15,6 +16,7 @@ const MERMAID_BLOCK_TALL_CLASS = "is-tall";
  * @typedef {import("./contracts").MermaidLibrary} MermaidLibrary
  * @typedef {import("./contracts").RuntimeManifest} RuntimeManifest
  * @typedef {import("./contracts").RuntimeWindow} RuntimeWindow
+ * @typedef {import("../i18n").UiMessages} UiMessages
  */
 
 /** @type {{ initialized: boolean; loadingPromise: Promise<MermaidLibrary | null> | null; scriptElement: HTMLScriptElement | null; lastCdnUrl: string; lastTheme: string }} */
@@ -172,10 +174,10 @@ function resetMermaidNodes(nodes) {
 
 /**
  * @param {MermaidConfig} config
- * @param {{ documentRef: Document; windowRef: RuntimeWindow }} environment
+ * @param {{ documentRef: Document; windowRef: RuntimeWindow; messages: UiMessages }} environment
  * @returns {Promise<MermaidLibrary | null>}
  */
-async function loadMermaidLibrary(config, { documentRef, windowRef }) {
+async function loadMermaidLibrary(config, { documentRef, windowRef, messages }) {
   if (!config.enabled) {
     return null;
   }
@@ -256,7 +258,7 @@ async function loadMermaidLibrary(config, { documentRef, windowRef }) {
       finalize();
     });
     script.addEventListener("error", () => {
-      finalize(new Error(`Mermaid 라이브러리 로드 실패: ${normalized.cdnUrl}`));
+      finalize(new Error(messages.mermaidLibraryLoadFailed(normalized.cdnUrl)));
     });
 
     if (!script.isConnected) {
@@ -269,12 +271,13 @@ async function loadMermaidLibrary(config, { documentRef, windowRef }) {
 
 /**
  * @param {MermaidConfig} config
- * @param {{ documentRef?: Document; windowRef?: RuntimeWindow }} [options]
+ * @param {{ documentRef?: Document; windowRef?: RuntimeWindow; messages?: UiMessages }} [options]
  * @returns {MermaidController}
  */
 export function createMermaidController(config, options = {}) {
   const documentRef = options.documentRef ?? globalThis.document;
   const windowRef = options.windowRef ?? globalThis.window;
+  const messages = options.messages ?? getUiMessages();
   let isSetup = false;
   let lifecycleGeneration = 0;
 
@@ -310,17 +313,13 @@ export function createMermaidController(config, options = {}) {
       resetMermaidNodes(blocks);
 
       try {
-        const mermaid = await loadMermaidLibrary(config, { documentRef, windowRef });
+        const mermaid = await loadMermaidLibrary(config, { documentRef, windowRef, messages });
         if (!isSetup || renderGeneration !== lifecycleGeneration) {
           return;
         }
         if (!mermaid) {
           for (const block of blocks) {
-            showMermaidError(
-              block,
-              "Mermaid 렌더링이 비활성화되어 코드 블록을 그대로 표시합니다.",
-              documentRef,
-            );
+            showMermaidError(block, messages.mermaidDisabled, documentRef);
           }
           return;
         }
@@ -340,11 +339,11 @@ export function createMermaidController(config, options = {}) {
               normalizeRenderedMermaidSvg(block, windowRef);
               continue;
             }
-            throw new Error("Mermaid 렌더러 API가 존재하지 않습니다.");
+            throw new Error(messages.mermaidApiUnavailable);
           } catch (error) {
-            const message = `Mermaid 렌더링 실패: ${
-              error instanceof Error ? error.message : String(error)
-            }`;
+            const message = messages.mermaidRenderFailed(
+              error instanceof Error ? error.message : String(error),
+            );
             showMermaidError(block, message, documentRef);
           }
         }
@@ -352,9 +351,9 @@ export function createMermaidController(config, options = {}) {
         if (!isSetup || renderGeneration !== lifecycleGeneration) {
           return;
         }
-        const message = `Mermaid 렌더링 실패: ${
-          error instanceof Error ? error.message : String(error)
-        }`;
+        const message = messages.mermaidRenderFailed(
+          error instanceof Error ? error.message : String(error),
+        );
         for (const block of blocks) {
           showMermaidError(block, message, documentRef);
         }

--- a/src/runtime/runtime-bootstrap.js
+++ b/src/runtime/runtime-bootstrap.js
@@ -1,5 +1,6 @@
 import { normalizeManifestPayload } from "./manifest-adapter.js";
 import { DEFAULT_SITE_TITLE } from "../defaults.ts";
+import { getUiMessages } from "../i18n.ts";
 import {
   normalizePathBase,
   normalizeRoute,
@@ -109,16 +110,17 @@ export async function loadRuntimeBootstrap(options = {}) {
     options.fetchManifest ?? ((/** @type {string} */ url) => globalThis.fetch(url));
   const initialViewData = loadInitialViewData(documentRef);
   const initialRuntimeData = loadInitialRuntimeData({ documentRef, windowRef });
+  const messages = getUiMessages(documentRef.documentElement?.lang);
   const initialPathBase = normalizePathBase(initialRuntimeData?.pathBase);
   const manifestUrl =
     initialRuntimeData?.manifestUrl ?? toPathWithBase("/manifest.json", initialPathBase);
   const response = await fetchManifest(manifestUrl);
   if (!response.ok) {
-    throw new Error(`Failed to load manifest: ${response.status}`);
+    throw new Error(messages.manifestLoadFailed(response.status));
   }
   const manifest = normalizeManifestPayload(await response.json());
   if (!manifest) {
-    throw new Error("Failed to load a supported manifest schema");
+    throw new Error(messages.unsupportedManifest);
   }
 
   return {

--- a/src/runtime/tree-controller.js
+++ b/src/runtime/tree-controller.js
@@ -1,5 +1,6 @@
 import { createEventScope } from "./controller-lifecycle.js";
 import { pickHomeRoute, resolveRouteFromLocation, toPathWithBase } from "./navigation-state.js";
+import { getUiMessages } from "../i18n.ts";
 
 const BRANCH_KEY = "fsblog.branch";
 const TREE_RUNTIME_STATE_ATTR = "data-tree-runtime";
@@ -183,6 +184,7 @@ export function createTreeController(options) {
     treeModuleUrl,
     navigate,
     announce = () => {},
+    messages = getUiMessages(),
     isCompactLayout = () => false,
     documentRef = globalThis.document,
     windowRef = globalThis.window,
@@ -245,7 +247,8 @@ export function createTreeController(options) {
     for (const branch of navigation.availableBranches) {
       const option = documentRef.createElement("option");
       option.value = branch;
-      option.textContent = branch === navigation.defaultBranch ? `${branch} (default)` : branch;
+      option.textContent =
+        branch === navigation.defaultBranch ? messages.branchDefault(branch) : branch;
       sidebarBranchSelect.appendChild(option);
     }
     sidebarBranchSelect.disabled = navigation.availableBranches.length < 2;
@@ -272,7 +275,7 @@ export function createTreeController(options) {
       }
     }
     if (treeSearchCount) {
-      treeSearchCount.textContent = hasSearch ? `${matchCount}개 일치` : "";
+      treeSearchCount.textContent = hasSearch ? messages.searchMatches(matchCount) : "";
     }
     if (sidebarSearchActions) {
       sidebarSearchActions.hidden = !hasSearch;
@@ -404,7 +407,7 @@ export function createTreeController(options) {
     if (metadata?.kind !== "file" || metadata.isNew !== true) {
       return null;
     }
-    return { text: "NEW", title: "New document" };
+    return { text: messages.newBadge, title: messages.newDocument };
   };
 
   /**
@@ -430,7 +433,7 @@ export function createTreeController(options) {
     const link = documentRef.createElement("a");
     link.className = "tree-context-link";
     link.href = toPathWithBase(route, pathBase);
-    link.textContent = "Open";
+    link.textContent = messages.open;
     Object.assign(link.style, {
       borderRadius: "4px",
       color: "inherit",
@@ -535,7 +538,7 @@ export function createTreeController(options) {
     const status = documentRef.createElement("p");
     status.className = "tree-load-status";
     status.setAttribute("role", "status");
-    status.textContent = "문서 탐색기를 불러오는 중입니다.";
+    status.textContent = messages.treeLoading;
     treeRoot.replaceChildren(status);
   };
 
@@ -546,15 +549,15 @@ export function createTreeController(options) {
     }
     const fallback = documentRef.createElement("section");
     fallback.className = "tree-load-fallback";
-    fallback.setAttribute("aria-label", "간이 문서 탐색기");
+    fallback.setAttribute("aria-label", messages.simpleDocumentExplorer);
     const message = documentRef.createElement("p");
     message.className = "tree-load-fallback-message";
     message.setAttribute("role", "alert");
-    message.textContent = "문서 트리를 불러오지 못했습니다. 아래 링크로 계속 탐색할 수 있습니다.";
+    message.textContent = messages.treeLoadFailed;
     const retry = documentRef.createElement("button");
     retry.className = "tree-load-retry";
     retry.type = "button";
-    retry.textContent = "탐색기 다시 불러오기";
+    retry.textContent = messages.retryExplorer;
     retry.addEventListener("click", () => {
       void requestLoad("retry", { retry: true });
     });
@@ -644,7 +647,7 @@ export function createTreeController(options) {
         treeRoot?.setAttribute("aria-busy", "false");
         setTreeRuntimeState("error");
         renderTreeFallback(error);
-        announce("문서 트리를 불러오지 못했습니다. 간이 링크 탐색기를 사용할 수 있습니다.");
+        announce(messages.treeFallbackAnnouncement);
         console.error("Tree runtime load failed:", error);
         return false;
       })

--- a/src/template.ts
+++ b/src/template.ts
@@ -1,11 +1,10 @@
 import { escapeHtmlAttribute } from "./seo";
 import { DEFAULT_SITE_TITLE } from "./defaults";
+import { getUiMessages, normalizeUiLocale } from "./i18n";
 import { renderAppIconSprite } from "./icon-sprite";
 import { renderAppIcon } from "./icons";
 import type { Manifest } from "./types";
 import { toViewPathWithBase } from "./view-contract";
-
-const DEFAULT_DESCRIPTION = "File-system style static blog with markdown explorer UI.";
 
 export interface AppShellMeta {
   title?: string;
@@ -78,10 +77,10 @@ function stringifyJsonLd(value: unknown): string {
     .replaceAll("\u2029", "\\u2029");
 }
 
-function renderHeadMeta(meta: AppShellMeta): string {
+function renderHeadMeta(meta: AppShellMeta, defaultDescription: string): string {
   const title = (meta.title ?? DEFAULT_SITE_TITLE).trim() || DEFAULT_SITE_TITLE;
   const description = typeof meta.description === "string" ? meta.description.trim() : "";
-  const fallbackDescription = description || DEFAULT_DESCRIPTION;
+  const fallbackDescription = description || defaultDescription;
   const canonicalUrl = typeof meta.canonicalUrl === "string" ? meta.canonicalUrl.trim() : "";
 
   const ogTitle = (meta.ogTitle ?? title).trim() || title;
@@ -90,13 +89,13 @@ function renderHeadMeta(meta: AppShellMeta): string {
   const ogLocale = typeof meta.ogLocale === "string" ? meta.ogLocale.trim() : "";
   const ogUrl = typeof meta.ogUrl === "string" ? meta.ogUrl.trim() : "";
   const ogDescription =
-    (meta.ogDescription ?? (description || DEFAULT_DESCRIPTION)).trim() || DEFAULT_DESCRIPTION;
+    (meta.ogDescription ?? (description || defaultDescription)).trim() || defaultDescription;
   const ogImage = typeof meta.ogImage === "string" ? meta.ogImage.trim() : "";
 
   const twitterCard = (meta.twitterCard ?? "summary").trim() || "summary";
   const twitterTitle = (meta.twitterTitle ?? title).trim() || title;
   const twitterDescription =
-    (meta.twitterDescription ?? (description || DEFAULT_DESCRIPTION)).trim() || DEFAULT_DESCRIPTION;
+    (meta.twitterDescription ?? (description || defaultDescription)).trim() || defaultDescription;
   const twitterImage = typeof meta.twitterImage === "string" ? meta.twitterImage.trim() : "";
   const twitterSite = typeof meta.twitterSite === "string" ? meta.twitterSite.trim() : "";
   const twitterCreator = typeof meta.twitterCreator === "string" ? meta.twitterCreator.trim() : "";
@@ -212,24 +211,29 @@ export function renderAppShellHtml(
   initialView: AppShellInitialView | null = null,
   manifest: AppShellManifestPayload | null = null,
 ): string {
-  const headMeta = renderHeadMeta(meta);
+  const locale = normalizeUiLocale(manifest?.locale);
+  const messages = getUiMessages(locale);
+  const text = escapeHtmlAttribute;
+  const headMeta = renderHeadMeta(meta, messages.defaultDescription);
   const initialViewScript = renderInitialViewScript(initialView);
   const runtimeBootstrapScript = renderRuntimeBootstrapScript(manifest, assets);
   const appTitle =
     typeof manifest?.siteTitle === "string" && manifest.siteTitle.trim().length > 0
       ? manifest.siteTitle.trim()
       : DEFAULT_SITE_TITLE;
-  const initialTitle = initialView ? escapeHtmlAttribute(initialView.title) : "문서를 선택하세요";
+  const initialTitle = initialView
+    ? escapeHtmlAttribute(initialView.title)
+    : text(messages.selectDocumentTitle);
   const initialBreadcrumb = initialView ? initialView.breadcrumbHtml : "";
   const initialMeta = initialView ? initialView.metaHtml : "";
   const initialContent = initialView
     ? initialView.contentHtml
-    : '<p class="placeholder">좌측 탐색기에서 문서를 선택하세요.</p>';
+    : `<p class="placeholder">${text(messages.selectDocumentBody)}</p>`;
   const initialBacklinks = initialView ? initialView.backlinksHtml : "";
   const initialNav = initialView ? initialView.navHtml : "";
 
   return `<!doctype html>
-<html lang="ko">
+<html lang="${locale}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -238,20 +242,20 @@ ${headMeta}
   </head>
   <body>
     ${renderAppIconSprite()}
-    <a class="skip-link" href="#viewer-panel">본문으로 건너뛰기</a>
+    <a class="skip-link" href="#viewer-panel">${text(messages.skipToContent)}</a>
     <div id="a11y-status" class="sr-only" aria-live="polite" aria-atomic="true"></div>
     <div class="app-root">
       <div id="sidebar-overlay" class="sidebar-overlay" aria-hidden="true" hidden></div>
-      <aside id="sidebar-panel" class="sidebar" role="complementary" aria-label="문서 탐색기 패널">
+      <aside id="sidebar-panel" class="sidebar" role="complementary" aria-label="${text(messages.documentExplorerPanel)}">
         <div class="sidebar-header">
           <div class="sidebar-heading">
             <h1 class="sidebar-title">${escapeHtmlAttribute(appTitle)}</h1>
-            <button id="sidebar-close" class="sidebar-close" type="button" aria-label="탐색기 닫기">
+            <button id="sidebar-close" class="sidebar-close" type="button" aria-label="${text(messages.closeExplorer)}">
               ${renderAppIcon("close")}
             </button>
           </div>
           <label class="sidebar-branch" for="sidebar-branch-select">
-            <span class="branch-label">Branch</span>
+            <span class="branch-label">${text(messages.branchLabel)}</span>
             <select id="sidebar-branch-select" class="branch-select"></select>
           </label>
         </div>
@@ -264,26 +268,26 @@ ${headMeta}
               type="search"
               autocomplete="off"
               spellcheck="false"
-              aria-label="문서 검색"
-              placeholder="Search"
+              aria-label="${text(messages.searchDocuments)}"
+              placeholder="${text(messages.searchPlaceholder)}"
             />
-            <button id="tree-search-clear" class="tree-search-clear" type="button" aria-label="검색 지우기" title="검색 지우기" hidden>
+            <button id="tree-search-clear" class="tree-search-clear" type="button" aria-label="${text(messages.clearSearch)}" title="${text(messages.clearSearch)}" hidden>
               ${renderAppIcon("close")}
             </button>
           </div>
           <div id="sidebar-search-actions" class="sidebar-search-actions" aria-live="polite" hidden>
             <span id="tree-search-count" class="tree-search-count"></span>
             <div class="tree-search-nav">
-              <button id="tree-search-prev" class="tree-search-step" type="button" aria-label="이전 검색 결과" title="이전 검색 결과" disabled>
+              <button id="tree-search-prev" class="tree-search-step" type="button" aria-label="${text(messages.previousSearchResult)}" title="${text(messages.previousSearchResult)}" disabled>
                 ${renderAppIcon("chevron-up")}
               </button>
-              <button id="tree-search-next" class="tree-search-step" type="button" aria-label="다음 검색 결과" title="다음 검색 결과" disabled>
+              <button id="tree-search-next" class="tree-search-step" type="button" aria-label="${text(messages.nextSearchResult)}" title="${text(messages.nextSearchResult)}" disabled>
                 ${renderAppIcon("chevron-down")}
               </button>
             </div>
           </div>
         </div>
-        <nav id="tree-root" class="tree-root" aria-label="문서 탐색기" tabindex="0"></nav>
+        <nav id="tree-root" class="tree-root" aria-label="${text(messages.documentExplorer)}" tabindex="0"></nav>
         <div class="sidebar-tools">
           <button
             id="settings-toggle"
@@ -291,41 +295,41 @@ ${headMeta}
             type="button"
             aria-controls="sidebar-settings"
             aria-expanded="false"
-            aria-label="탐색기 설정 열기"
+            aria-label="${text(messages.openExplorerSettings)}"
           >
             ${renderAppIcon("settings")}
           </button>
-          <section id="sidebar-settings" class="sidebar-settings" hidden aria-label="탐색기 설정">
-            <p class="sidebar-settings-title">탐색기 설정</p>
+          <section id="sidebar-settings" class="sidebar-settings" hidden aria-label="${text(messages.explorerSettings)}">
+            <p class="sidebar-settings-title">${text(messages.explorerSettings)}</p>
             <fieldset class="settings-group">
-              <legend>메뉴 버튼 위치</legend>
+              <legend>${text(messages.menuButtonPosition)}</legend>
               <label class="settings-option">
                 <input type="radio" name="menu-toggle-position" value="right" checked />
-                <span>오른쪽 하단</span>
+                <span>${text(messages.bottomRight)}</span>
               </label>
               <label class="settings-option">
                 <input type="radio" name="menu-toggle-position" value="left" />
-                <span>왼쪽 하단</span>
+                <span>${text(messages.bottomLeft)}</span>
               </label>
             </fieldset>
             <fieldset class="settings-group">
-              <legend>테마</legend>
-              <div class="settings-segment" role="radiogroup" aria-label="테마 선택">
+              <legend>${text(messages.theme)}</legend>
+              <div class="settings-segment" role="radiogroup" aria-label="${text(messages.selectTheme)}">
                 <label class="settings-segment-option">
                   <input type="radio" name="theme-mode" value="light" />
-                  <span>Light</span>
+                  <span>${text(messages.lightTheme)}</span>
                 </label>
                 <label class="settings-segment-option">
                   <input type="radio" name="theme-mode" value="system" checked />
-                  <span>System</span>
+                  <span>${text(messages.systemTheme)}</span>
                 </label>
                 <label class="settings-segment-option">
                   <input type="radio" name="theme-mode" value="dark" />
-                  <span>Dark</span>
+                  <span>${text(messages.darkTheme)}</span>
                 </label>
               </div>
             </fieldset>
-            <button id="settings-close" class="settings-close" type="button">닫기</button>
+            <button id="settings-close" class="settings-close" type="button">${text(messages.close)}</button>
           </section>
         </div>
       </aside>
@@ -335,7 +339,7 @@ ${headMeta}
         role="separator"
         aria-orientation="vertical"
         aria-controls="sidebar-panel viewer-panel"
-        aria-label="탐색기 너비 조절"
+        aria-label="${text(messages.resizeExplorer)}"
         tabindex="0"
       ></div>
       <main id="viewer-panel" class="viewer" tabindex="-1">
@@ -345,20 +349,20 @@ ${headMeta}
           type="button"
           aria-controls="sidebar-panel"
           aria-expanded="false"
-          aria-label="탐색기 열기"
+          aria-label="${text(messages.openExplorer)}"
         >
           ${renderAppIcon("menu")}
-          <span>Files</span>
+          <span>${text(messages.files)}</span>
         </button>
         <div class="viewer-container">
-          <nav id="viewer-breadcrumb" class="viewer-breadcrumb" aria-label="경로">${initialBreadcrumb}</nav>
+          <nav id="viewer-breadcrumb" class="viewer-breadcrumb" aria-label="${text(messages.path)}">${initialBreadcrumb}</nav>
           <header id="viewer-header" class="viewer-header">
             <h1 id="viewer-title" class="viewer-title">${initialTitle}</h1>
             <div id="viewer-meta" class="viewer-meta">${initialMeta}</div>
           </header>
           <article id="viewer-content" class="viewer-content">${initialContent}</article>
-          <section id="viewer-backlinks" class="viewer-backlinks" aria-label="문서를 참조한 링크" ${initialBacklinks ? "" : "hidden"}>${initialBacklinks}</section>
-          <nav id="viewer-nav" class="viewer-nav" aria-label="문서 이전/다음 탐색">${initialNav}</nav>
+          <section id="viewer-backlinks" class="viewer-backlinks" aria-label="${text(messages.referencingDocuments)}" ${initialBacklinks ? "" : "hidden"}>${initialBacklinks}</section>
+          <nav id="viewer-nav" class="viewer-nav" aria-label="${text(messages.documentNavigation)}">${initialNav}</nav>
         </div>
       </main>
     </div>
@@ -375,9 +379,13 @@ export function render404Html(
   assets: AppShellAssets = DEFAULT_ASSETS,
   homeHref = "/",
   siteTitle = DEFAULT_SITE_TITLE,
+  locale: unknown = undefined,
 ): string {
+  const normalizedLocale = normalizeUiLocale(locale);
+  const messages = getUiMessages(normalizedLocale);
+  const text = escapeHtmlAttribute;
   return `<!doctype html>
-<html lang="ko">
+<html lang="${normalizedLocale}">
   <head>
     <meta charset="UTF-8" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
@@ -391,10 +399,10 @@ export function render404Html(
         ${renderAppIcon("folder-off")}
       </div>
       <h1>404</h1>
-      <p>요청한 문서를 찾을 수 없습니다.</p>
+      <p>${text(messages.notFoundMessage)}</p>
       <a href="${escapeHtmlAttribute(homeHref)}" class="not-found-link">
         ${renderAppIcon("home")}
-        홈으로 이동
+        ${text(messages.goHome)}
       </a>
     </main>
   </body>

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import type { RuntimeLayoutConfig } from "./defaults";
+import type { UiLocale } from "./i18n";
 
 export type ImagePolicy = "keep" | "omit-local";
 
@@ -50,6 +51,7 @@ export interface UserConfig {
     categoryPath?: string;
   };
   ui?: {
+    locale?: UiLocale;
     newWithinDays?: number;
     recentLimit?: number;
   };
@@ -78,6 +80,7 @@ export interface BuildOptions {
   staticPaths: string[];
   newWithinDays: number;
   recentLimit: number;
+  locale: UiLocale;
   defaultBranch: string;
   siteTitle?: string;
   pinnedMenu: PinnedMenuOption | null;
@@ -158,6 +161,7 @@ export interface Manifest {
   schemaVersion: 2;
   siteTitle: string;
   pathBase: string;
+  locale: UiLocale;
   defaultBranch: string;
   branches: string[];
   mermaid: {

--- a/src/view-contract.ts
+++ b/src/view-contract.ts
@@ -1,4 +1,5 @@
 import { DEFAULT_BRANCH, DEFAULT_SITE_TITLE } from "./defaults";
+import { getUiMessages, type UiMessages } from "./i18n";
 import { renderAppIcon } from "./icons";
 
 export interface ViewBacklinkContract {
@@ -305,21 +306,25 @@ function renderMeta(model: ViewChromeModel["meta"]): string {
   return items.join("");
 }
 
-function renderNavLink(link: ViewLinkModel, direction: "previous" | "next"): string {
+function renderNavLink(
+  link: ViewLinkModel,
+  direction: "previous" | "next",
+  messages: UiMessages,
+): string {
   if (direction === "previous") {
-    return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">${renderAppIcon("arrow-left")}Previous</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
+    return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-prev" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">${renderAppIcon("arrow-left")}${escapeViewText(messages.previous)}</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
   }
-  return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">Next${renderAppIcon("arrow-right")}</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
+  return `<a href="${escapeViewAttribute(link.href)}" class="nav-link nav-link-next" data-route="${escapeViewAttribute(link.route)}"><div class="nav-link-label">${escapeViewText(messages.next)}${renderAppIcon("arrow-right")}</div><div class="nav-link-title">${escapeViewText(link.title)}</div></a>`;
 }
 
-function renderNavigation(model: ViewChromeModel["navigation"]): string {
+function renderNavigation(model: ViewChromeModel["navigation"], messages: UiMessages): string {
   return [
-    model.previous ? renderNavLink(model.previous, "previous") : "",
-    model.next ? renderNavLink(model.next, "next") : "",
+    model.previous ? renderNavLink(model.previous, "previous", messages) : "",
+    model.next ? renderNavLink(model.next, "next", messages) : "",
   ].join("");
 }
 
-function renderBacklinks(model: ViewChromeModel["backlinks"]): string {
+function renderBacklinks(model: ViewChromeModel["backlinks"], messages: UiMessages): string {
   if (model.length === 0) {
     return "";
   }
@@ -331,7 +336,7 @@ function renderBacklinks(model: ViewChromeModel["backlinks"]): string {
       return `<li class="backlinks-item"><a href="${escapeViewAttribute(backlink.href)}" class="backlink-link" data-route="${escapeViewAttribute(backlink.route)}">${prefix}<span class="backlink-text">${escapeViewText(backlink.title)}</span></a></li>`;
     })
     .join("");
-  return `<h2 class="backlinks-title">Backlinks</h2><ul class="backlinks-list">${items}</ul>`;
+  return `<h2 class="backlinks-title">${escapeViewText(messages.backlinks)}</h2><ul class="backlinks-list">${items}</ul>`;
 }
 
 export function renderViewChrome(options: {
@@ -339,13 +344,15 @@ export function renderViewChrome(options: {
   doc: ViewDocContract;
   docs: readonly ViewDocContract[];
   pathBase: unknown;
+  locale?: unknown;
 }): RenderedViewChrome {
   const model = createViewChromeModel(options);
+  const messages = getUiMessages(options.locale);
   return {
     breadcrumbHtml: renderBreadcrumb(model.breadcrumb),
     metaHtml: renderMeta(model.meta),
-    backlinksHtml: renderBacklinks(model.backlinks),
-    navHtml: renderNavigation(model.navigation),
+    backlinksHtml: renderBacklinks(model.backlinks, messages),
+    navHtml: renderNavigation(model.navigation, messages),
   };
 }
 

--- a/tests/e2e/build-phases.spec.ts
+++ b/tests/e2e/build-phases.spec.ts
@@ -10,6 +10,7 @@ const options: BuildOptions = {
   outDir: "/output",
   exclude: [],
   staticPaths: [],
+  locale: "ko",
   newWithinDays: 7,
   recentLimit: 5,
   defaultBranch: "dev",
@@ -67,7 +68,8 @@ test.describe("build phase contracts", () => {
       { id: "source", route: "/SOURCE/", title: "Source", prefix: "SOURCE" },
     ]);
     expect(graph.wikiLookup.byTitle.get("target")).toEqual([target]);
-    expect(graph.tree[0]).toMatchObject({ type: "folder", name: "Recent", virtual: true });
+    expect(graph.tree[0]).toMatchObject({ type: "folder", name: "최근 문서", virtual: true });
+    expect(graph.manifest.locale).toBe("ko");
   });
 
   test("custom defaultBranch가 manifest, branch order, home selection에 일관되게 적용된다", () => {

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -364,6 +364,7 @@ cached code
         cache.sources["icon-cache.md"].rawHash,
         "/CACHE-ICON/",
         "github-dark",
+        "ko",
         "omit-local",
         "wikilinks-on",
         "safe-html-v1",

--- a/tests/e2e/local-icon-system.spec.ts
+++ b/tests/e2e/local-icon-system.spec.ts
@@ -99,10 +99,10 @@ test.describe("local SVG icon system", () => {
     }
 
     const copyButton = page.locator(".code-copy").first();
-    await expect(copyButton).toHaveAccessibleName("Copy code");
+    await expect(copyButton).toHaveAccessibleName("코드 복사");
     await expect(copyButton.locator("use")).toHaveAttribute("href", "#eiam-icon-copy");
     await copyButton.click();
-    await expect(copyButton).toHaveAccessibleName("Copied");
+    await expect(copyButton).toHaveAccessibleName("복사됨");
     await expect(copyButton.locator("use")).toHaveAttribute("href", "#eiam-icon-check");
     await expect(copyButton).toHaveClass(/copied/);
   });

--- a/tests/e2e/locale-copy.spec.ts
+++ b/tests/e2e/locale-copy.spec.ts
@@ -1,0 +1,251 @@
+import { spawnSync } from "node:child_process";
+import fs from "node:fs";
+import { createServer, type IncomingMessage, type ServerResponse } from "node:http";
+import type { AddressInfo } from "node:net";
+import os from "node:os";
+import path from "node:path";
+import { expect, test } from "@playwright/test";
+import type { Manifest } from "../../src/types";
+import { waitForAppReady, waitForTreeReady } from "./utils/app-ready";
+
+interface CliResult {
+  status: number | null;
+  output: string;
+}
+
+function writeText(filePath: string, content: string): void {
+  fs.mkdirSync(path.dirname(filePath), { recursive: true });
+  fs.writeFileSync(filePath, content, "utf8");
+}
+
+function runBuild(cwd: string, cliPath: string, vaultDir: string, outDir: string): CliResult {
+  const result = spawnSync("bun", [cliPath, "build", "--vault", vaultDir, "--out", outDir], {
+    cwd,
+    encoding: "utf8",
+  });
+  return {
+    status: result.status,
+    output: `${result.stdout ?? ""}${result.stderr ?? ""}`,
+  };
+}
+
+function writeConfig(workDir: string, locale: "ko" | "en"): void {
+  writeText(
+    path.join(workDir, "blog.config.mjs"),
+    `export default {
+  ui: { locale: ${JSON.stringify(locale)} },
+  markdown: { mermaid: { enabled: false } },
+};
+`,
+  );
+}
+
+function writeVault(vaultDir: string): void {
+  writeText(
+    path.join(vaultDir, "alpha.md"),
+    `---
+publish: true
+prefix: LC-01
+category_path: locale
+title: English Alpha
+date: 2026-07-18
+---
+
+# English Alpha
+
+[[English Beta]]
+
+![Local diagram](local.png)
+
+\`\`\`text
+localized copy control
+\`\`\`
+`,
+  );
+  writeText(
+    path.join(vaultDir, "beta.md"),
+    `---
+publish: true
+prefix: LC-02
+category_path: locale
+title: English Beta
+date: 2026-07-19
+---
+
+# English Beta
+
+Second document.
+
+\`\`\`text
+client navigation copy control
+\`\`\`
+`,
+  );
+}
+
+function contentType(filePath: string): string {
+  if (filePath.endsWith(".html")) return "text/html; charset=utf-8";
+  if (filePath.endsWith(".json")) return "application/json; charset=utf-8";
+  if (filePath.endsWith(".js")) return "text/javascript; charset=utf-8";
+  if (filePath.endsWith(".css")) return "text/css; charset=utf-8";
+  return "application/octet-stream";
+}
+
+function toFilePath(outDir: string, pathname: string): string {
+  const clean = pathname.replace(/^\/+/, "");
+  if (!clean) return path.join(outDir, "index.html");
+
+  const direct = path.join(outDir, clean);
+  if (fs.existsSync(direct) && fs.statSync(direct).isFile()) return direct;
+
+  const withIndex = path.join(outDir, clean, "index.html");
+  return fs.existsSync(withIndex) ? withIndex : path.join(outDir, "404.html");
+}
+
+async function startStaticServer(
+  outDir: string,
+): Promise<{ baseUrl: string; close: () => Promise<void> }> {
+  const server = createServer((req: IncomingMessage, res: ServerResponse) => {
+    const requestUrl = new URL(req.url ?? "/", "http://127.0.0.1");
+    const filePath = toFilePath(outDir, requestUrl.pathname);
+    if (!fs.existsSync(filePath)) {
+      res.statusCode = 404;
+      res.end("Not Found");
+      return;
+    }
+    res.statusCode = filePath.endsWith("404.html") ? 404 : 200;
+    res.setHeader("Content-Type", contentType(filePath));
+    res.end(fs.readFileSync(filePath));
+  });
+
+  await new Promise<void>((resolve, reject) => {
+    server.once("error", reject);
+    server.listen(0, "127.0.0.1", resolve);
+  });
+  const address = server.address() as AddressInfo;
+  return {
+    baseUrl: `http://127.0.0.1:${address.port}`,
+    close: () =>
+      new Promise<void>((resolve, reject) => {
+        server.close((error) => (error ? reject(error) : resolve()));
+        server.closeAllConnections();
+      }),
+  };
+}
+
+test.describe("configurable UI locale and copy", () => {
+  const repoRoot = process.cwd();
+  const cliPath = path.join(repoRoot, "src/cli.ts");
+  let workDir = "";
+  let outDir = "";
+  let manifest: Manifest;
+  let englishRouteHtml = "";
+  let englishNotFoundHtml = "";
+  let koreanContentHtml = "";
+  let localeRebuildOutput = "";
+  let server: { baseUrl: string; close: () => Promise<void> } | null = null;
+
+  test.beforeAll(async () => {
+    workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-locale-copy-"));
+    const vaultDir = path.join(workDir, "vault");
+    outDir = path.join(workDir, "dist");
+    writeVault(vaultDir);
+
+    writeConfig(workDir, "en");
+    const firstEnglish = runBuild(workDir, cliPath, vaultDir, outDir);
+    expect(firstEnglish.status, firstEnglish.output).toBe(0);
+
+    writeConfig(workDir, "ko");
+    const korean = runBuild(workDir, cliPath, vaultDir, outDir);
+    expect(korean.status, korean.output).toBe(0);
+    localeRebuildOutput = korean.output;
+    const koreanManifest = JSON.parse(
+      fs.readFileSync(path.join(outDir, "manifest.json"), "utf8"),
+    ) as Manifest;
+    koreanContentHtml = fs.readFileSync(
+      path.join(outDir, koreanManifest.docsById[koreanManifest.docIds[0]].contentUrl),
+      "utf8",
+    );
+
+    writeConfig(workDir, "en");
+    const finalEnglish = runBuild(workDir, cliPath, vaultDir, outDir);
+    expect(finalEnglish.status, finalEnglish.output).toBe(0);
+
+    manifest = JSON.parse(fs.readFileSync(path.join(outDir, "manifest.json"), "utf8")) as Manifest;
+    englishRouteHtml = fs.readFileSync(path.join(outDir, "LC-01", "index.html"), "utf8");
+    englishNotFoundHtml = fs.readFileSync(path.join(outDir, "404.html"), "utf8");
+    server = await startStaticServer(outDir);
+  });
+
+  test.afterAll(async () => {
+    await server?.close();
+    if (workDir) fs.rmSync(workDir, { recursive: true, force: true });
+  });
+
+  test("build output and content cache follow ui.locale", () => {
+    expect(manifest.locale).toBe("en");
+    expect(manifest.tree[0]).toMatchObject({ name: "Recent", virtual: true });
+    expect(englishRouteHtml).toContain('<html lang="en">');
+    expect(englishRouteHtml).toContain(">Branch<");
+    expect(englishRouteHtml).toContain('aria-label="Search documents"');
+    expect(englishRouteHtml).toContain('aria-label="Copy code"');
+    expect(englishRouteHtml).toContain("(image omitted: Local diagram)");
+    expect(englishNotFoundHtml).toContain('<html lang="en">');
+    expect(englishNotFoundHtml).toContain("The requested document could not be found.");
+    expect(englishNotFoundHtml).toContain("Go home");
+
+    expect(localeRebuildOutput).toContain("total=2 rendered=2 skipped=0");
+    expect(koreanContentHtml).toContain('aria-label="코드 복사"');
+    expect(koreanContentHtml).toContain("(이미지 생략: Local diagram)");
+  });
+
+  test("client navigation and dynamic controls retain the English catalog", async ({
+    context,
+    page,
+  }) => {
+    expect(server).not.toBeNull();
+    await context.grantPermissions(["clipboard-read", "clipboard-write"], {
+      origin: new URL(server!.baseUrl).origin,
+    });
+    await page.goto(`${server!.baseUrl}/LC-01/`);
+    await waitForAppReady(page);
+    await waitForTreeReady(page);
+
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    const branchSelect = page.getByRole("combobox", { name: "Branch" });
+    await expect(branchSelect).toBeVisible();
+    await expect(branchSelect.locator("option").first()).toContainText("(default)");
+    await expect(page.getByRole("button", { name: "Open explorer settings" })).toBeVisible();
+
+    await page.getByRole("searchbox", { name: "Search documents" }).fill("English");
+    await expect(page.locator("#tree-search-count")).toHaveText(/[1-9]\d* matches/);
+
+    const copyButton = page.locator(".code-copy").first();
+    await expect(copyButton).toHaveAccessibleName("Copy code");
+    await copyButton.click();
+    await expect(copyButton).toHaveAccessibleName("Copied");
+
+    await page.locator("#viewer-nav .nav-link-next").click();
+    await expect(page).toHaveURL(`${server!.baseUrl}/LC-02/`);
+    await expect(page.locator("#viewer-title")).toHaveText("English Beta");
+    await expect(page.locator("#viewer-nav .nav-link-prev .nav-link-label")).toContainText(
+      "Previous",
+    );
+    await expect(page.locator("#viewer-backlinks .backlinks-title")).toHaveText("Backlinks");
+    await expect(page.locator("#a11y-status")).toHaveText(
+      "Navigation complete: opened English Beta.",
+    );
+    await expect(page.locator(".code-copy").first()).toHaveAccessibleName("Copy code");
+  });
+
+  test("English 404 remains localized without application JavaScript", async ({ page }) => {
+    expect(server).not.toBeNull();
+    const response = await page.goto(`${server!.baseUrl}/missing/`);
+    expect(response?.status()).toBe(404);
+    await expect(page.locator("html")).toHaveAttribute("lang", "en");
+    await expect(page.locator(".not-found p")).toHaveText(
+      "The requested document could not be found.",
+    );
+    await expect(page.getByRole("link", { name: "Go home" })).toBeVisible();
+  });
+});

--- a/tests/e2e/manifest-adapter.spec.ts
+++ b/tests/e2e/manifest-adapter.spec.ts
@@ -24,6 +24,7 @@ test.describe("manifest schema adapter", () => {
     });
 
     expect(normalized).not.toBeNull();
+    expect(normalized?.locale).toBe("ko");
     expect(getManifestDocs(normalized).map((doc) => doc.route)).toEqual(["/B/", "/A/"]);
   });
 
@@ -87,5 +88,26 @@ test.describe("manifest schema adapter", () => {
         docsById: {},
       }),
     ).toBeNull();
+  });
+
+  test("locale은 지원값을 유지하고 이전 payload에는 한국어 fallback을 적용한다", () => {
+    expect(
+      normalizeManifestPayload({
+        ...envelope,
+        schemaVersion: 2,
+        locale: "en",
+        docIds: [],
+        docsById: {},
+      })?.locale,
+    ).toBe("en");
+    expect(
+      normalizeManifestPayload({
+        ...envelope,
+        schemaVersion: 2,
+        locale: "fr",
+        docIds: [],
+        docsById: {},
+      })?.locale,
+    ).toBe("ko");
   });
 });

--- a/tests/e2e/path-base-routing.spec.ts
+++ b/tests/e2e/path-base-routing.spec.ts
@@ -210,7 +210,7 @@ test.describe("pathBase 정식 지원", () => {
 
       const setupRow = page
         .locator(
-          '#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]',
+          '#tree-root [data-type="item"][data-item-type="file"][data-item-path="최근 문서/BC-VO-02 Setup Guide"]',
         )
         .first();
       await expect(setupRow).toBeVisible();

--- a/tests/e2e/runtime-controller-lifecycle.spec.ts
+++ b/tests/e2e/runtime-controller-lifecycle.spec.ts
@@ -416,7 +416,7 @@ test.describe("runtime controller module contracts", () => {
     controller.setup();
     expect(branchSelect.children).toHaveLength(2);
     expect(branchSelect.children.map((option) => option.textContent)).toEqual([
-      "dev (default)",
+      "dev (기본값)",
       "main",
     ]);
     expect(branchSelect.value).toBe("dev");

--- a/tests/e2e/runtime-defaults.spec.ts
+++ b/tests/e2e/runtime-defaults.spec.ts
@@ -9,6 +9,7 @@ import {
   DEFAULT_RUNTIME_LAYOUT,
   DEFAULT_SITE_TITLE,
 } from "../../src/defaults";
+import { DEFAULT_UI_LOCALE } from "../../src/i18n";
 import { resolveMermaidConfig } from "../../src/runtime/mermaid-controller.js";
 import { createNavigationState } from "../../src/runtime/navigation-state.js";
 import { resolveSiteTitle } from "../../src/runtime/runtime-bootstrap.js";
@@ -91,6 +92,7 @@ test("default와 custom config가 emitted runtime defaults를 같은 경로로 �
     repoRoot,
     `export default {
   defaultBranch: " MAIN ",
+  ui: { locale: "en" },
   seo: { siteName: "Custom Notes" },
   markdown: {
     mermaid: {
@@ -105,12 +107,14 @@ test("default와 custom config가 emitted runtime defaults를 같은 경로로 �
 
   expect(defaults.manifest).toMatchObject({
     defaultBranch: DEFAULT_BRANCH,
+    locale: DEFAULT_UI_LOCALE,
     siteTitle: DEFAULT_SITE_TITLE,
     mermaid: DEFAULT_MERMAID_CONFIG,
     layout: DEFAULT_RUNTIME_LAYOUT,
   });
   expect(custom.manifest).toMatchObject({
     defaultBranch: "main",
+    locale: "en",
     siteTitle: "Custom Notes",
     mermaid: {
       enabled: false,
@@ -134,8 +138,11 @@ test("default와 custom config가 emitted runtime defaults를 같은 경로로 �
   expect(clampDesktopSidebarWidth(9999, 1440, custom.manifest.layout)).toBe(750);
 
   expect(custom.indexHtml).toContain("Custom Notes");
+  expect(custom.indexHtml).toContain('<html lang="en">');
+  expect(defaults.indexHtml).toContain('<html lang="ko">');
   expect(custom.indexHtml).toContain('"name":"Custom Notes"');
   expect(custom.notFoundHtml).toContain("<title>404 - Custom Notes</title>");
+  expect(custom.notFoundHtml).toContain("The requested document could not be found.");
   expect(custom.appCss).toBe(defaults.appCss);
   expect(custom.appJs).toBe(defaults.appJs);
   expect(defaults.appCss).toContain("--desktop-sidebar-default:420px");

--- a/tests/e2e/runtime-xss-guard.spec.ts
+++ b/tests/e2e/runtime-xss-guard.spec.ts
@@ -14,7 +14,7 @@ test.describe("런타임 렌더링 XSS 가드", () => {
     await expect(
       page
         .locator(
-          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="Recent/BC-VO-02 Setup Guide"]',
+          '#tree-root [data-type="item"][data-item-type="file"][data-item-selected][data-item-path="최근 문서/BC-VO-02 Setup Guide"]',
         )
         .first(),
     ).toBeVisible();

--- a/tests/e2e/shiki-loading.spec.ts
+++ b/tests/e2e/shiki-loading.spec.ts
@@ -15,6 +15,7 @@ function buildOptions(shikiTheme = "github-dark"): BuildOptions {
     outDir: "dist",
     exclude: [],
     staticPaths: [],
+    locale: "ko",
     newWithinDays: 7,
     recentLimit: 5,
     defaultBranch: "dev",

--- a/tests/e2e/sidebar-chrome.spec.ts
+++ b/tests/e2e/sidebar-chrome.spec.ts
@@ -11,11 +11,11 @@ test.describe("purposeful sidebar chrome", () => {
     await waitForTreeReady(page);
     const manifest = await getInitialManifest(page);
 
-    const branchSelect = page.getByRole("combobox", { name: "Branch" });
+    const branchSelect = page.getByRole("combobox", { name: "브랜치" });
     await expect(branchSelect).toBeVisible();
     await expect(branchSelect).toHaveValue(manifest.defaultBranch);
     await expect(branchSelect.locator("option")).toHaveCount(2);
-    await expect(branchSelect.locator("option").first()).toContainText("(default)");
+    await expect(branchSelect.locator("option").first()).toContainText("(기본값)");
 
     for (const removedChrome of [
       ".icon-terminal",

--- a/tests/e2e/tree-search.spec.ts
+++ b/tests/e2e/tree-search.spec.ts
@@ -13,7 +13,7 @@ test.describe("Trees sidebar search", () => {
     const searchNext = page.locator("#tree-search-next");
     const setupRow = page
       .locator(
-        '#tree-root [data-type="item"][data-item-type="file"][data-item-path="Recent/BC-VO-02 Setup Guide"]',
+        '#tree-root [data-type="item"][data-item-type="file"][data-item-path="최근 문서/BC-VO-02 Setup Guide"]',
       )
       .first();
 

--- a/tests/unit/cache-guards.test.ts
+++ b/tests/unit/cache-guards.test.ts
@@ -38,6 +38,7 @@ function createBuildOptions(vaultDir: string, outDir: string): BuildOptions {
       theme: "default",
     },
     layout: { ...DEFAULT_RUNTIME_LAYOUT },
+    locale: "ko",
     newWithinDays: 7,
     outDir,
     pinnedMenu: null,

--- a/tests/unit/config-validation.test.ts
+++ b/tests/unit/config-validation.test.ts
@@ -31,6 +31,7 @@ describe("user config validation", () => {
           categoryPath: " news / releases/ ",
         },
         ui: {
+          locale: " EN ",
           newWithinDays: 0,
           recentLimit: 12,
         },
@@ -80,6 +81,7 @@ describe("user config validation", () => {
         categoryPath: "news/releases",
       },
       ui: {
+        locale: "en",
         newWithinDays: 0,
         recentLimit: 12,
       },
@@ -195,6 +197,12 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
       receivedType: "boolean",
     },
     { name: "ui", config: { ui: [] }, field: "ui", receivedType: "array" },
+    {
+      name: "ui.locale",
+      config: { ui: { locale: 1 } },
+      field: "ui.locale",
+      receivedType: "number",
+    },
     {
       name: "ui.newWithinDays",
       config: { ui: { newWithinDays: "7" } },
@@ -438,6 +446,18 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
     });
   });
 
+  test("accepts only the documented UI locales", () => {
+    expect(() => validateUserConfig({ ui: { locale: "   " } }, () => {})).toThrow(
+      '"ui.locale" must be a non-empty string',
+    );
+    expect(() => validateUserConfig({ ui: { locale: "fr" } }, () => {})).toThrow(
+      '"ui.locale" must be one of "ko", "en"',
+    );
+    expect(validateUserConfig({ ui: { locale: " KO " } }, () => {})).toEqual({
+      ui: { locale: "ko", newWithinDays: undefined, recentLimit: undefined },
+    });
+  });
+
   test("validates the complete user config even when CLI values would override it", () => {
     expect(() =>
       resolveBuildOptions(
@@ -456,6 +476,7 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
         vaultDir: "./vault",
         outDir: "./site",
         exclude: ["private/**"],
+        ui: { locale: "en" },
         seo: { siteName: "Notes without canonical URLs" },
       },
       null,
@@ -466,6 +487,7 @@ export const ui = { newWithinDays: 2, recentLimit: 9 };
     expect(options.outDir).toBe(path.join("/workspace", "site"));
     expect(options.exclude).toEqual([".obsidian/**", "private/**", "drafts/**"]);
     expect(options.defaultBranch).toBe("dev");
+    expect(options.locale).toBe("en");
     expect(options.siteTitle).toBe("Notes without canonical URLs");
     expect(options.layout).toMatchObject({
       compactBreakpointPx: 1024,

--- a/tests/unit/i18n.test.ts
+++ b/tests/unit/i18n.test.ts
@@ -1,0 +1,38 @@
+import { describe, expect, test } from "bun:test";
+import {
+  DEFAULT_UI_LOCALE,
+  getUiMessages,
+  normalizeUiLocale,
+  UI_MESSAGE_CATALOG,
+  type UiMessageCatalog,
+} from "../../src/i18n";
+
+describe("UI message catalog", () => {
+  test("ships complete Korean and English catalogs", () => {
+    expect(Object.keys(UI_MESSAGE_CATALOG.en).sort()).toEqual(
+      Object.keys(UI_MESSAGE_CATALOG.ko).sort(),
+    );
+    expect(getUiMessages("ko").copyCode).toBe("코드 복사");
+    expect(getUiMessages("en").copyCode).toBe("Copy code");
+    expect(getUiMessages("en").searchMatches(1)).toBe("1 match");
+    expect(getUiMessages("en").searchMatches(2)).toBe("2 matches");
+  });
+
+  test("falls back to Korean deterministically for unknown locales and missing entries", () => {
+    const {
+      next: _next,
+      searchMatches: _searchMatches,
+      ...incompleteEnglish
+    } = UI_MESSAGE_CATALOG.en;
+    const incompleteCatalog: UiMessageCatalog = {
+      ...UI_MESSAGE_CATALOG,
+      en: incompleteEnglish,
+    };
+
+    expect(normalizeUiLocale(" EN ")).toBe("en");
+    expect(normalizeUiLocale("en-US")).toBe(DEFAULT_UI_LOCALE);
+    expect(getUiMessages("unknown")).toBe(getUiMessages("ko"));
+    expect(getUiMessages("en", incompleteCatalog).next).toBe(getUiMessages("ko").next);
+    expect(getUiMessages("en", incompleteCatalog).searchMatches(3)).toBe("3개 일치");
+  });
+});

--- a/tests/unit/manifest-adapter.test.ts
+++ b/tests/unit/manifest-adapter.test.ts
@@ -49,6 +49,7 @@ describe("manifest transforms", () => {
     });
 
     expect(manifest).not.toBeNull();
+    expect(manifest?.locale).toBe("ko");
     expect(getManifestDocs(manifest).map((doc) => doc.id)).toEqual(["b", "a"]);
   });
 
@@ -77,6 +78,24 @@ describe("manifest transforms", () => {
     expect(getRuntimeManifestDocs(manifest, Date.parse("2026-07-19T00:00:00Z"))[0]?.isNew).toBe(
       true,
     );
+  });
+
+  test("preserves supported locales and deterministically falls back for legacy values", () => {
+    const current = normalizeManifestPayload({
+      ...envelope,
+      locale: "en",
+      docIds: [],
+      docsById: {},
+    });
+    const unsupported = normalizeManifestPayload({
+      ...envelope,
+      locale: "fr",
+      docIds: [],
+      docsById: {},
+    });
+
+    expect(current?.locale).toBe("en");
+    expect(unsupported?.locale).toBe("ko");
   });
 
   test("rejects dangling, duplicate, and unsupported document indexes", () => {

--- a/tests/unit/runtime-defaults.test.ts
+++ b/tests/unit/runtime-defaults.test.ts
@@ -9,12 +9,14 @@ import {
   DEFAULT_SITE_TITLE,
   resolveRuntimeLayoutConfig,
 } from "../../src/defaults";
+import { DEFAULT_UI_LOCALE } from "../../src/i18n";
 
 describe("canonical runtime defaults", () => {
   test("exposes one immutable default payload", () => {
     expect(DEFAULT_RUNTIME_CONFIG).toEqual({
       defaultBranch: DEFAULT_BRANCH,
       siteTitle: DEFAULT_SITE_TITLE,
+      locale: DEFAULT_UI_LOCALE,
       mermaid: DEFAULT_MERMAID_CONFIG,
       layout: DEFAULT_RUNTIME_LAYOUT,
     });


### PR DESCRIPTION
## Summary

- add validated `ui.locale` support for Korean (default) and English
- set app and 404 HTML `lang` from the resolved UI locale
- centralize shell, view, tree, runtime, Markdown, code-copy, manifest-error, and Mermaid copy in one typed catalog
- apply deterministic Korean fallback to unknown runtime locales and missing catalog entries
- keep fixed UTC `YYYY-MM-DD HH:mm` date presentation documented for SSR/client parity
- include locale in rendered-content hashes so incremental locale changes refresh cached copy
- document the runtime payload delta and retain the combined JavaScript budget

## DnD checklist

- [x] App and 404 pages emit the configured HTML language
- [x] Built-in visible and accessibility copy is sourced from one catalog
- [x] Korean and English catalogs are supplied
- [x] Missing translations and legacy manifests fall back deterministically
- [x] SSR and client navigation render the same localized chrome
- [x] Date presentation has a documented fixed UTC format
- [x] Locale changes invalidate locale-sensitive Markdown fragments
- [x] English tree/search/copy/navigation/404 behavior is browser-tested

## Payload

- app before: 42,258 B raw / 14,756 B gzip
- app after: 48,086 B raw / 16,616 B gzip
- total JS after: 258,922 B raw / 75,173 B gzip
- app-specific guardrail: 50,000 B raw / 17,000 B gzip
- combined guardrail remains 260,000 B raw / 78,000 B gzip

## Validation

- `bun run typecheck`
- `bun run lint:source`
- `bun run format:check`
- `bun run lint:md:publish`
- `bun run test:unit` (87 passed)
- focused locale/browser regression (3 passed)
- affected existing E2E specs (33 passed)
- `bun run test:e2e` (103 passed)
- production build and size budget
- reproducibility check (18 files; stable digest `787abcb5aec5`)

Part of #37. Detailed acceptance criteria: #42.
