### PR TITLE
ci: pin the Bun toolchain for issue #44

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -35,6 +33,9 @@ jobs:
 
       - name: Run unit tests
         run: bun run test:unit
+
+      - name: Inspect package contents
+        run: bun pm pack --dry-run
 
       - name: Install Playwright browser
         run: bunx playwright install --with-deps chromium

--- a/.github/workflows/publish-bunx.yml
+++ b/.github/workflows/publish-bunx.yml
@@ -18,8 +18,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/release-single-file.yml
+++ b/.github/workflows/release-single-file.yml
@@ -28,8 +28,6 @@ jobs:
 
       - name: Setup Bun
         uses: oven-sh/setup-bun@v2
-        with:
-          bun-version: latest
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/README.ko.md
+++ b/README.ko.md
@@ -19,6 +19,10 @@ Everything-Is-A-Markdown은 로컬 Markdown 볼트를 정적 웹사이트로 빌
 
 ## 설치
 
+지원하는 Bun 버전의 단일 기준은 `package.json`의 정확한 `packageManager` 값입니다.
+CI와 릴리스 workflow도 `oven-sh/setup-bun`을 통해 같은 값을 읽습니다. 버전을 올릴 때는
+그 값 하나를 변경하고 install, build, package, unit, E2E 검증을 함께 통과해야 합니다.
+
 ```bash
 bun install
 ```

--- a/README.md
+++ b/README.md
@@ -45,10 +45,10 @@ If two notes normalize to the same public route, the builder keeps both and auto
 
 ## Requirements
 
-- `bun` installed
+- The exact Bun version declared by `packageManager` in `package.json`
 - A Markdown vault directory
 
-This repository is authored around Bun. The CLI entry point is `src/cli.ts`, and package scripts assume Bun is available.
+This repository is authored around Bun. The CLI entry point is `src/cli.ts`, and package scripts assume Bun is available. The exact `packageManager` value is the single source of truth for the supported version; GitHub Actions lets `oven-sh/setup-bun` read it directly, so CI and release jobs cannot silently move to a different Bun release. Toolchain upgrades must update that one value and pass install, build, package, unit, and E2E verification.
 
 ## Install
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,7 @@
 {
   "name": "@limcpf/everything-is-a-markdown",
   "version": "0.8.0",
+  "packageManager": "bun@1.3.14",
   "license": "MIT",
   "private": false,
   "type": "module",

--- a/renovate.json
+++ b/renovate.json
@@ -1,0 +1,15 @@
+{
+  "$schema": "https://docs.renovatebot.com/renovate-schema.json",
+  "extends": ["config:recommended"],
+  "customManagers": [
+    {
+      "customType": "regex",
+      "description": "Keep the supported Bun runtime upgrade explicit",
+      "managerFilePatterns": ["/^package\\.json$/"],
+      "matchStrings": ["\"packageManager\"\\s*:\\s*\"bun@(?<currentValue>[^\"]+)\""],
+      "depNameTemplate": "oven-sh/bun",
+      "datasourceTemplate": "github-releases",
+      "extractVersionTemplate": "^bun-v(?<version>.*)$"
+    }
+  ]
+}

--- a/tests/unit/toolchain-version.test.ts
+++ b/tests/unit/toolchain-version.test.ts
@@ -1,0 +1,44 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const repositoryRoot = path.resolve(import.meta.dir, "../..");
+
+describe("Bun toolchain version", () => {
+  test("uses one exact packageManager version in every workflow", () => {
+    const packageJson = JSON.parse(
+      fs.readFileSync(path.join(repositoryRoot, "package.json"), "utf8"),
+    ) as { packageManager?: unknown };
+
+    expect(packageJson.packageManager).toMatch(/^bun@\d+\.\d+\.\d+$/);
+
+    const workflowsDir = path.join(repositoryRoot, ".github/workflows");
+    const workflows = fs
+      .readdirSync(workflowsDir)
+      .filter((fileName) => fileName.endsWith(".yml"))
+      .map((fileName) => fs.readFileSync(path.join(workflowsDir, fileName), "utf8"));
+
+    for (const workflow of workflows) {
+      if (!workflow.includes("oven-sh/setup-bun@")) {
+        continue;
+      }
+      expect(workflow).not.toMatch(/bun-version:\s*(?:latest|canary|\d)/);
+      expect(workflow).not.toContain("bun-version-file:");
+    }
+  });
+
+  test("configures deliberate Bun release updates", () => {
+    const renovate = JSON.parse(
+      fs.readFileSync(path.join(repositoryRoot, "renovate.json"), "utf8"),
+    ) as {
+      customManagers?: Array<{ depNameTemplate?: string; datasourceTemplate?: string }>;
+    };
+
+    expect(renovate.customManagers).toContainEqual(
+      expect.objectContaining({
+        depNameTemplate: "oven-sh/bun",
+        datasourceTemplate: "github-releases",
+      }),
+    );
+  });
+});


### PR DESCRIPTION
## Goal

Complete the first recommended slice of #44 / #50 by making every CI and release workflow use one exact, reviewable Bun version.

## Scope

- declare the supported Bun release once in `package.json#packageManager`
- let every `setup-bun` step resolve that same value instead of `latest`
- add a package dry-run to the regular quality gate
- configure Renovate to propose explicit Bun release upgrades
- document the contributor/package-user contract in English and Korean

## DnD

- [x] CI and all release workflows resolve the same exact Bun version
- [x] the supported version and single source of truth are documented
- [x] dependency automation can propose deliberate Bun upgrades
- [x] upgrade PRs run install, package, build, unit, and E2E verification

## Verification

- `bun run lint:source`
- `bun run format:check`
- `bun run typecheck`
- `bun run test:unit` (89 passed)
- `bun pm pack --dry-run`
- `bun run build -- --vault ./test-vault --out ./dist`
- `bun run check:size`
- `bun run check:reproducible`
- `bun run test:e2e` (112 passed)
- `bunx -p renovate renovate-config-validator renovate.json`

Part of #44. Detailed acceptance criteria: #50.
