### PR TITLE
build: preserve successful output with staged publication

### DIFF
--- a/README.ko.md
+++ b/README.ko.md
@@ -42,6 +42,10 @@ bun run blog [build|dev|clean] [options]
 
 빌드는 vault를 검증하고 읽은 뒤 전용 출력 디렉터리에 `.eiam-output.json` 소유권 마커를 기록하고 canonical vault/output/cache-root 경로에서 파생한 cache namespace에 결속합니다. 비어 있지 않은 미소유 또는 namespace 불일치 디렉터리, cache root를 포함하거나 그 안에 놓인 경로는 출력으로 사용하지 않으며, symlink인 cache path component, namespace, index도 거부합니다. `staticPaths`는 output 밖으로 벗어나거나 예약된 `.eiam-output.json` 마커와 충돌할 수 없습니다. `dev`는 초기 build가 이 안전 검사를 통과하지 못하면 watcher와 server를 시작하지 않고 종료하며, 안전하게 시작된 뒤의 rebuild 실패만 로그로 남깁니다. `clean`도 광범위한 경로나 선택한 실행 context와 마커가 일치하지 않는 디렉터리를 삭제하지 않습니다. build migration과 `clean`은 과거 EIAM cache schema로 확인된 `.cache/build-index.json`만 제거하며, pre-marker output을 거부하는 경로에서도 이 migration을 수행합니다. 예약 static path는 migration이나 storage 검사보다 앞선 config 검증에서 거부합니다. sibling EIAM cache namespace와 일반 `.cache`의 다른 파일은 보존합니다.
 
+각 build는 output과 같은 파일시스템의 sibling staging 디렉터리에서 완성됩니다. 렌더링,
+번들링, static copy, cache 준비가 모두 성공한 뒤에만 디렉터리를 교체하므로 rebuild가
+실패하면 마지막 성공 output과 그 cache를 그대로 보존합니다.
+
 자주 쓰는 옵션:
 
 - `--vault <path>`: Markdown 루트 디렉터리 (기본 `.`)

--- a/README.md
+++ b/README.md
@@ -214,6 +214,7 @@ Key points:
 - `manifest.json` uses schema v2: `docIds` preserves order, `docsById` is the canonical metadata index, and tree file nodes carry document references instead of duplicated metadata. The runtime adapter also accepts legacy unversioned/v1 `docs` arrays during migration.
 - Route HTML embeds only a small path-aware runtime bootstrap; the shared manifest is fetched once from `manifest.json` instead of being copied into every generated page.
 - Generated files omit wall-clock build metadata and derived current-time flags, so two builds with unchanged content and config produce byte-identical output. The runtime derives each `NEW` badge from the manifest `date` and configured `newWithinDays` when the page loads.
+- Every build is assembled in a sibling staging directory. EIAM publishes it with a same-filesystem directory swap only after rendering, bundling, static copying, and cache preparation succeed; a failed rebuild leaves both the last successful output and its cache unchanged.
 - Static files declared in config are copied into the same relative paths under `dist/`.
 - Build cache is stored under `.cache/eiam/v2-<namespace>/build-index.json`.
 

--- a/src/build/contracts.ts
+++ b/src/build/contracts.ts
@@ -45,6 +45,14 @@ export interface BuildStorageState {
   previousOutputHashes: BuildCache["outputHashes"];
 }
 
+export interface BuildStorageTransaction {
+  cacheLocation: CacheLocation;
+  outputRoot: string;
+  stagingRoot: string;
+  backupRoot: string;
+  hadPreviousOutput: boolean;
+}
+
 export interface DocumentGraphResult {
   tree: TreeNode[];
   manifest: Manifest;

--- a/src/build/pipeline.ts
+++ b/src/build/pipeline.ts
@@ -5,11 +5,12 @@ import { buildDocumentGraph } from "./graph";
 import { emitOutputPhase, prepareOutputPhase, validateStaticOutputPlan } from "./output";
 import { readPublishedDocs } from "./source";
 import {
+  abortBuildStorageTransaction,
   BUILD_CACHE_VERSION,
-  claimBuildStorage,
+  beginBuildStorageTransaction,
   cleanBuildArtifacts,
+  commitBuildStorageTransaction,
   inspectBuildStorage,
-  persistBuildCache,
 } from "./storage";
 
 export { cleanBuildArtifacts };
@@ -21,30 +22,45 @@ export async function buildSite(options: BuildOptions): Promise<BuildResult> {
   const { docs, nextSources } = await readPublishedDocs(options, storage.previousCache.sources);
   docs.sort((left, right) => left.relNoExt.localeCompare(right.relNoExt, "ko-KR"));
 
-  await claimBuildStorage(options, storage, docs);
-  const output = await prepareOutputPhase(options, storage.previousOutputHashes);
-  const graph = buildDocumentGraph(docs, options);
-  const rendered = await renderDocuments(
-    docs,
-    options,
-    storage.previousDocs,
-    output.context,
-    graph.wikiLookup,
-  );
+  const transaction = await beginBuildStorageTransaction(options, storage);
+  const stagedOptions: BuildOptions = { ...options, outDir: transaction.stagingRoot };
 
-  await emitOutputPhase(output, docs, graph.manifest, options, rendered.contentByDocId);
+  try {
+    const output = await prepareOutputPhase(stagedOptions, storage.previousOutputHashes);
+    const graph = buildDocumentGraph(docs, stagedOptions);
+    const rendered = await renderDocuments(
+      docs,
+      stagedOptions,
+      storage.previousDocs,
+      output.context,
+      graph.wikiLookup,
+    );
 
-  const nextCache: BuildCache = {
-    version: BUILD_CACHE_VERSION,
-    sources: nextSources,
-    docs: rendered.nextDocs,
-    outputHashes: output.context.nextHashes,
-  };
-  await persistBuildCache(storage.cacheLocation, nextCache);
+    await emitOutputPhase(output, docs, graph.manifest, stagedOptions, rendered.contentByDocId);
 
-  return {
-    totalDocs: docs.length,
-    renderedDocs: rendered.renderedDocs,
-    skippedDocs: rendered.skippedDocs,
-  };
+    const nextCache: BuildCache = {
+      version: BUILD_CACHE_VERSION,
+      sources: nextSources,
+      docs: rendered.nextDocs,
+      outputHashes: output.context.nextHashes,
+    };
+    await commitBuildStorageTransaction(transaction, nextCache);
+
+    return {
+      totalDocs: docs.length,
+      renderedDocs: rendered.renderedDocs,
+      skippedDocs: rendered.skippedDocs,
+    };
+  } catch (error) {
+    try {
+      await abortBuildStorageTransaction(transaction);
+    } catch (cleanupError) {
+      throw new AggregateError(
+        [error, cleanupError],
+        "[build] Failed build cleanup was incomplete",
+        { cause: cleanupError },
+      );
+    }
+    throw error;
+  }
 }

--- a/src/build/storage.ts
+++ b/src/build/storage.ts
@@ -1,11 +1,12 @@
+import crypto from "node:crypto";
 import fs from "node:fs/promises";
 import path from "node:path";
-import type { BuildCache, BuildOptions, DocRecord } from "../types";
-import { ensureDir, fileExists, makeHash, removeEmptyParents, removeFileIfExists } from "../utils";
-import type { BuildStorageState, CacheLocation } from "./contracts";
+import type { BuildCache, BuildOptions } from "../types";
+import { ensureDir, fileExists, makeHash } from "../utils";
+import type { BuildStorageState, BuildStorageTransaction, CacheLocation } from "./contracts";
 import { normalizeCategoryPath } from "../publication";
 import { parseBranch, parseStringArray } from "./source";
-import { OUTPUT_MARKER_FILE_NAME, toContentFileName } from "./shared";
+import { OUTPUT_MARKER_FILE_NAME } from "./shared";
 
 const CACHE_VERSION = 6;
 export const BUILD_CACHE_VERSION = CACHE_VERSION;
@@ -185,21 +186,6 @@ async function writeOutputMarker(outputRoot: string, cacheNamespace: string): Pr
     path.join(outputRoot, OUTPUT_MARKER_FILE_NAME),
     `${JSON.stringify(marker, null, 2)}\n`,
   );
-}
-
-async function prepareOwnedOutputDirectory(
-  options: BuildOptions,
-  cacheLocation: CacheLocation,
-  outputRoot: string,
-): Promise<void> {
-  await assertClaimableOutputDirectory(options, cacheLocation, outputRoot);
-
-  const requestedOutputRoot = path.resolve(options.outDir);
-  await fs.mkdir(requestedOutputRoot, { recursive: true });
-
-  if (!(await hasValidOutputMarker(outputRoot, cacheLocation.namespace))) {
-    await writeOutputMarker(outputRoot, cacheLocation.namespace);
-  }
 }
 
 async function assertClaimableOutputDirectory(
@@ -450,41 +436,28 @@ async function writeCache(location: CacheLocation, cache: BuildCache): Promise<v
   await assertSafeCacheLocation(location);
   await ensureDir(location.namespaceDir);
   await assertSafeCacheLocation(location);
-  await Bun.write(location.cachePath, `${JSON.stringify(cache, null, 2)}\n`);
+  const temporaryCachePath = `${location.cachePath}.${process.pid}-${crypto.randomUUID()}.tmp`;
+  try {
+    await Bun.write(temporaryCachePath, `${JSON.stringify(cache, null, 2)}\n`);
+    await fs.rename(temporaryCachePath, location.cachePath);
+  } finally {
+    await fs.rm(temporaryCachePath, { force: true });
+  }
 }
 
-async function cleanRemovedOutputs(
-  outDir: string,
-  oldCache: BuildCache,
-  currentDocs: DocRecord[],
-): Promise<void> {
-  const currentIds = new Set(currentDocs.map((doc) => doc.id));
-  const currentRouteById = new Map(currentDocs.map((doc) => [doc.id, doc.route]));
+function createTransactionPath(outputRoot: string, kind: "backup" | "staging", token: string) {
+  return path.join(path.dirname(outputRoot), `.${path.basename(outputRoot)}.eiam-${kind}-${token}`);
+}
 
-  for (const [id, entry] of Object.entries(oldCache.docs)) {
-    if (currentIds.has(id)) {
-      const currentRoute = currentRouteById.get(id);
-      if (currentRoute && currentRoute !== entry.route) {
-        const previousRouteDir = path.join(
-          outDir,
-          entry.route.replace(/^\//, "").replace(/\/$/, ""),
-        );
-        const previousRouteIndex = path.join(previousRouteDir, "index.html");
-        await removeFileIfExists(previousRouteIndex);
-        await removeEmptyParents(previousRouteDir, outDir);
-      }
-      continue;
+async function outputDirectoryExists(outputRoot: string): Promise<boolean> {
+  try {
+    const outputStat = await fs.lstat(outputRoot);
+    return outputStat.isDirectory() && !outputStat.isSymbolicLink();
+  } catch (error) {
+    if ((error as NodeJS.ErrnoException).code === "ENOENT") {
+      return false;
     }
-
-    const legacyContentPath = path.join(outDir, "content", `${id}.html`);
-    const hashedContentPath = path.join(outDir, "content", toContentFileName(id));
-    await removeFileIfExists(legacyContentPath);
-    await removeFileIfExists(hashedContentPath);
-
-    const routeDir = path.join(outDir, entry.route.replace(/^\//, "").replace(/\/$/, ""));
-    const routeIndex = path.join(routeDir, "index.html");
-    await removeFileIfExists(routeIndex);
-    await removeEmptyParents(routeDir, outDir);
+    throw error;
   }
 }
 
@@ -543,16 +516,98 @@ export async function inspectBuildStorage(options: BuildOptions): Promise<BuildS
   };
 }
 
-export async function claimBuildStorage(
+export async function beginBuildStorageTransaction(
   options: BuildOptions,
   storage: BuildStorageState,
-  docs: DocRecord[],
-): Promise<void> {
-  await prepareOwnedOutputDirectory(options, storage.cacheLocation, storage.outputRoot);
-  await ensureDir(path.join(options.outDir, "content"));
-  await cleanRemovedOutputs(options.outDir, storage.previousCache, docs);
+): Promise<BuildStorageTransaction> {
+  await assertClaimableOutputDirectory(options, storage.cacheLocation, storage.outputRoot);
+
+  const token = `${process.pid}-${crypto.randomUUID()}`;
+  const transaction: BuildStorageTransaction = {
+    cacheLocation: storage.cacheLocation,
+    outputRoot: storage.outputRoot,
+    stagingRoot: createTransactionPath(storage.outputRoot, "staging", token),
+    backupRoot: createTransactionPath(storage.outputRoot, "backup", token),
+    hadPreviousOutput: await outputDirectoryExists(storage.outputRoot),
+  };
+
+  await ensureDir(path.dirname(storage.outputRoot));
+  try {
+    if (transaction.hadPreviousOutput) {
+      await fs.cp(storage.outputRoot, transaction.stagingRoot, {
+        errorOnExist: true,
+        force: false,
+        recursive: true,
+      });
+    } else {
+      await fs.mkdir(transaction.stagingRoot);
+    }
+
+    if (!(await hasValidOutputMarker(transaction.stagingRoot, storage.cacheLocation.namespace))) {
+      await writeOutputMarker(transaction.stagingRoot, storage.cacheLocation.namespace);
+    }
+    await ensureDir(path.join(transaction.stagingRoot, "content"));
+    return transaction;
+  } catch (error) {
+    await fs.rm(transaction.stagingRoot, { force: true, recursive: true });
+    throw error;
+  }
 }
 
-export async function persistBuildCache(location: CacheLocation, cache: BuildCache): Promise<void> {
-  await writeCache(location, cache);
+async function rollbackBuildStorageTransaction(
+  transaction: BuildStorageTransaction,
+  previousMoved: boolean,
+  stagedPublished: boolean,
+): Promise<void> {
+  if (stagedPublished) {
+    await fs.rename(transaction.outputRoot, transaction.stagingRoot);
+  }
+  if (previousMoved) {
+    await fs.rename(transaction.backupRoot, transaction.outputRoot);
+  }
+}
+
+export async function commitBuildStorageTransaction(
+  transaction: BuildStorageTransaction,
+  cache: BuildCache,
+): Promise<void> {
+  let previousMoved = false;
+  let stagedPublished = false;
+
+  try {
+    if (transaction.hadPreviousOutput) {
+      await fs.rename(transaction.outputRoot, transaction.backupRoot);
+      previousMoved = true;
+    }
+    await fs.rename(transaction.stagingRoot, transaction.outputRoot);
+    stagedPublished = true;
+    await writeCache(transaction.cacheLocation, cache);
+  } catch (error) {
+    try {
+      await rollbackBuildStorageTransaction(transaction, previousMoved, stagedPublished);
+    } catch (rollbackError) {
+      throw new AggregateError(
+        [error, rollbackError],
+        `[build] Failed to publish staged output and restore the previous output. Backup retained at ${transaction.backupRoot}`,
+        { cause: rollbackError },
+      );
+    }
+    throw error;
+  }
+
+  if (previousMoved) {
+    try {
+      await fs.rm(transaction.backupRoot, { force: true, recursive: true });
+    } catch (error) {
+      console.warn(
+        `[build] Published output but could not remove transaction backup ${transaction.backupRoot}: ${String(error)}`,
+      );
+    }
+  }
+}
+
+export async function abortBuildStorageTransaction(
+  transaction: BuildStorageTransaction,
+): Promise<void> {
+  await fs.rm(transaction.stagingRoot, { force: true, recursive: true });
 }

--- a/tests/e2e/build-regression.spec.ts
+++ b/tests/e2e/build-regression.spec.ts
@@ -322,6 +322,81 @@ ALPHA
     }
   });
 
+  test("실패한 rebuild는 마지막 성공 output과 cache를 원자적으로 보존한다", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-atomic-build-"));
+    const vaultDir = path.join(workDir, "vault");
+    const outDir = path.join(workDir, "dist");
+    const configPath = path.join(workDir, "blog.config.mjs");
+    const sourcePath = path.join(vaultDir, "atomic.md");
+    const transactionArtifacts = () =>
+      fs
+        .readdirSync(workDir)
+        .filter(
+          (entry) =>
+            entry.startsWith(".dist.eiam-backup-") || entry.startsWith(".dist.eiam-staging-"),
+        );
+
+    try {
+      writeText(
+        sourcePath,
+        `---
+publish: true
+prefix: ATOMIC-01
+category_path: build/atomic
+title: Atomic output
+---
+
+LAST_SUCCESSFUL_OUTPUT
+`,
+      );
+
+      const firstBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(firstBuild.status, firstBuild.output).toBe(0);
+      const outputBeforeFailure = snapshotOutputHashes(outDir);
+      const cachePath = findOnlyCacheIndexPath(workDir);
+      const cacheBeforeFailure = fs.readFileSync(cachePath, "utf8");
+
+      writeText(
+        sourcePath,
+        fs
+          .readFileSync(sourcePath, "utf8")
+          .replace("LAST_SUCCESSFUL_OUTPUT", "FAILED_BUILD_MUST_NOT_PUBLISH"),
+      );
+      writeText(
+        configPath,
+        'export default { markdown: { highlight: { theme: "../invalid-theme" } } };\n',
+      );
+
+      const failedBuild = runCli(workDir, [cliPath, "build", "--vault", vaultDir, "--out", outDir]);
+      expect(failedBuild.status).not.toBe(0);
+      expect(failedBuild.output).toContain("Invalid Shiki theme");
+      expect(snapshotOutputHashes(outDir)).toEqual(outputBeforeFailure);
+      expect(fs.readFileSync(cachePath, "utf8")).toBe(cacheBeforeFailure);
+      expect(readDocContentHtml(outDir, "/ATOMIC-01/")).toContain("LAST_SUCCESSFUL_OUTPUT");
+      expect(readDocContentHtml(outDir, "/ATOMIC-01/")).not.toContain(
+        "FAILED_BUILD_MUST_NOT_PUBLISH",
+      );
+      expect(transactionArtifacts()).toEqual([]);
+
+      fs.rmSync(configPath);
+      const recoveredBuild = runCli(workDir, [
+        cliPath,
+        "build",
+        "--vault",
+        vaultDir,
+        "--out",
+        outDir,
+      ]);
+      expect(recoveredBuild.status, recoveredBuild.output).toBe(0);
+      expect(readDocContentHtml(outDir, "/ATOMIC-01/")).toContain("FAILED_BUILD_MUST_NOT_PUBLISH");
+      expect(snapshotOutputHashes(outDir)).not.toEqual(outputBeforeFailure);
+      expect(fs.readFileSync(cachePath, "utf8")).not.toBe(cacheBeforeFailure);
+      expect(transactionArtifacts()).toEqual([]);
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
   test("content renderer version은 기존 Markdown fragment cache를 무효화한다", () => {
     const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "mfs-content-renderer-version-"));
     const vaultDir = path.join(workDir, "vault");


### PR DESCRIPTION
## Goal

Complete the original atomic-build scope of #44: a failed rebuild must never partially replace the last deployable site.

## Scope

- build into a unique sibling staging directory on the same filesystem
- reuse the prior output/cache inside staging so no-op document rendering remains incremental
- publish staged output only after render, bundle, static-copy, and emission phases succeed
- write cache indexes through a temporary file and commit output/cache as one rollback-capable transaction
- retain and restore the previous directory if publication or cache commit fails
- clean staging artifacts after failed builds

## DnD

- [x] a rebuild failure preserves every byte of the last successful output
- [x] a rebuild failure preserves the matching cache index
- [x] successful rebuilds publish changed content and cache together
- [x] no staging/backup artifacts remain after normal success or handled failure
- [x] no-op output remains byte-reproducible and cached documents remain skipped

## Verification

- `bun run format:check`
- `bun run lint:source`
- `bun run typecheck`
- `bun run test:unit` (89 passed)
- atomic failure/recovery regression test
- `bun run build -- --vault ./test-vault --out ./dist` (`rendered=0 skipped=5` on cached build)
- `bun run check:size`
- `bun run check:reproducible` (18 stable files)
- `bun run test:e2e` (113 passed)

Part of #44.
