### PR TITLE
ci: deploy validated sites to Cloudflare Pages

### DIFF
--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -65,6 +65,9 @@ on:
       artifact-digest:
         description: SHA-256 digest reported by actions/upload-artifact
         value: ${{ jobs.build-validate.outputs.artifact-digest }}
+      validation-report-artifact-name:
+        description: Production validation report artifact uploaded by the build job
+        value: ${{ jobs.build-validate.outputs.report-artifact-name }}
       deployment-url:
         description: Immutable Cloudflare Pages deployment URL; empty in artifact-only mode
         value: ${{ jobs.deploy.outputs.deployment-url }}
@@ -91,6 +94,7 @@ jobs:
       deploy-branch: ${{ steps.inputs.outputs.deploy-branch }}
       output-path: ${{ steps.inputs.outputs.output-path }}
       project-name: ${{ steps.inputs.outputs.project-name }}
+      report-artifact-name: ${{ steps.inputs.outputs.report-artifact-name }}
       report-path: ${{ steps.inputs.outputs.report-path }}
     steps:
       - name: Checkout caller repository
@@ -172,18 +176,24 @@ jobs:
 
           if [[ "$DEPLOYMENT_ENVIRONMENT" == "production" ]]; then
             deploy_branch="$PRODUCTION_BRANCH"
-            [[ "$GITHUB_REF" == "refs/heads/$PRODUCTION_BRANCH" ]] || fail "production deployment must run from refs/heads/$PRODUCTION_BRANCH"
+            if [[ "$ARTIFACT_ONLY" != "true" && "$GITHUB_REF" != "refs/heads/$PRODUCTION_BRANCH" ]]; then
+              fail "production deployment must run from refs/heads/$PRODUCTION_BRANCH"
+            fi
           else
             deploy_branch="$PREVIEW_BRANCH"
             if [[ -z "$deploy_branch" ]]; then
               deploy_branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
             fi
             validate_branch "preview-branch" "$deploy_branch"
-            [[ "$deploy_branch" != "$PRODUCTION_BRANCH" ]] || fail "preview-branch must differ from production-branch"
+            if [[ "$ARTIFACT_ONLY" != "true" && "$deploy_branch" == "$PRODUCTION_BRANCH" ]]; then
+              fail "preview-branch must differ from production-branch"
+            fi
           fi
 
-          report_path=".eiam-reports/production-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
-          artifact_name="eiam-site-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          invocation_id="$(openssl rand -hex 16)"
+          report_path=".eiam-reports/production-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${invocation_id}"
+          artifact_name="eiam-site-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${invocation_id}"
+          report_artifact_name="production-validation-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}-${invocation_id}"
           output_resolved="$(realpath -m -- "$OUTPUT_PATH")"
           report_resolved="$(realpath -m -- "$report_path")"
           if [[ "$output_resolved" == "$report_resolved" || "$output_resolved" == "$report_resolved"/* || "$report_resolved" == "$output_resolved"/* ]]; then
@@ -194,6 +204,7 @@ jobs:
             echo "deploy-branch=$deploy_branch"
             echo "output-path=$OUTPUT_PATH"
             echo "project-name=$PROJECT_NAME"
+            echo "report-artifact-name=$report_artifact_name"
             echo "report-path=$report_path"
           } >> "$GITHUB_OUTPUT"
 
@@ -269,9 +280,10 @@ jobs:
         if: always() && steps.inputs.outcome == 'success'
         uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
         with:
-          name: production-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          name: ${{ steps.inputs.outputs.report-artifact-name }}
           path: ${{ steps.inputs.outputs.report-path }}/**
           if-no-files-found: warn
+          include-hidden-files: true
           retention-days: 14
 
       - name: Upload exact validated site

--- a/.github/workflows/deploy-cloudflare-pages.yml
+++ b/.github/workflows/deploy-cloudflare-pages.yml
@@ -1,0 +1,383 @@
+name: Deploy validated site to Cloudflare Pages
+
+on:
+  workflow_call:
+    inputs:
+      vault-path:
+        description: Repository-relative Markdown vault directory
+        required: true
+        type: string
+      output-path:
+        description: Repository-relative deployable output directory
+        required: false
+        default: dist
+        type: string
+      config-path:
+        description: Repository-relative production config module
+        required: true
+        type: string
+      project-name:
+        description: Existing Cloudflare Pages project (optional in artifact-only mode)
+        required: false
+        default: ""
+        type: string
+      deployment-environment:
+        description: Cloudflare Pages environment selected by branch
+        required: false
+        default: preview
+        type: string
+      production-branch:
+        description: Branch configured as production in the Cloudflare Pages project
+        required: false
+        default: main
+        type: string
+      preview-branch:
+        description: Preview alias branch; defaults to the caller head branch
+        required: false
+        default: ""
+        type: string
+      artifact-only:
+        description: Build, validate, and upload artifacts without reading Cloudflare secrets
+        required: false
+        default: false
+        type: boolean
+      exclude-patterns:
+        description: Optional newline-separated vault exclusion patterns
+        required: false
+        default: ""
+        type: string
+      markdown-baseline-path:
+        description: Optional repository-relative strict Markdown baseline
+        required: false
+        default: ""
+        type: string
+    secrets:
+      CLOUDFLARE_API_TOKEN:
+        description: API token scoped to Cloudflare Pages Write
+        required: false
+      CLOUDFLARE_ACCOUNT_ID:
+        description: Cloudflare account identifier containing the Pages project
+        required: false
+    outputs:
+      artifact-name:
+        description: Validated site artifact uploaded by the build job
+        value: ${{ jobs.build-validate.outputs.artifact-name }}
+      artifact-digest:
+        description: SHA-256 digest reported by actions/upload-artifact
+        value: ${{ jobs.build-validate.outputs.artifact-digest }}
+      deployment-url:
+        description: Immutable Cloudflare Pages deployment URL; empty in artifact-only mode
+        value: ${{ jobs.deploy.outputs.deployment-url }}
+      deployment-alias-url:
+        description: Production or preview alias URL; empty in artifact-only mode
+        value: ${{ jobs.deploy.outputs.deployment-alias-url }}
+      deployment-id:
+        description: Cloudflare Pages deployment identifier; empty in artifact-only mode
+        value: ${{ jobs.deploy.outputs.deployment-id }}
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-pages-${{ github.repository }}-${{ inputs.project-name || 'artifact-only' }}-${{ inputs.deployment-environment }}
+  cancel-in-progress: false
+
+jobs:
+  build-validate:
+    runs-on: ubuntu-latest
+    outputs:
+      artifact-name: ${{ steps.inputs.outputs.artifact-name }}
+      artifact-digest: ${{ steps.site-artifact.outputs.artifact-digest }}
+      deploy-branch: ${{ steps.inputs.outputs.deploy-branch }}
+      output-path: ${{ steps.inputs.outputs.output-path }}
+      project-name: ${{ steps.inputs.outputs.project-name }}
+      report-path: ${{ steps.inputs.outputs.report-path }}
+    steps:
+      - name: Checkout caller repository
+        uses: actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10 # v6
+        with:
+          persist-credentials: false
+
+      - name: Validate deployment inputs
+        id: inputs
+        shell: bash
+        env:
+          ARTIFACT_ONLY: ${{ inputs.artifact-only }}
+          CONFIG_PATH: ${{ inputs.config-path }}
+          DEPLOYMENT_ENVIRONMENT: ${{ inputs.deployment-environment }}
+          IS_FORK: ${{ github.event.pull_request.head.repo.fork || false }}
+          MARKDOWN_BASELINE_PATH: ${{ inputs.markdown-baseline-path }}
+          OUTPUT_PATH: ${{ inputs.output-path }}
+          PREVIEW_BRANCH: ${{ inputs.preview-branch }}
+          PRODUCTION_BRANCH: ${{ inputs.production-branch }}
+          PROJECT_NAME: ${{ inputs.project-name }}
+          VAULT_PATH: ${{ inputs.vault-path }}
+        run: |
+          fail() {
+            echo "::error title=Invalid Cloudflare deployment input::$1"
+            exit 1
+          }
+
+          validate_relative_path() {
+            local label="$1"
+            local value="$2"
+            local allow_root="$3"
+            [[ -n "$value" ]] || fail "$label must not be empty"
+            [[ "$value" != *$'\n'* && "$value" != *$'\r'* ]] || fail "$label must be one path"
+            [[ "$value" != /* && "$value" != \\* ]] || fail "$label must be repository-relative"
+
+            local resolved
+            resolved="$(realpath -m -- "$value")"
+            case "$resolved" in
+              "$GITHUB_WORKSPACE")
+                [[ "$allow_root" == "true" ]] || fail "$label must not select the repository root"
+                ;;
+              "$GITHUB_WORKSPACE"/*) ;;
+              *) fail "$label must stay inside the caller repository" ;;
+            esac
+          }
+
+          validate_branch() {
+            local label="$1"
+            local value="$2"
+            [[ "$value" =~ ^[A-Za-z0-9][A-Za-z0-9._/-]*$ ]] || fail "$label contains unsupported characters"
+            [[ "$value" != *..* && "$value" != *//* && "$value" != */ && "$value" != *.lock ]] || fail "$label is not a safe Git branch name"
+          }
+
+          validate_relative_path "vault-path" "$VAULT_PATH" true
+          validate_relative_path "output-path" "$OUTPUT_PATH" false
+          validate_relative_path "config-path" "$CONFIG_PATH" false
+          [[ -d "$VAULT_PATH" ]] || fail "vault-path must be an existing directory"
+          [[ -f "$CONFIG_PATH" ]] || fail "config-path must be an existing file"
+          package_manager="$(jq -er '.packageManager | select(type == "string")' package.json 2>/dev/null || true)"
+          [[ "$package_manager" =~ ^bun@[0-9]+\.[0-9]+\.[0-9]+$ ]] || fail "caller packageManager must pin one exact stable Bun version"
+
+          if [[ -n "$MARKDOWN_BASELINE_PATH" ]]; then
+            validate_relative_path "markdown-baseline-path" "$MARKDOWN_BASELINE_PATH" false
+            [[ -f "$MARKDOWN_BASELINE_PATH" ]] || fail "markdown-baseline-path must be an existing file"
+          fi
+
+          [[ "$DEPLOYMENT_ENVIRONMENT" == "preview" || "$DEPLOYMENT_ENVIRONMENT" == "production" ]] || fail "deployment-environment must be preview or production"
+          validate_branch "production-branch" "$PRODUCTION_BRANCH"
+
+          if [[ "$ARTIFACT_ONLY" != "true" ]]; then
+            [[ "$PROJECT_NAME" =~ ^[a-z0-9]([a-z0-9-]{0,56}[a-z0-9])?$ ]] || fail "project-name must be a lowercase Cloudflare Pages project name"
+          elif [[ -n "$PROJECT_NAME" && ! "$PROJECT_NAME" =~ ^[a-z0-9]([a-z0-9-]{0,56}[a-z0-9])?$ ]]; then
+            fail "project-name must be a lowercase Cloudflare Pages project name when provided"
+          fi
+
+          if [[ "$IS_FORK" == "true" && "$ARTIFACT_ONLY" != "true" ]]; then
+            fail "fork pull requests must use artifact-only mode"
+          fi
+
+          if [[ "$DEPLOYMENT_ENVIRONMENT" == "production" ]]; then
+            deploy_branch="$PRODUCTION_BRANCH"
+            [[ "$GITHUB_REF" == "refs/heads/$PRODUCTION_BRANCH" ]] || fail "production deployment must run from refs/heads/$PRODUCTION_BRANCH"
+          else
+            deploy_branch="$PREVIEW_BRANCH"
+            if [[ -z "$deploy_branch" ]]; then
+              deploy_branch="${GITHUB_HEAD_REF:-$GITHUB_REF_NAME}"
+            fi
+            validate_branch "preview-branch" "$deploy_branch"
+            [[ "$deploy_branch" != "$PRODUCTION_BRANCH" ]] || fail "preview-branch must differ from production-branch"
+          fi
+
+          report_path=".eiam-reports/production-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          artifact_name="eiam-site-${GITHUB_RUN_ID}-${GITHUB_RUN_ATTEMPT}"
+          output_resolved="$(realpath -m -- "$OUTPUT_PATH")"
+          report_resolved="$(realpath -m -- "$report_path")"
+          if [[ "$output_resolved" == "$report_resolved" || "$output_resolved" == "$report_resolved"/* || "$report_resolved" == "$output_resolved"/* ]]; then
+            fail "output-path must not overlap the workflow validation report directory"
+          fi
+          {
+            echo "artifact-name=$artifact_name"
+            echo "deploy-branch=$deploy_branch"
+            echo "output-path=$OUTPUT_PATH"
+            echo "project-name=$PROJECT_NAME"
+            echo "report-path=$report_path"
+          } >> "$GITHUB_OUTPUT"
+
+      - name: Setup caller-pinned Bun toolchain
+        uses: oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6 # v2
+
+      - name: Install caller dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Locate pinned production validator
+        id: validator
+        shell: bash
+        run: |
+          dependency_validator="node_modules/@limcpf/everything-is-a-markdown/scripts/validate-production.ts"
+          local_validator="scripts/validate-production.ts"
+          package_name="$(bun -e 'const value = await Bun.file("package.json").json(); process.stdout.write(String(value.name ?? ""));')"
+
+          if [[ -f "$dependency_validator" ]]; then
+            declared_version="$(bun -e '
+              const value = await Bun.file("package.json").json();
+              const name = "@limcpf/everything-is-a-markdown";
+              process.stdout.write(String(value.dependencies?.[name] ?? value.devDependencies?.[name] ?? ""));
+            ')"
+            installed_version="$(bun -e '
+              const value = await Bun.file("node_modules/@limcpf/everything-is-a-markdown/package.json").json();
+              process.stdout.write(String(value.version ?? ""));
+            ')"
+            if [[ ! "$declared_version" =~ ^[0-9]+\.[0-9]+\.[0-9]+$ || "$installed_version" != "$declared_version" ]]; then
+              echo "::error title=Unpinned EIAM dependency::Declare one exact stable @limcpf/everything-is-a-markdown version and commit its frozen lockfile"
+              exit 1
+            fi
+            validator_path="$dependency_validator"
+          elif [[ "$package_name" == "@limcpf/everything-is-a-markdown" && -f "$local_validator" ]]; then
+            validator_path="$local_validator"
+          else
+            echo "::error title=Missing EIAM production validator::Pin an @limcpf/everything-is-a-markdown release containing scripts/validate-production.ts in the caller lockfile"
+            exit 1
+          fi
+
+          echo "path=$validator_path" >> "$GITHUB_OUTPUT"
+
+      - name: Build and validate production output
+        id: production-validation
+        shell: bash
+        env:
+          CONFIG_PATH: ${{ inputs.config-path }}
+          EXCLUDE_PATTERNS: ${{ inputs.exclude-patterns }}
+          MARKDOWN_BASELINE_PATH: ${{ inputs.markdown-baseline-path }}
+          OUTPUT_PATH: ${{ steps.inputs.outputs.output-path }}
+          REPORT_PATH: ${{ steps.inputs.outputs.report-path }}
+          VALIDATOR_PATH: ${{ steps.validator.outputs.path }}
+          VAULT_PATH: ${{ inputs.vault-path }}
+        run: |
+          validation_args=(
+            --config "$CONFIG_PATH"
+            --vault "$VAULT_PATH"
+            --out "$OUTPUT_PATH"
+            --report-dir "$REPORT_PATH"
+          )
+
+          if [[ -n "$MARKDOWN_BASELINE_PATH" ]]; then
+            validation_args+=(--markdown-baseline "$MARKDOWN_BASELINE_PATH")
+          fi
+
+          while IFS= read -r pattern || [[ -n "$pattern" ]]; do
+            [[ -z "$pattern" ]] && continue
+            validation_args+=(--exclude "$pattern")
+          done <<< "$EXCLUDE_PATTERNS"
+
+          bun run "$VALIDATOR_PATH" "${validation_args[@]}"
+
+      - name: Upload production validation report
+        if: always() && steps.inputs.outcome == 'success'
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: production-validation-${{ github.run_id }}-${{ github.run_attempt }}
+          path: ${{ steps.inputs.outputs.report-path }}/**
+          if-no-files-found: warn
+          retention-days: 14
+
+      - name: Upload exact validated site
+        id: site-artifact
+        uses: actions/upload-artifact@ea165f8d65b6e75b540449e92b4886f43607fa02 # v4
+        with:
+          name: ${{ steps.inputs.outputs.artifact-name }}
+          path: ${{ steps.inputs.outputs.output-path }}/
+          if-no-files-found: error
+          include-hidden-files: true
+          compression-level: 0
+          retention-days: 7
+
+  deploy:
+    if: ${{ !inputs.artifact-only }}
+    needs: build-validate
+    runs-on: ubuntu-latest
+    environment:
+      name: cloudflare-${{ inputs.deployment-environment }}
+    outputs:
+      deployment-url: ${{ steps.deploy.outputs.deployment-url }}
+      deployment-alias-url: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+      deployment-id: ${{ steps.deploy.outputs.pages-deployment-id }}
+    steps:
+      - name: Download exact validated site
+        uses: actions/download-artifact@634f93cb2916e3fdff6788551b99b062d0335ce0 # v5
+        with:
+          name: ${{ needs.build-validate.outputs.artifact-name }}
+          path: .eiam-pages-site
+
+      - name: Verify Cloudflare project environment
+        shell: bash
+        env:
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          DEPLOY_BRANCH: ${{ needs.build-validate.outputs.deploy-branch }}
+          DEPLOYMENT_ENVIRONMENT: ${{ inputs.deployment-environment }}
+          EXPECTED_PRODUCTION_BRANCH: ${{ inputs.production-branch }}
+          PROJECT_NAME: ${{ needs.build-validate.outputs.project-name }}
+        run: |
+          [[ "$CLOUDFLARE_ACCOUNT_ID" =~ ^[0-9a-fA-F]{32}$ ]] || {
+            echo "::error title=Invalid Cloudflare account::CLOUDFLARE_ACCOUNT_ID must be a 32-character account identifier"
+            exit 1
+          }
+          [[ -n "$CLOUDFLARE_API_TOKEN" ]] || {
+            echo "::error title=Missing Cloudflare credential::CLOUDFLARE_API_TOKEN is required outside artifact-only mode"
+            exit 1
+          }
+
+          response_path="$RUNNER_TEMP/cloudflare-pages-project.json"
+          curl --silent --show-error --fail-with-body \
+            "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$PROJECT_NAME" \
+            --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN" \
+            --output "$response_path"
+
+          if ! actual_production_branch="$(jq -er 'select(.success == true) | .result.production_branch | select(type == "string" and length > 0)' "$response_path")"; then
+            echo "::error title=Cloudflare project preflight failed::Project lookup did not return a production branch"
+            exit 1
+          fi
+          if [[ "$actual_production_branch" != "$EXPECTED_PRODUCTION_BRANCH" ]]; then
+            echo "::error title=Cloudflare production branch mismatch::Project uses $actual_production_branch, workflow requires $EXPECTED_PRODUCTION_BRANCH"
+            exit 1
+          fi
+          if [[ "$DEPLOYMENT_ENVIRONMENT" == "production" && "$DEPLOY_BRANCH" != "$actual_production_branch" ]] || \
+             [[ "$DEPLOYMENT_ENVIRONMENT" == "preview" && "$DEPLOY_BRANCH" == "$actual_production_branch" ]]; then
+            echo "::error title=Cloudflare environment mismatch::The selected branch would deploy to a different Pages environment"
+            exit 1
+          fi
+
+      - name: Deploy validated artifact
+        id: deploy
+        uses: cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0 # v4.0.0
+        with:
+          apiToken: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          accountId: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+          packageManager: npm
+          wranglerVersion: 4.112.0
+          command: >-
+            pages deploy .eiam-pages-site
+            --project-name=${{ needs.build-validate.outputs.project-name }}
+            --branch=${{ needs.build-validate.outputs.deploy-branch }}
+            --commit-hash=${{ github.sha }}
+            --commit-dirty=false
+
+      - name: Verify deployment result
+        shell: bash
+        env:
+          ACTUAL_ENVIRONMENT: ${{ steps.deploy.outputs.pages-environment }}
+          DEPLOYMENT_ALIAS_URL: ${{ steps.deploy.outputs.pages-deployment-alias-url }}
+          DEPLOYMENT_ID: ${{ steps.deploy.outputs.pages-deployment-id }}
+          DEPLOYMENT_URL: ${{ steps.deploy.outputs.deployment-url }}
+          EXPECTED_ENVIRONMENT: ${{ inputs.deployment-environment }}
+        run: |
+          [[ -n "$DEPLOYMENT_ID" && -n "$DEPLOYMENT_URL" ]] || {
+            echo "::error title=Missing Cloudflare deployment identity::Wrangler did not return a deployment ID and URL"
+            exit 1
+          }
+          [[ "$ACTUAL_ENVIRONMENT" == "$EXPECTED_ENVIRONMENT" ]] || {
+            echo "::error title=Unexpected Cloudflare environment::Expected $EXPECTED_ENVIRONMENT but Wrangler reported $ACTUAL_ENVIRONMENT"
+            exit 1
+          }
+          {
+            echo "### Cloudflare Pages deployment"
+            echo
+            echo "- Environment: \`$ACTUAL_ENVIRONMENT\`"
+            echo "- Deployment ID: \`$DEPLOYMENT_ID\`"
+            echo "- Immutable URL: $DEPLOYMENT_URL"
+            [[ -z "$DEPLOYMENT_ALIAS_URL" ]] || echo "- Alias URL: $DEPLOYMENT_ALIAS_URL"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/README.ko.md
+++ b/README.ko.md
@@ -131,6 +131,20 @@ bun run validate:production -- \
 정확히 같아야 하므로 finding 추가·삭제·위치·내용 변화는 baseline을 명시적으로 검토해야
 합니다. `--vault`와 반복 가능한 `--exclude` override도 지원합니다.
 
+## Cloudflare Pages 배포
+
+Vault 저장소는 재사용 가능한
+[`deploy-cloudflare-pages.yml`](.github/workflows/deploy-cloudflare-pages.yml)을 호출해 lockfile에
+고정된 EIAM으로 자체 vault를 빌드·검증한 뒤, 분리된 job에서 검증된 output만 배포할 수
+있습니다. vault, output, config, Pages project, production/preview branch, exclude, Markdown
+baseline을 명시적으로 입력받습니다. `artifact-only` 모드는 Cloudflare secret을 읽지 않으므로
+fork PR과 배포 전 검토에 사용할 수 있습니다.
+
+완전한 caller workflow 예제, `Pages Write` token 범위, GitHub environment 보호 규칙,
+root 배포와 prefix 배포의 `pathBase` 차이, 실패 artifact, host smoke check, production rollback
+절차는 [Cloudflare Pages 배포 문서](docs/CLOUDFLARE-PAGES.md)에 정리되어 있습니다. Generator
+npm package publish는 별도 release workflow이며 caller vault를 배포하지 않습니다.
+
 ## 개발 품질 검사
 
 브라우저 설치나 E2E 실행 전에 빠른 source gate를 로컬에서 그대로 실행할 수 있습니다.

--- a/README.md
+++ b/README.md
@@ -719,6 +719,20 @@ Copy fingerprints from the report's
 lists exactly, so a new, removed, moved, or changed finding requires an explicit
 baseline review. Other useful overrides are `--vault` and repeatable `--exclude`.
 
+## Cloudflare Pages Deployment
+
+Vault repositories can call the reusable
+[`deploy-cloudflare-pages.yml`](.github/workflows/deploy-cloudflare-pages.yml) workflow to build and
+validate their own locked EIAM dependency before a separate job deploys the exact output directory.
+It accepts explicit vault, output, config, Pages project, production/preview branch, exclusion, and
+Markdown baseline inputs. `artifact-only` mode never reads Cloudflare secrets, so it is suitable for
+fork pull requests and pre-deployment review.
+
+The complete caller template, required `Pages Write` token scope, GitHub environment protection,
+root-versus-prefix `pathBase` behavior, failure artifacts, host smoke checks, and production rollback
+procedure are documented in [Cloudflare Pages deployment](docs/CLOUDFLARE-PAGES.md). Generator npm
+publication remains a separate release workflow and never deploys a caller's vault.
+
 ## Example Vault
 
 This repository includes `test-vault/` as a working sample.

--- a/docs/CLOUDFLARE-PAGES.md
+++ b/docs/CLOUDFLARE-PAGES.md
@@ -76,8 +76,9 @@ jobs:
 
 This example deploys `main` to production, deploys pushes to `preview` as a Pages preview, and makes
 every pull request artifact-only. Fork pull requests must use artifact-only mode; the reusable
-workflow rejects a fork that attempts a credentialed deploy. An artifact-only caller may omit
-`project-name` and both Cloudflare secrets.
+workflow rejects a fork that attempts a credentialed deploy. Because artifact-only work cannot
+change a Pages alias, a fork whose head branch is also named `main` remains a valid dry run. An
+artifact-only caller may omit `project-name` and both Cloudflare secrets.
 
 The optional `markdown-baseline-path` input points to the exact strict Markdown baseline. Additional
 exclusions are newline-separated in `exclude-patterns`; each non-empty line becomes one
@@ -111,16 +112,19 @@ for the host-side project contract.
 
 `artifact-only: true` performs the frozen install and full production validation, then uploads:
 
-- `eiam-site-<run>-<attempt>`: the exact validated directory, including `_headers` and hidden EIAM
-  ownership metadata;
-- `production-validation-<run>-<attempt>`: the JSON validation and Markdown reports.
+- `eiam-site-<run>-<attempt>-<invocation>`: the exact validated directory, including `_headers` and
+  hidden EIAM ownership metadata;
+- `production-validation-<run>-<attempt>-<invocation>`: the JSON validation and Markdown reports,
+  explicitly including files under the hidden report directory.
 
 No Cloudflare secret is read and no network mutation is attempted. This is the supported path for
 forks and for reviewing a deploy candidate before credentials exist.
 
 On a validation failure, the report upload still runs but the site artifact and deploy job do not.
-The report is retained for 14 days; a successful site artifact is retained for 7 days. A rerun
-creates a new artifact name, and Wrangler attaches the caller commit SHA to the deployment.
+The report is retained for 14 days; a successful site artifact is retained for 7 days. Every
+reusable call generates an independent 128-bit invocation ID, so matrix jobs and multiple vaults in
+one caller run cannot collide. A rerun creates another artifact name, and Wrangler attaches the
+caller commit SHA to the deployment.
 
 ## `pathBase` behavior
 

--- a/docs/CLOUDFLARE-PAGES.md
+++ b/docs/CLOUDFLARE-PAGES.md
@@ -1,0 +1,176 @@
+# Cloudflare Pages deployment
+
+EIAM site deployment is intentionally separate from publishing the generator package. A vault
+repository owns its source notes, production config, generated site, Cloudflare project, and deploy
+credentials. The reusable workflow in
+`.github/workflows/deploy-cloudflare-pages.yml` runs in that caller repository.
+
+The workflow has two ordered jobs:
+
+1. install the caller's frozen dependencies, run EIAM production validation, and upload the exact
+   validated output plus its machine-readable report;
+2. when `artifact-only` is false, download that output and deploy it with an exact Wrangler version.
+
+The deploy job cannot start when the build or validation gate fails. Cloudflare secrets are not
+referenced by the build job, and the deploy job is omitted entirely in artifact-only mode.
+
+## Caller prerequisites
+
+The vault repository must:
+
+- pin the exact Bun version supported by EIAM in `packageManager`;
+- pin an exact `@limcpf/everything-is-a-markdown` release containing
+  `scripts/validate-production.ts`, and commit `bun.lock`;
+- provide a production config with `seo.siteUrl` and the intended `seo.pathBase`;
+- create the Cloudflare Pages project in advance and configure its production branch;
+- create `cloudflare-preview` and `cloudflare-production` GitHub environments.
+
+Install the released package without a range. Replace the placeholder with the release that also
+contains the reusable workflow:
+
+```bash
+bun add --dev --exact @limcpf/everything-is-a-markdown@<exact-version>
+```
+
+The workflow uses `bun install --frozen-lockfile`, then invokes the validator from that installed
+package. It does not fetch a mutable `latest` package or build the generator repository's test
+vault.
+
+## Complete caller workflow
+
+Create this file in the vault repository. Pin `uses` to a release tag or, for the strongest
+immutability, the full commit SHA containing the workflow.
+
+```yaml
+name: Deploy EIAM site
+
+on:
+  push:
+    branches:
+      - main
+      - preview
+  pull_request:
+
+permissions:
+  contents: read
+
+jobs:
+  pages:
+    uses: limcpf/Everything-Is-A-Markdown/.github/workflows/deploy-cloudflare-pages.yml@<full-commit-sha>
+    with:
+      vault-path: vault
+      output-path: dist
+      config-path: blog.config.ts
+      project-name: my-notes
+      deployment-environment: ${{ github.ref == 'refs/heads/main' && 'production' || 'preview' }}
+      production-branch: main
+      preview-branch: ${{ github.head_ref || github.ref_name }}
+      artifact-only: ${{ github.event_name == 'pull_request' }}
+      exclude-patterns: |
+        .obsidian/**
+        private/**
+    secrets:
+      CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+      CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+```
+
+This example deploys `main` to production, deploys pushes to `preview` as a Pages preview, and makes
+every pull request artifact-only. Fork pull requests must use artifact-only mode; the reusable
+workflow rejects a fork that attempts a credentialed deploy. An artifact-only caller may omit
+`project-name` and both Cloudflare secrets.
+
+The optional `markdown-baseline-path` input points to the exact strict Markdown baseline. Additional
+exclusions are newline-separated in `exclude-patterns`; each non-empty line becomes one
+`--exclude` argument without shell evaluation.
+
+## Environment and credential controls
+
+Create a custom Cloudflare API token restricted to the target account with **Cloudflare Pages:
+Edit** (`Pages Write`). Store the token and the 32-character account ID as the caller repository
+secrets `CLOUDFLARE_API_TOKEN` and `CLOUDFLARE_ACCOUNT_ID`. The workflow needs only
+`contents: read` from GitHub and does not persist checkout credentials or pass `GITHUB_TOKEN` to
+Wrangler.
+
+Configure the caller's GitHub environments as follows:
+
+- `cloudflare-preview`: optional approval and preview-specific branch policy;
+- `cloudflare-production`: required reviewers and a deployment branch rule limited to `main`.
+
+Before Wrangler receives credentials, the deploy job reads the existing Pages project and requires
+its configured production branch to equal `production-branch`. A production run must originate
+from that exact Git ref. A preview branch must differ from it. This prevents a mislabeled preview
+run from updating the production alias.
+
+The workflow never creates or reconfigures a Pages project. It uses Direct Upload to send the
+validated directory and records the immutable deployment URL, alias URL, environment, and
+deployment ID in the job summary. Production and preview runs are serialized per repository,
+project, and environment. See Cloudflare's [Direct Upload documentation](https://developers.cloudflare.com/pages/get-started/direct-upload/)
+for the host-side project contract.
+
+## Artifact-only and failure behavior
+
+`artifact-only: true` performs the frozen install and full production validation, then uploads:
+
+- `eiam-site-<run>-<attempt>`: the exact validated directory, including `_headers` and hidden EIAM
+  ownership metadata;
+- `production-validation-<run>-<attempt>`: the JSON validation and Markdown reports.
+
+No Cloudflare secret is read and no network mutation is attempted. This is the supported path for
+forks and for reviewing a deploy candidate before credentials exist.
+
+On a validation failure, the report upload still runs but the site artifact and deploy job do not.
+The report is retained for 14 days; a successful site artifact is retained for 7 days. A rerun
+creates a new artifact name, and Wrangler attaches the caller commit SHA to the deployment.
+
+## `pathBase` behavior
+
+For a Pages project served directly at `<project>.pages.dev` or at a custom domain root, use an empty
+`seo.pathBase`. Cloudflare Direct Upload deploys the selected directory at the site root; it does
+not mount that directory under an arbitrary URL prefix.
+
+Use a non-empty value such as `/notes` only when a separately configured routing layer makes the
+Pages output available at that prefix. That layer must preserve the generated route, asset,
+canonical, sitemap, and `_headers` semantics. The production validator confirms that generated
+references and cache rules consistently include `pathBase`, but it cannot create or verify an
+external reverse-proxy rewrite. Test direct route loads and actual response headers at the public
+URL before promoting the deployment.
+
+## Rollback
+
+Cloudflare can roll production back only to an earlier successful **production** deployment; a
+preview deployment is not a valid target. Use the deployment ID recorded by this workflow, verify
+the target in **Workers & Pages > project > Deployments**, and choose **Rollback to this
+deployment**. This is the preferred manual recovery path because the operator sees the target URL,
+time, commit, and environment before confirmation.
+
+Cloudflare documents the same restriction and dashboard procedure in [Pages
+rollbacks](https://developers.cloudflare.com/pages/configuration/rollbacks/). The API form below is
+the official [`rollback` endpoint](https://developers.cloudflare.com/api/resources/pages/subresources/projects/subresources/deployments/methods/rollback/).
+
+The equivalent API operation requires the same Pages Write token:
+
+```bash
+curl --silent --show-error --fail-with-body \
+  "https://api.cloudflare.com/client/v4/accounts/$CLOUDFLARE_ACCOUNT_ID/pages/projects/$CLOUDFLARE_PROJECT/deployments/$CLOUDFLARE_DEPLOYMENT_ID/rollback" \
+  --request POST \
+  --header "Authorization: Bearer $CLOUDFLARE_API_TOKEN"
+```
+
+Never select a target from a preview URL alone. Confirm that the deployment API or dashboard marks
+it `production` and `success`, retain the failed deployment ID for diagnosis, and run the public URL
+and cache-header smoke checks again after rollback.
+
+## Host verification
+
+After either environment deploys, check at least:
+
+```bash
+curl -sI https://example.com/manifest.json
+curl -sI -H 'Accept-Encoding: br' https://example.com/assets/app.<hash>.js
+curl -sI https://example.com/<published-route>/
+```
+
+HTML, content, manifest, SEO files, and stable-name static files must revalidate. Exact hashed EIAM
+JS/CSS files must be immutable. Confirm that `_headers` reached the artifact, that Brotli or Gzip is
+negotiated by the host, and that a direct published route returns successfully without an SPA
+rewrite.

--- a/scripts/validate-production.ts
+++ b/scripts/validate-production.ts
@@ -40,6 +40,8 @@ const CHECK_IDS = [
   "cache-headers",
   "output-budgets",
 ] as const;
+const PUBLISHED_MARKDOWN_LINT_SCRIPT = path.join(import.meta.dir, "lint-published-markdown.ts");
+const OUTPUT_SIZE_SCRIPT = path.join(import.meta.dir, "check-output-size.ts");
 
 function printHelp(): void {
   console.log(`
@@ -156,7 +158,7 @@ async function validateResolvedProduction(
     await fs.rm(markdownReportPath, { force: true });
     const lintArgs = [
       "run",
-      "scripts/lint-published-markdown.ts",
+      PUBLISHED_MARKDOWN_LINT_SCRIPT,
       "--out-dir",
       report.configuration.reportDir,
       ...(args.configPath ? ["--config", args.configPath] : []),
@@ -230,12 +232,7 @@ async function validateResolvedProduction(
       await validateCacheHeaders(options.outDir, options.seo?.pathBase ?? "", docs),
     );
 
-    const sizeResult = runBunScript([
-      "run",
-      "scripts/check-output-size.ts",
-      "--out",
-      options.outDir,
-    ]);
+    const sizeResult = runBunScript(["run", OUTPUT_SIZE_SCRIPT, "--out", options.outDir]);
     addValidationCheck(
       report,
       "output-budgets",

--- a/tests/e2e/production-validation.spec.ts
+++ b/tests/e2e/production-validation.spec.ts
@@ -23,9 +23,12 @@ function writeText(filePath: string, content: string): void {
   fs.writeFileSync(filePath, content, "utf8");
 }
 
-function runValidation(args: string[]): { status: number | null; output: string } {
+function runValidation(
+  args: string[],
+  cwd = repositoryRoot,
+): { status: number | null; output: string } {
   const result = spawnSync("bun", [validatorPath, ...args], {
-    cwd: repositoryRoot,
+    cwd,
     encoding: "utf8",
   });
   return {
@@ -66,6 +69,47 @@ test.describe("production validation command", () => {
       const homeHtml = fs.readFileSync(path.join(outDir, "index.html"), "utf8");
       expect(homeHtml).toContain('href="/docs/PROD-02/"');
       expect(homeHtml).not.toContain('href="/PROD-02/"');
+    } finally {
+      fs.rmSync(workDir, { recursive: true, force: true });
+    }
+  });
+
+  test("resolves packaged helper scripts when invoked from a caller directory", () => {
+    const workDir = fs.mkdtempSync(path.join(os.tmpdir(), "eiam-production-caller-"));
+    const vaultDir = path.join(workDir, "vault");
+    const configPath = path.join(workDir, "blog.config.mjs");
+
+    try {
+      writeText(
+        path.join(vaultDir, "note.md"),
+        `---
+publish: true
+prefix: CALLER-01
+category_path: production
+---
+
+Caller-owned production note.
+`,
+      );
+      writeText(
+        configPath,
+        `export default {
+  vaultDir: "./vault",
+  seo: { siteUrl: "https://example.com" },
+};
+`,
+      );
+
+      const result = runValidation(
+        ["--config", "./blog.config.mjs", "--out", "./dist", "--report-dir", "./reports"],
+        workDir,
+      );
+      expect(result.status, result.output).toBe(0);
+
+      const report = readReport(path.join(workDir, "reports"));
+      expect(report.status).toBe("passed");
+      expect(report.checks).toHaveLength(8);
+      expect(report.checks.every(({ status }) => status === "passed")).toBe(true);
     } finally {
       fs.rmSync(workDir, { recursive: true, force: true });
     }

--- a/tests/unit/cloudflare-deployment-workflow.test.ts
+++ b/tests/unit/cloudflare-deployment-workflow.test.ts
@@ -1,0 +1,118 @@
+import fs from "node:fs";
+import path from "node:path";
+import { describe, expect, test } from "bun:test";
+
+const repositoryRoot = path.resolve(import.meta.dir, "../..");
+const workflowPath = path.join(repositoryRoot, ".github/workflows/deploy-cloudflare-pages.yml");
+const documentationPath = path.join(repositoryRoot, "docs/CLOUDFLARE-PAGES.md");
+
+function readWorkflow(): string {
+  return fs.readFileSync(workflowPath, "utf8");
+}
+
+describe("reusable Cloudflare Pages deployment workflow", () => {
+  test("accepts explicit caller build and Pages environment inputs", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("workflow_call:");
+    for (const input of [
+      "vault-path:",
+      "output-path:",
+      "config-path:",
+      "project-name:",
+      "deployment-environment:",
+      "production-branch:",
+      "preview-branch:",
+      "artifact-only:",
+      "exclude-patterns:",
+      "markdown-baseline-path:",
+    ]) {
+      expect(workflow).toContain(input);
+    }
+
+    expect(workflow).toContain("CLOUDFLARE_API_TOKEN:");
+    expect(workflow).toContain("CLOUDFLARE_ACCOUNT_ID:");
+    expect(workflow).toContain("permissions:\n  contents: read");
+  });
+
+  test("builds and validates before transferring the exact site to a separate job", () => {
+    const workflow = readWorkflow();
+    const orderedMarkers = [
+      "Install caller dependencies",
+      "Locate pinned production validator",
+      "Build and validate production output",
+      'bun run "$VALIDATOR_PATH"',
+      "Upload production validation report",
+      "Upload exact validated site",
+      "deploy:\n    if: ${{ !inputs.artifact-only }}",
+      "needs: build-validate",
+      "Download exact validated site",
+      "Verify Cloudflare project environment",
+      "Deploy validated artifact",
+      "Verify deployment result",
+    ];
+
+    let previousIndex = -1;
+    for (const marker of orderedMarkers) {
+      const markerIndex = workflow.indexOf(marker);
+      expect(markerIndex).toBeGreaterThan(previousIndex);
+      previousIndex = markerIndex;
+    }
+
+    expect(workflow).toContain("bun install --frozen-lockfile");
+    expect(workflow).toContain("caller packageManager must pin one exact stable Bun version");
+    expect(workflow).toContain("Unpinned EIAM dependency");
+    expect(workflow).toContain("output-path must not overlap");
+    expect(workflow).toContain("include-hidden-files: true");
+    expect(workflow).toContain("if-no-files-found: error");
+    expect(workflow).toContain("compression-level: 0");
+  });
+
+  test("keeps credentials out of artifact-only work and pins deploy tooling", () => {
+    const workflow = readWorkflow();
+    const buildJob = workflow.slice(
+      workflow.indexOf("  build-validate:"),
+      workflow.indexOf("\n  deploy:"),
+    );
+    const deployJob = workflow.slice(workflow.indexOf("\n  deploy:"));
+
+    expect(buildJob).not.toContain("${{ secrets.");
+    expect(deployJob).toContain("if: ${{ !inputs.artifact-only }}");
+    expect(deployJob).toContain("cloudflare-${{ inputs.deployment-environment }}");
+    expect(deployJob).toContain(
+      "cloudflare/wrangler-action@ebbaa1584979971c8614a24965b4405ff95890e0",
+    );
+    expect(deployJob).toContain("wranglerVersion: 4.112.0");
+    expect(deployJob).not.toContain("gitHubToken:");
+    expect(workflow).toContain("actions/checkout@df4cb1c069e1874edd31b4311f1884172cec0e10");
+    expect(workflow).toContain("oven-sh/setup-bun@0c5077e51419868618aeaa5fe8019c62421857d6");
+  });
+
+  test("guards forks and proves the requested branch maps to the real Pages environment", () => {
+    const workflow = readWorkflow();
+
+    expect(workflow).toContain("fork pull requests must use artifact-only mode");
+    expect(workflow).toContain("preview-branch must differ from production-branch");
+    expect(workflow).toContain("production deployment must run from refs/heads/$PRODUCTION_BRANCH");
+    expect(workflow).toContain("/pages/projects/$PROJECT_NAME");
+    expect(workflow).toContain(".result.production_branch");
+    expect(workflow).toContain("Cloudflare production branch mismatch");
+    expect(workflow).toContain("Cloudflare environment mismatch");
+    expect(workflow).toContain("pages-environment");
+  });
+
+  test("documents a locked caller, pathBase limits, fork dry runs, and rollback", () => {
+    const documentation = fs.readFileSync(documentationPath, "utf8");
+
+    expect(documentation).toContain("bun install --frozen-lockfile");
+    expect(documentation).toContain("@<full-commit-sha>");
+    expect(documentation).toContain("Pages Write");
+    expect(documentation).toContain("cloudflare-production");
+    expect(documentation).toContain("artifact-only");
+    expect(documentation).toContain("Fork pull requests must use artifact-only mode");
+    expect(documentation).toContain("Cloudflare Direct Upload");
+    expect(documentation).toContain("under an arbitrary URL prefix");
+    expect(documentation).toContain("/rollback");
+    expect(documentation).toContain("preview deployment is not a valid target");
+  });
+});

--- a/tests/unit/cloudflare-deployment-workflow.test.ts
+++ b/tests/unit/cloudflare-deployment-workflow.test.ts
@@ -63,9 +63,11 @@ describe("reusable Cloudflare Pages deployment workflow", () => {
     expect(workflow).toContain("caller packageManager must pin one exact stable Bun version");
     expect(workflow).toContain("Unpinned EIAM dependency");
     expect(workflow).toContain("output-path must not overlap");
-    expect(workflow).toContain("include-hidden-files: true");
+    expect(workflow.match(/include-hidden-files: true/g)).toHaveLength(2);
     expect(workflow).toContain("if-no-files-found: error");
     expect(workflow).toContain("compression-level: 0");
+    expect(workflow).toContain('invocation_id="$(openssl rand -hex 16)"');
+    expect(workflow).toContain("report-artifact-name");
   });
 
   test("keeps credentials out of artifact-only work and pins deploy tooling", () => {
@@ -94,6 +96,9 @@ describe("reusable Cloudflare Pages deployment workflow", () => {
     expect(workflow).toContain("fork pull requests must use artifact-only mode");
     expect(workflow).toContain("preview-branch must differ from production-branch");
     expect(workflow).toContain("production deployment must run from refs/heads/$PRODUCTION_BRANCH");
+    expect(workflow).toContain(
+      '[[ "$ARTIFACT_ONLY" != "true" && "$deploy_branch" == "$PRODUCTION_BRANCH" ]]',
+    );
     expect(workflow).toContain("/pages/projects/$PROJECT_NAME");
     expect(workflow).toContain(".result.production_branch");
     expect(workflow).toContain("Cloudflare production branch mismatch");


### PR DESCRIPTION
## Summary

- add a reusable caller-owned Cloudflare Pages workflow that builds and production-validates a locked vault before artifact transfer
- separate credential-free artifact-only work from the environment-protected deploy job, with fork, branch, project, and exact-version guards
- preflight the Pages project's real production branch before pinned Wrangler deploys
- document caller setup, permissions, preview/production behavior, `pathBase`, failure artifacts, host verification, and production rollback
- add unit contracts for workflow inputs, ordering, credential isolation, branch mapping, and documentation

## Issue

Implements the final deployment item in #44 using the detailed requirements retained in #49.

## Definition of Done

- [x] accepts explicit vault, output, config, project, account, production, preview, exclude, and Markdown baseline inputs
- [x] preview and production are distinct GitHub environments and verified against the Cloudflare project's configured production branch
- [x] deploy job requires successful production validation and downloads only the immutable validated site artifact
- [x] exact Bun/EIAM/Actions/Wrangler contracts, minimal GitHub permissions, and Pages Write secrets are enforced or documented
- [x] root and non-root `pathBase` behavior is explicit
- [x] fork-safe artifact-only mode uploads the site and validation report without reading Cloudflare secrets
- [x] production rollback target and official API/dashboard recovery procedure are documented
- [x] generator npm publication remains separate from vault site deployment

## Review fixes

- resolve production validator helper scripts relative to the installed package, verified from a separate caller cwd and a packed dependency
- include hidden validation reports explicitly
- allow production-named fork branches in non-mutating artifact-only mode
- generate an independent 128-bit artifact identity for every reusable workflow call

## Validation

- `bun run lint:source`
- `bun run format:check`
- `bun run typecheck`
- `bun run test:unit` — 109 passed
- `bun run test:e2e` — 126 passed
- packaged tarball installed as a temporary caller dependency; production validation 8/8 passed
- `bun run scripts/validate-production.ts --config tests/fixtures/production-site/blog.config.ts --vault tests/fixtures/production-site/vault --out .tmp/cloudflare-artifact-only-dist --report-dir .tmp/cloudflare-artifact-only-report`
- `bun run check:size`
- `bun run check:reproducible`
- `bun pm pack --dry-run`
- `actionlint 1.7.12 .github/workflows/*.yml`

## Review focus

- reusable workflow expression and job-output semantics
- absence of credential references in `build-validate`
- branch/environment preflight before the mutation step
- package-local validator helpers and per-call artifact identity
- caller instructions for pinned dependencies, fork runs, `pathBase`, and rollback
